### PR TITLE
変更履歴の記載位置が誤っているのを修正

### DIFF
--- a/reference/info/functions/assert.xml
+++ b/reference/info/functions/assert.xml
@@ -105,23 +105,6 @@
      </thead>
      <tbody>
       <row>
-       <entry>8.0.0</entry>
-       <entry>
-        名前空間の内部で、
-        <literal>assert()</literal> をコールすることはできなくなりました。
-        コールした場合、<constant>E_COMPILE_ERROR</constant> が発生します。
-       </entry>
-      </row>
-      <row>
-       <entry>7.3.0</entry>
-       <entry>
-        名前空間の内部で、
-        <literal>assert()</literal> をコールすることは推奨されなくなりました。
-        コールした場合、
-        <constant>E_DEPRECATED</constant> が発生するようになっています。
-       </entry>
-      </row>
-      <row>
        <entry>
         <link linkend="ini.zend.assertions">zend.assertions</link>
        </entry>
@@ -237,7 +220,24 @@
       </row>
      </thead>
      <tbody>
-       <row>
+      <row>
+       <entry>8.0.0</entry>
+       <entry>
+        名前空間の内部で、
+        <literal>assert()</literal> をコールすることはできなくなりました。
+        コールした場合、<constant>E_COMPILE_ERROR</constant> が発生します。
+       </entry>
+      </row>
+      <row>
+       <entry>7.3.0</entry>
+       <entry>
+        名前空間の内部で、
+        <literal>assert()</literal> をコールすることは推奨されなくなりました。
+        コールした場合、
+        <constant>E_DEPRECATED</constant> が発生するようになっています。
+       </entry>
+      </row>
+      <row>
        <entry>7.2.0</entry>
        <entry>
         <parameter>assertion</parameter> に <type>string</type> を使うことは


### PR DESCRIPTION
https://www.php.net/manual/ja/function.assert.php の「PHP 7 における assert() 用の設定ディレクティブ」の表に誤って変更履歴が記載されているのを修正しました。