### PR TITLE
連結演算子の優先順位変更の表現を改善

### DIFF
--- a/appendices/migration80/incompatible.xml
+++ b/appendices/migration80/incompatible.xml
@@ -252,8 +252,7 @@ function my_error_handler($err_no, $err_msg, $filename, $linenum) {
     </listitem>
     <listitem>
      <para>
-      連結演算子の優先順位は、減算の演算子と同様に、
-      ビットシフトや加算の演算子に関連するように変更されました。
+      ビットシフトや加算、減算に対する連結演算子の優先順位が変更されました。
      </para>
      <para>
       <programlisting role="php">


### PR DESCRIPTION
元の訳文の意味が取りづらかったので表現を変更してみました。

## 原文リンク

https://github.com/php/doc-en/blob/e49940b757b35b8ef26bb64380c231eda7b49fc4/appendices/migration80/incompatible.xml#L241-L242
