### PR TITLE
printf 系のフォーマット文字列で、引数の位置指定書式の解説が誤っていたのを修正

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -2855,7 +2855,7 @@ local: {
   <formalpara>
    <title>Argnum</title>
    <para>
-    何個の引数を変換の対象にするかを指定するために、
+    何番目の引数を変換の対象にするかを指定するために、
     数値の後にドル記号 <literal>$</literal> を続けます。
    </para>
   </formalpara>


### PR DESCRIPTION
# 原文リンク
- https://github.com/php/doc-en/blob/d278431ef5e561787093a7b2679327a615b09367/language-snippets.ent#L2770

# 確認用ページ
- JA:  https://www.php.net/manual/ja/function.printf
- EN:  https://www.php.net/manual/en/function.printf

# 参考情報
-  POSIX や MS での C の `%n$` と同じ
	- https://pubs.opengroup.org/onlinepubs/9699919799/functions/printf.html
	- https://github.com/MicrosoftDocs/cpp-docs.ja-jp/blob/f7558298ddc3db6a6d58a1a0bf7cd7ff1ee2dd5e/docs/c-runtime-library/printf-p-positional-parameters.md#%E4%BD%8D%E7%BD%AE%E6%8C%87%E5%AE%9A%E3%83%91%E3%83%A9%E3%83%A1%E3%83%BC%E3%82%BF%E3%83%BC%E3%81%AE%E6%8C%87%E5%AE%9A%E6%96%B9%E6%B3%95
