### PR TITLE
「バックティック」を「バッククォート」に変更

### DIFF
--- a/reference/exec/functions/escapeshellarg.xml
+++ b/reference/exec/functions/escapeshellarg.xml
@@ -23,7 +23,7 @@
    シェル関数への引数として渡す際にエスケープするために使用する必要
    があります。シェル関数には、<function>exec</function>,
    <function>system</function>そして
-   <link linkend="language.operators.execution">バックティック演算子</link>
+   <link linkend="language.operators.execution">バッククォート演算子</link>
    を含むシェル関数が含まれます。
   </para>
   <para>
@@ -80,7 +80,7 @@ system('ls '.escapeshellarg($dir));
     <member><function>exec</function></member>
     <member><function>popen</function></member>
     <member><function>system</function></member>
-    <member><link linkend="language.operators.execution">バックティック演算子</link></member>
+    <member><link linkend="language.operators.execution">バッククォート演算子</link></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/exec/functions/escapeshellcmd.xml
+++ b/reference/exec/functions/escapeshellcmd.xml
@@ -20,7 +20,7 @@
    だまして勝手なコマンドを実行する可能性がある文字をエスケープします。
    この関数は、ユーザーに入力されたデータを関数
    <function>exec</function> または <function>system</function> または、
-   <link linkend="language.operators.execution">バックティック演算子</link>
+   <link linkend="language.operators.execution">バッククォート演算子</link>
    に渡す前に全てエスケープを行う場合に使用するべきです。
   </para>
   <para>
@@ -115,7 +115,7 @@ $cmd = preg_replace('`(?<!^) `', '^ ', escapeshellcmd($cmd));
     <member><function>exec</function></member>
     <member><function>popen</function></member>
     <member><function>system</function></member>
-    <member><link linkend="language.operators.execution">バックティック演算子</link></member>
+    <member><link linkend="language.operators.execution">バッククォート演算子</link></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/exec/functions/exec.xml
+++ b/reference/exec/functions/exec.xml
@@ -127,7 +127,7 @@ Array
     <member><function>passthru</function></member>
     <member><function>escapeshellcmd</function></member>
     <member><function>pcntl_exec</function></member>
-    <member><link linkend="language.operators.execution">バックティック演算子</link></member>
+    <member><link linkend="language.operators.execution">バッククォート演算子</link></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/exec/functions/passthru.xml
+++ b/reference/exec/functions/passthru.xml
@@ -78,7 +78,7 @@
     <member><function>system</function></member>
     <member><function>popen</function></member>
     <member><function>escapeshellcmd</function></member>
-    <member><link linkend="language.operators.execution">バックティック演算子</link></member>
+    <member><link linkend="language.operators.execution">バッククォート演算子</link></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/exec/functions/proc-open.xml
+++ b/reference/exec/functions/proc-open.xml
@@ -384,7 +384,7 @@ if (is_resource($process)) {
     <member><function>system</function></member>
     <member><function>passthru</function></member>
     <member><function>stream_select</function></member>
-    <member><link linkend="language.operators.execution">バックティック演算子</link></member>
+    <member><link linkend="language.operators.execution">バッククォート演算子</link></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/exec/functions/shell-exec.xml
+++ b/reference/exec/functions/shell-exec.xml
@@ -17,7 +17,7 @@
   </methodsynopsis>
   <para>
    この関数は <link
-   linkend="language.operators.execution">バックティック演算子</link>
+   linkend="language.operators.execution">バッククォート演算子</link>
    と等価です。
   </para>
   <note>

--- a/reference/exec/functions/system.xml
+++ b/reference/exec/functions/system.xml
@@ -106,7 +106,7 @@ echo '
     <member><function>popen</function></member>
     <member><function>escapeshellcmd</function></member>
     <member><function>pcntl_exec</function></member>
-    <member><link linkend="language.operators.execution">バックティック演算子</link></member>
+    <member><link linkend="language.operators.execution">バッククォート演算子</link></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/exec/reference.xml
+++ b/reference/exec/reference.xml
@@ -22,7 +22,7 @@
    &reftitle.seealso;
     <para>
      以下の関数は、
-     <link linkend="language.operators.execution">バックティック演算子</link>
+     <link linkend="language.operators.execution">バッククォート演算子</link>
      にも関係します。
     </para>
    </section>

--- a/reference/filter/constants.xml
+++ b/reference/filter/constants.xml
@@ -453,7 +453,7 @@
    </term>
    <listitem>
     <simpara>
-     バックティック文字を取り除きます。
+     バッククォート文字を取り除きます。
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/filter/filters.xml
+++ b/reference/filter/filters.xml
@@ -567,7 +567,7 @@ filter.default_flags = 0
         <constant>FILTER_UNSAFE_RAW</constant>
        </entry>
        <entry>
-        バックティック文字を除去します。
+        バッククォート文字を除去します。
        </entry>
       </row>
       <row>


### PR DESCRIPTION
[実行演算子](https://www.php.net/manual/ja/language.operators.execution.php)について、英語の表記では「backtick operator」となっているところが「バッククォート演算子」と「バックティック演算子」に表記が揺れていました。
日本では「バックティック」より「バッククォート」が親しまれているため「バッククォート」に寄せました。

また、データのフィルタリングのページにおいても「バックティック」という単語が使われていたため、併せて「バッククォート」に統一いたしました。

当該ページ一覧
[プログラム実行関数]
https://www.php.net/manual/ja/ref.exec.php
https://www.php.net/manual/ja/function.escapeshellarg.php
https://www.php.net/manual/ja/function.escapeshellcmd.php
https://www.php.net/manual/ja/function.exec.php
https://www.php.net/manual/ja/function.passthru.php
https://www.php.net/manual/ja/function.proc-open.php
https://www.php.net/manual/ja/function.shell-exec.php
https://www.php.net/manual/ja/function.system.php
[データのフィルタリング] 
https://www.php.net/manual/ja/filter.filters.flags.php
https://www.php.net/manual/ja/filter.constants.php
