### PR TITLE
短縮形のechoタグ`<?=`の説明の誤訳訂正

### DIFF
--- a/reference/strings/functions/echo.xml
+++ b/reference/strings/functions/echo.xml
@@ -29,7 +29,7 @@
    <literal>echo</literal> には、開始タグの直後に等号を付ける短縮構文もあります。
    この短縮構文は、設定オプション<link
     linkend="ini.short-open-tag">short_open_tag</link>
-   が無効な場合しか使えません。
+   が無効な場合でも使えます。
    <informalexample>
     <programlisting role="php">
 <![CDATA[


### PR DESCRIPTION
> This syntax is available even with the short_open_tag configuration setting disabled.

原文の"even"の意味が抜け落ちて反対の意味の訳になっていました。
実際には、`short_open_tag`の設定に関わらず`<?=`の開始タグは有効です。

```console
$ php -v
PHP 8.0.5 (cli) (built: May  3 2021 11:30:38) ( NTS )
Copyright (c) The PHP Group
Zend Engine v4.0.5, Copyright (c) Zend Technologies
    with Zend OPcache v8.0.5, Copyright (c), by Zend Technologies
$ echo '<? echo "foo"; ?><?= "bar\n" ?>' | php -d short_open_tag=On
foobar
$ echo '<? echo "foo"; ?><?= "bar\n" ?>' | php -d short_open_tag=Off
<? echo "foo"; ?>bar
```

- 原文リンク
  - https://github.com/php/doc-en/blob/6a7a96ccc689ed202b81964f38d2360962cd70b2/reference/strings/functions/echo.xml#L26-L29