### PR TITLE
コードコメントの誤りを修正

### DIFF
--- a/language/control-structures/match.xml
+++ b/language/control-structures/match.xml
@@ -86,8 +86,8 @@ $return_value = match (制約式) {
 <?php
 $result = match ($x) {
     foo() => ...,
-    $this->bar() => ..., // foo() === $x でなければ bar() は呼び出されません。
-    $this->baz => beep(), // $x === $this->baz でなければ、beep() は呼び出されません。
+    $this->bar() => ..., // foo() === $x であれば bar() は呼び出されません。
+    $this->baz => beep(), // $x === $this->baz でなければ beep() は呼び出されません。
     // などなど
 };
 ?>


### PR DESCRIPTION
コードコメントの誤訳を修正しました。

また、同じ構造の2文のうち後者にだけ読点が使われていて不自然だったので文体を揃えました。