### PR TITLE
タイポ修正と冗長な表現を簡潔にしました。

### DIFF
--- a/appendices/comparisons.xml
+++ b/appendices/comparisons.xml
@@ -30,9 +30,9 @@
  <note>
   <para>
    <varname>$x</varname>が定義されていない状態で単に
-   <literal>if ($x)</literal>としてしまうと<constant>E_NOTICE</constant>
-   レベルのエラーが発行てしまいます。代わりに、<function>empty</function>や
-   <function>isset</function>を使うかあるいは変数を初期化するように
+   <literal>if ($x)</literal>とすると<constant>E_NOTICE</constant>
+   レベルのエラーが発生します。代わりに、<function>empty</function>や
+   <function>isset</function>を使うか、あるいは変数を初期化するように
    してください。
   </para>
  </note>


### PR DESCRIPTION
[PHP 型の比較表](https://www.php.net/manual/ja/types.comparisons.php)で、送り仮名の抜け落ちと思われるタイポがありましたので修正しました。
また周辺で冗長な表現が使用されていたので簡潔な表現に置き換えました。