### PR TITLE
非推奨のlibxml_disable_entity_loader()を推奨するような文章になっていたため、非推奨だということが伝わる文章に変更

### DIFF
--- a/reference/libxml/functions/libxml-set-external-entity-loader.xml
+++ b/reference/libxml/functions/libxml-set-external-entity-loader.xml
@@ -19,7 +19,7 @@
    デフォルトの外部エンティティローダーを変更します。
    たとえ <constant>LIBXML_NOENT</constant> が個別のXMLの操作に設定されている場合でも、
    XXE攻撃を避けるために、任意の外部エンティティの展開を抑制するために使うことができます。
-   また、 <function>libxml_disable_entity_loader</function> を呼び出すことよりも通常は好ましいです。
+   また、 <function>libxml_disable_entity_loader</function> を呼び出すことよりも、この関数を呼び出すほうが通常は好ましいです。
   </para>
  </refsect1>
 

--- a/reference/libxml/functions/libxml-set-external-entity-loader.xml
+++ b/reference/libxml/functions/libxml-set-external-entity-loader.xml
@@ -18,8 +18,8 @@
   <para>
    デフォルトの外部エンティティローダーを変更します。
    たとえ <constant>LIBXML_NOENT</constant> が個別のXMLの操作に設定されている場合でも、
-   XXE攻撃を避けるために、任意の外部エンティティの展開を抑制するために使います。
-   <function>libxml_disable_entity_loader</function> を呼び出すことが通常は好ましいです。
+   XXE攻撃を避けるために、任意の外部エンティティの展開を抑制するために使うことができます。
+   また、 <function>libxml_disable_entity_loader</function> を呼び出すことよりも通常は好ましいです。
   </para>
  </refsect1>
 


### PR DESCRIPTION
https://www.php.net/manual/ja/function.libxml-set-external-entity-loader.php
こちらのページにある概要に関してなのですが、

> デフォルトの外部エンティティローダーを変更します。 たとえ LIBXML_NOENT が個別のXMLの操作に設定されている場合でも、 XXE攻撃を避けるために、任意の外部エンティティの展開を抑制するために使います。 libxml_disable_entity_loader() を呼び出すことが通常は好ましいです。

と書かれています。一方で、[libxml_disable_entity_loader()](https://www.php.net/manual/ja/function.libxml-disable-entity-loader.php) は php8.0.0 にて非推奨になる関数で、こちらの関数を呼び出すと **が** 望ましいとは考えにくいです。

英語の文章を読んでみると、

> Changes the default external entity loader. This can be used to suppress the expansion of arbitrary external entities to avoid XXE attacks, even when LIBXML_NOENT has been set for the respective operation, and is usually preferable over calling libxml_disable_entity_loader().

と書かれており、 `This is preferable over calling libxml_disable_entity_loader()` は 「これはlibxml_disable_entity_loader()よりも好ましい」 と私は解釈したため、意味が逆になっているのではないかと考えました。

結果、プルリクのタイトルの通り現在非推奨の関数を推奨するような文章になってしまっており、修正したほうが良いのではないかと思いPRを出させていただきました。

確認よろしくおねがいします :bow:
