### PR TITLE
PHP 8.0.x から PHP 8.1.x への移行ガイド

### DIFF
--- a/appendices/migration81.xml
+++ b/appendices/migration81.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 4d2479dcf35d82aca39ee61f8ab36ceed78a869c Maintainer: mumumu Status: ready -->
+<appendix xml:id="migration81" xmlns="http://docbook.org/ns/docbook" xmlns:phd="http://www.php.net/ns/phd">
+ <title>PHP 8.0.x から PHP 8.1.x への移行</title>
+
+ &appendices.migration81.new-features;
+ &appendices.migration81.new-classes;
+ &appendices.migration81.new-functions;
+ &appendices.migration81.constants;
+ &appendices.migration81.incompatible;
+ &appendices.migration81.deprecated;
+ &appendices.migration81.other-changes;
+
+ <sect1 phd:chunk="false" xml:id="migration81.intro">
+  <para>
+   この新しいマイナーバージョンには、
+   たくさんの
+   <link linkend="migration81.new-features">新機能</link> と
+   <link linkend="migration81.incompatible">互換性のない変更</link>
+   がいくつかあります。
+   実運用環境の PHP をこのバージョンにあげる前に、
+   これらの変更を必ずテストすべきです。
+  </para>
+
+  <para>
+   &manual.migration.seealso;
+   <link linkend="migration71">7.1.x</link>,
+   <link linkend="migration72">7.2.x</link>,
+   <link linkend="migration73">7.3.x</link>,
+   <link linkend="migration74">7.4.x</link>,
+   <link linkend="migration80">8.0.x</link>.
+  </para>
+ </sect1>
+</appendix>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/appendices/migration81/constants.xml
+++ b/appendices/migration81/constants.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 4d2479dcf35d82aca39ee61f8ab36ceed78a869c Maintainer: mumumu Status: ready -->
+<sect1 xml:id="migration81.constants" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>新しいグローバル定数</title>
+
+ <sect2 xml:id="migration81.constants.mysqli">
+  <title>MySQLi</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara><constant>MYSQLI_REFRESH_REPLICA</constant></simpara>
+    <para>
+     この定数は、<constant>MYSQLI_REFRESH_SLAVE</constant>
+     の代替として追加されました。
+     MySQL の最新の変更に追随したものです。
+     古い定数は後方互換性を保つためにまだ残されていますが、
+     将来非推奨になるか、削除される可能性があります。
+    </para>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+ <sect2 xml:id="migration81.constants.sockets">
+  <title>Sockets</title>
+
+  <para>
+   以下のソケットオプションが、
+   サポートされている場合に定義されるようになりました:
+  </para>
+  <itemizedlist>
+   <listitem>
+    <simpara><constant>SO_ACCEPTFILTER</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>SO_DONTTRUNC</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>SO_WANTMORE</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>SO_MARK</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>TCP_DEFER_ACCEPT</constant></simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+</sect1>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/appendices/migration81/deprecated.xml
+++ b/appendices/migration81/deprecated.xml
@@ -1,0 +1,412 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 4d2479dcf35d82aca39ee61f8ab36ceed78a869c Maintainer: mumumu Status: ready -->
+<sect1 xml:id="migration81.deprecated">
+ <title>PHP 8.1.x で推奨されなくなる機能</title>
+
+ <sect2 xml:id="migration81.deprecated.core">
+  <title>PHP コア</title>
+
+  <sect3 xml:id="migration81.deprecated.core.serialize-interface">
+   <title>
+    <function>__serialize</function>,
+    <function>__unserialize</function> がない状態で、
+    <interfacename>Serializable</interfacename> を実装するのは推奨されない
+   </title>
+
+   <para>
+    新しいこれらのメソッドだけを実装するか、
+    このメソッドをサポートしていない
+    PHP 7.4 より前のバージョンでも使う場合は、
+    古いものと新しいンターフェイスを両方実装すべきです。
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration81.deprecated.core.null-not-nullable-internal">
+   <title>組み込み関数の nullable でない引数に &null; を渡した場合</title>
+
+   <para>
+    組み込み関数のスカラー型の引数は、
+    デフォルトで nullable になっていますが、
+    ユーザ定義の関数と組み合わせた場合、
+    この振る舞いは推奨されなくなりました。
+    この場合、スカラー型は nullable と明示的にマークする必要があるからです
+
+    <informalexample>
+     <programlisting role="php">
+<![CDATA[
+<?php
+var_dump(str_contains("foobar", null));
+// Deprecated: Passing null to parameter #2 ($needle) of type string
+//             is deprecated
+?>
+]]>
+     </programlisting>
+    </informalexample>
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration81.deprecated.core.implicit-float-conversion">
+   <title>暗黙の &float; から &integer; への変換</title>
+
+   <para>
+    精度を損なうことになる
+    &float; から &integer; への暗黙の変換は、
+    推奨されなくなりました。
+    これは配列のキーに &float; を使った場合や、
+    型の強制 (coerciveモード) 時に &integer; 型を宣言した場合や、
+    &integer; に対して演算子を適用する場合に影響します。
+    <informalexample>
+     <programlisting role="php">
+<![CDATA[
+<?php
+$a = [];
+$a[15.5]; // 推奨されません。0.5 がキーの値から失われるからです
+$a[15.0]; // 15.0 == 15 なので OK
+?>
+]]>
+     </programlisting>
+    </informalexample>
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration81.deprecated.core.static-trait">
+   <title>トレイトの <modifier>static</modifier> な要素をコールする</title>
+
+   <para>
+    トレイトにある
+    <modifier>static</modifier>
+    メソッドや、
+    <modifier>static</modifier>
+    なプロパティに直接アクセスすることは、推奨されなくなりました。
+    これらは、トレイトを使っているクラスからのみアクセスすべきものです。
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration81.deprecated.core.magic-sleep">
+   <title><function>__sleep</function> から配列でない値を返す</title>
+
+   <para>
+    配列でない値を
+    <link linkend="object.sleep">__sleep()</link>
+    から返すと、警告が発生するようになりました。
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration81.deprecated.core.void-by-ref">
+   <title><type>void</type> の関数からリファレンスを返す</title>
+
+   <para>
+    <informalexample>
+     <programlisting role="php">
+<![CDATA[
+<?php
+function &test(): void {}
+?>
+]]>
+     </programlisting>
+    </informalexample>
+    上記のような関数は矛盾しているため、
+    呼び出された時に
+    <literal>Only variable references should be returned by reference</literal>
+    という <constant>E_NOTICE</constant>
+    が既に発生するようになっています。
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration81.deprecated.core.autovivification-false">
+   <title>&false; な変数を自動的に復活させる挙動(Autovivification)</title>
+   <para>
+    Autovivification とは、
+    値を追加しようとする際に配列を自動で生成する処理のことです。
+    スカラー型の値からこのような処理を行うことは禁止されていますが、
+    &false; だけは例外でした。
+    このバージョンから、この例外も推奨されなくなります。
+    <informalexample>
+     <programlisting role="php">
+<![CDATA[
+<?php
+$arr = false;
+$arr[] = 2;   // 推奨されません
+?>
+]]>
+     </programlisting>
+    </informalexample>
+   </para>
+   <note>
+    <para>
+     &null; や 未定義値から、
+     自動的に配列を生成する処理は未だ許可されています:
+     <informalexample>
+      <programlisting role="php">
+<![CDATA[
+<?php
+// 未定義値から配列を生成
+$arr[] = 'some value';
+$arr['doesNotExist'][] = 2;
+// null から配列を生成
+$arr = null;
+$arr[] = 2;
+?>
+]]>
+      </programlisting>
+     </informalexample>
+    </para>
+   </note>
+  </sect3>
+
+ </sect2>
+
+ <sect2 xml:id="migration81.deprecated.ctype">
+  <title>ctype 関数</title>
+
+  <sect3 xml:id="migration81.deprecated.ctype.nonstring-arguments">
+   <title>文字列でない引数の検証</title>
+
+   <para>
+    ctype関数 に文字列でない引数を渡すことは、
+    推奨されなくなりました。
+    将来のバージョンでは、引数は ASCII コードポイントではなく、
+    文字列として解釈されるようになります。
+    ユーザが意図する振る舞いによっては、
+    引数を文字列にキャストするか、
+    <function>chr</function>
+    を明示的にコールすべきです。
+    全ての <literal>ctype_*()</literal> 関数が影響を受けます。
+   </para>
+  </sect3>
+ </sect2>
+
+ <sect2 xml:id="migration81.deprecated.date">
+  <title>日付・時刻 関数</title>
+
+  <para>
+   <function>date_sunrise</function>
+   と
+   <function>date_sunset</function>
+   は、推奨されなくなりました。
+   <function>date_sun_info</function>
+   を使って下さい。
+  </para>
+
+  <para>
+   <function>strptime</function> 関数は、
+   推奨されなくなりました。
+   (ロケールに依存しないパースを行う場合)
+   <function>date_parse_from_format</function>
+   または
+   (ロケールに依存するパースを行う場合)
+   <methodname>IntlDateFormatter::parse</methodname>
+   を代わりに使って下さい。
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration81.deprecated.filter">
+  <title>Filter</title>
+
+  <para>
+   <constant>FILTER_SANITIZE_STRING</constant>
+   と
+   <constant>FILTER_SANITIZE_STRIPPED</constant>
+   フィルタは、推奨されなくなりました。
+  </para>
+  <para>
+   INI ディレクティブ
+   <link linkend="ini.filter.default">filter.default</link>
+   は、推奨されなくなりました。
+   <!-- TODO Check that filter.default_flags -->
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration81.deprecated.gd">
+  <title>GD</title>
+
+  <para>
+   <function>imageopenpolygon</function> と
+   <function>imagefilledpolygon</function>
+   の
+   <parameter>num_points</parameter> 引数は、
+   推奨されなくなりました。
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration81.deprecated.hash">
+  <title>Hash</title>
+
+  <para>
+   <function>mhash</function>,
+   <function>mhash_keygen_s2k</function>,
+   <function>mhash_count</function>,
+   <function>mhash_get_block_size</function>,
+   <function>mhash_get_hash_name</function>
+   は、推奨されなくなりました。
+   <literal>hash_*()</literal> 関数を代わりに使って下さい。
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration81.deprecated.imap">
+  <title>IMAP</title>
+
+  <para>
+   定数 <constant>NIL</constant> は、推奨されなくなりました。
+   <literal>0</literal> を代わりに使って下さい。
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration81.deprecated.intl">
+  <title>国際化関数(Intl)</title>
+
+  <para>
+   <methodname>IntlCalendar::roll</methodname>
+   に &boolean; 引数を渡してコールすることは、
+   推奨されなくなりました。
+   &true; と &false;
+   の代わりに、
+   <literal>1</literal> と <literal>-1</literal>
+   をそれぞれ渡すようにして下さい。
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration81.deprecated.mbstring">
+  <title>マルチバイト文字列</title>
+
+  <para>
+   <function>mb_check_encoding</function>
+   関数を引数を渡さずにコールすることは、推奨されなくなりました。
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration81.deprecated.mysqli">
+  <title>MySQLi</title>
+
+  <para>
+   <property>mysqli_driver::$driver_version</property>
+   プロパティは、推奨されなくなりました。
+   このプロパティは意味がなく、時代遅れになっています。
+   <constant>PHP_VERSION_ID</constant>
+   を代わりに使って下さい。
+  </para>
+
+  <para>
+   <parameter>mysqli</parameter> 引数を渡して、
+   <methodname>mysqli::get_client_info</methodname> や
+   <function>mysqli_get_client_info</function>
+   をコールすることは、推奨されなくなりました。
+   クライアントライブラリのバージョン情報を取得するには、
+   <function>mysqli_get_client_info</function>
+   を引数なしでコールするようにして下さい。
+  </para>
+
+  <para>
+   <methodname>mysqli::init</methodname> メソッドは、
+   推奨されなくなりました。
+   <methodname>parent::init</methodname> のコールを
+   <methodname>parent::__construct</methodname>
+   に置き換えるようにして下さい。
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration81.deprecated.oci8">
+  <title>OCI8</title>
+
+  <para>
+   INI ディレクティブ
+   <link linkend="ini.oci8.old-oci-close-semantics">oci8.old_oci_close_semantics</link>
+   は、推奨されなくなりました。
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration81.deprecated.odbc">
+  <title>ODBC</title>
+
+  <para>
+   <function>odbc_result_all</function> 関数は推奨されなくなりました。
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration81.deprecated.pdo">
+  <title>PDO</title>
+
+  <para>
+   フェッチモードの定数 <constant>PDO::FETCH_SERIALIZE</constant>
+   は、推奨されなくなりました。
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration81.deprecated.pgsql">
+  <title>PgSQL</title>
+
+  <para>
+   全ての
+   <literal>pgsql_*()</literal>
+   関数に対して、接続リソースを渡さないことは推奨されなくなりました。
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration81.deprecated.soap">
+  <title>SOAP</title>
+
+  <para>
+   <methodname>SoapClient::__construct</methodname>
+   の
+   <literal>ssl_method</literal> オプションは推奨されなくなりました。
+   SSL コンテキストオプションを使うのが望ましいです。
+   <!-- The direct equivalent would be
+    crypto_method, but min_proto_version/max_proto_version are recommended
+    instead. -->
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration81.deprecated.standard">
+  <title>Standard</title>
+
+  <para>
+   &object; に対して、
+   <function>key</function>, <function>current</function>,
+   <function>next</function>, <function>prev</function>,
+   <function>reset</function>, <function>end</function>
+   を呼び出すことは推奨されなくなりました。
+   &object; を渡して
+   <function>get_mangled_object_vars</function>
+   を呼び出すか、
+   <classname>ArrayIterator</classname>
+   を使って下さい。
+  </para>
+
+  <para>
+   INI ディレクティブ
+   <link linkend="ini.auto-detect-line-endings">auto_detect_line_endings</link>
+   は、推奨されなくなりました。
+   必要な場合は、
+   <literal>"\r"</literal> を手動で扱うようにして下さい。
+  </para>
+
+  <para>
+   定数
+   <constant>FILE_BINARY</constant> と
+   <constant>FILE_TEXT</constant> は推奨されなくなりました。
+   これらの定数は、使われたことがありませんでした。
+  </para>
+ </sect2>
+
+</sect1>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/appendices/migration81/incompatible.xml
+++ b/appendices/migration81/incompatible.xml
@@ -1,0 +1,399 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 4d2479dcf35d82aca39ee61f8ab36ceed78a869c Maintainer: mumumu Status: ready -->
+<sect1 xml:id="migration81.incompatible" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>下位互換性のない変更点</title>
+
+ <sect2 xml:id="migration81.incompatible.core">
+  <title>PHP コア</title>
+
+  <sect3 xml:id="migration81.incompatible.core.globals-access">
+   <title>$GLOBALS へのアクセス制限</title>
+
+   <para>
+    <varname>$GLOBALS</varname> 配列へのアクセスに対し、
+    多くの制限が適用されるようになりました。
+    <code>$GLOBALS['var']</code> のような、
+    個別の配列要素に対する読み取りや書き込みは、
+    これまで通り動作します。
+    <varname>$GLOBALS</varname> 配列全体への読み取り専用のアクセスも、
+    引き続きサポートされます。
+    しかし、<varname>$GLOBALS</varname> 配列全体への書き込みは、
+    もはやサポートされなくなりました。
+    たとえば、<code>array_pop($GLOBALS)</code>
+    のようなコードは、エラーが発生します。
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration81.incompatible.core.static-variable-inheritance">
+   <title>
+    継承したメソッド内で <modifier>static</modifier> な変数を使う
+   </title>
+
+   <para>
+    static 変数を使っているメソッドが継承された
+    (但し、オーバーライドはされていない)
+    場合、継承されたメソッドは
+    static 変数を親クラスのメソッドと共有するようになりました。
+    <informalexample>
+     <programlisting role="php">
+<![CDATA[
+<?php
+class A {
+    public static function counter() {
+        static $counter = 0;
+        $counter++;
+        return $counter;
+    }
+}
+class B extends A {}
+var_dump(A::counter()); // int(1)
+var_dump(A::counter()); // int(2)
+var_dump(B::counter()); // int(3), 以前のバージョンでは int(1)
+var_dump(B::counter()); // int(4), 以前のバージョンでは int(2)
+?>
+]]>
+     </programlisting>
+    </informalexample>
+
+    これは、メソッド中の static 変数が、
+    static なプロパティと同じ振る舞いをするようになったということです。
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration81.incompatible.core.type-compatibility-internal">
+   <title>内部クラスと戻り値の型の互換性</title>
+
+   <para>
+    ほとんどの final でない内部メソッドは、
+    それをオーバライドする際、
+    互換性がある戻り値の型を宣言することが必須になりました。
+    そうしない場合、継承が有効かを検証する際に、
+    推奨されない警告が発生するようになります。
+    PHP のバージョン間の互換性を保ちたいがために、
+    戻り値の型を宣言できない場合、
+    アトリビュート <code>#[ReturnTypeWillChange]</code>
+    を追加することで警告を抑止できます。
+   </para>
+  </sect3>
+
+ </sect2>
+
+ <sect2 xml:id="migration81.incompatible.resource2object">
+  <title>リソースからオブジェクトへの移行</title>
+
+  <para>
+   いくつかの &resource; が、&object; に移行しました。
+   <function>is_resource</function>
+   関数を使って戻り値をチェックしているコードは、
+   &false; を返すことをチェックするコードに置き換えるべきです。 
+  </para>
+  <itemizedlist>
+   <listitem>
+    <para>
+     <link linkend="book.fileinfo">FileInfo</link> 関数はそれぞれ、
+     <literal>fileinfo</literal> &resource; ではなく、
+     <classname>finfo</classname> オブジェクトを受け取り、
+     返すようになりました。
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     <link linkend="book.ftp">FTP</link> 関数はそれぞれ、
+     <literal>ftp</literal> &resource; ではなく、
+     <classname>FTP\Connection</classname> オブジェクトを受け取り、
+     返すようになりました。
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     <link linkend="book.imap">IMAP</link> 関数はそれぞれ、
+     <literal>imap</literal> &resource; ではなく、
+     <classname>IMAP\Connection</classname> オブジェクトを受け取り、
+     返すようになりました。
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     <link linkend="book.ldap">LDAP</link> 関数はそれぞれ、
+     <literal>ldap link</literal> &resource; ではなく、
+     <classname>LDAP\Connection</classname> オブジェクトを受け取り、
+     返すようになりました。
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     <link linkend="book.ldap">LDAP</link> 関数はそれぞれ、
+     <literal>ldap result</literal> &resource; ではなく、
+     <classname>LDAP\Result</classname> オブジェクトを受け取り、
+     返すようになりました。
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     <link linkend="book.ldap">LDAP</link> 関数はそれぞれ、
+     <literal>ldap result entry</literal> &resource; ではなく、
+     <classname>LDAP\ResultEntry</classname> オブジェクトを受け取り、
+     返すようになりました。
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     <link linkend="book.pgsql">PgSQL</link> 関数はそれぞれ、
+     <literal>ppgsql link</literal> &resource; ではなく、
+     <classname>PgSql\Connection</classname> オブジェクトを受け取り、
+     返すようになりました。
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     <link linkend="book.pgsql">PgSQL</link> 関数はそれぞれ、
+     <literal>ppgsql result</literal> &resource; ではなく、
+     <classname>PgSql\Result</classname> オブジェクトを受け取り、
+     返すようになりました。
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     <link linkend="book.pgsql">PgSQL</link> 関数はそれぞれ、
+     <literal>ppgsql large object</literal> &resource; ではなく、
+     <classname>PgSql\Lob</classname> オブジェクトを受け取り、
+     返すようになりました。
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     <link linkend="book.pspell">PSpell</link> 関数はそれぞれ、
+     <literal>pspell</literal> &resource; ではなく、
+     <classname>PSpell\Dictionary</classname> オブジェクトを受け取り、
+     返すようになりました。
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     <link linkend="book.pspell">PSpell</link> 関数はそれぞれ、
+     <literal>pspell config</literal> &resource; ではなく、
+     <classname>PSpell\Config</classname> オブジェクトを受け取り、
+     返すようになりました。
+    </para>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+ <sect2 xml:id="migration81.incompatible.mysqli">
+  <title>MySQLi</title>
+
+  <para>
+   <function>mysqli_fetch_fields</function>
+   と
+   <function>mysqli_fetch_field_direct</function> は、
+   <property>max_length</property> を指定すると
+   常に <literal>0</literal> を返すようになりました。
+   この情報は、結果セットを繰り返し処理する際に計算できますし、
+   長さの最大値をとります。
+   PHP でも以前のバージョンから、
+   内部的にこれと同じ処理が行われてきました。
+  </para>
+
+  <para>
+   <constant>MYSQLI_STMT_ATTR_UPDATE_MAX_LENGTH</constant>
+   オプションは、もはや意味をなさなくなりました。
+  </para>
+
+  <para>
+   <constant>MYSQLI_STORE_RESULT_COPY_DATA</constant>
+   オプションは、もはや意味をなさなくなりました。
+   <methodname>mysqli::store_result</methodname>
+   の <parameter>mode</parameter> 引数にどんな値を渡しても、
+   同様に意味がなくなっています。
+  </para>
+
+  <para>
+   <methodname>mysqli::connect</methodname> は、
+   成功時に &null; ではなく、&true; を返すようになりました。
+  </para>
+
+  <para>
+   デフォルトのエラー処理モードが、
+   "silent" から
+   "exceptions" に変わりました。
+   この変更の意味の詳細と、
+   どのようにこの属性を明示的に設定するかについては、
+   <link linkend="mysqli-driver.report-mode">MySQLi のエラー報告モード</link>
+   のページを参照して下さい。
+   以前のバージョンの振る舞いは、
+   <code>mysqli_report(MYSQLI_REPORT_OFF);</code>
+   を使うことで再現できます。
+  </para>
+
+  <para>
+   <methodname>mysqli_stmt::execute</methodname>
+   を継承したクラスは、
+   追加の必須の引数を指定しなければいけません。
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration81.incompatible.mysqlnd">
+  <title>MySQLnd</title>
+
+  <para>
+   INI ディレクティブ
+   <link linkend="ini.mysqlnd.fetch_data_copy">mysqlnd.fetch_data_copy</link>
+   が削除されました。
+   このディレクティブによって、
+   ユーザーの目に見える形で、振る舞いが変更されるべきではないからです。
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration81.incompatible.openssl">
+  <title>OpenSSL</title>
+
+  <para>
+   EC キーの秘密鍵は、他のキーと同じように
+   PKCS#8 フォーマットでエクスポートされるようになりました。
+  </para>
+  <para>
+   <function>openssl_pkcs7_encrypt</function>
+   と
+   <function>openssl_cms_encrypt</function> は、
+   デフォルト値が RC2-40 から AES-128-CBC に変わりました。
+   RC2-40 暗号はセキュアではないと見なされており、
+   OpenSSL 3 からはデフォルトで有効ではなくなっています。
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration81.incompatible.pdo">
+  <title>PHP Data Objects(PDO)</title>
+
+  <para>
+   <constant>PDO::ATTR_STRINGIFY_FETCHES</constant>
+   は、&boolean; 型の値を
+   <literal>"0"</literal> や <literal>"1"</literal>
+   に変換するようになりました。
+   以前のバージョンでは、&boolean; は文字列に変換されていませんでした。
+  </para>
+  <para>
+   <methodname>PDOStatement::bindColumn</methodname>
+   に
+   <constant>PDO::PARAM_LOB</constant>
+   を指定してコールした場合、
+   かつ、<constant>PDO::ATTR_STRINGIFY_FETCHES</constant>
+   が有効になっていない場合は、
+   常にストリームに結果をバインドするようになりました。
+   以前のバージョンでは、
+   使っているデータベースドライバやバインドが行われるタイミングによって、
+   文字列にバインドされることもあれば、
+   ストリームにバインドされることもありました。
+  </para>
+
+  <sect3 xml:id="migration81.incompatible.pdo.mysql">
+   <title>MySQL ドライバ</title>
+
+   <para>
+    結果セットの整数と浮動小数点の値は、
+    エミュレートされたプリペアドステートメントを使った場合、
+    文字列ではなく、
+    ネイティブの PHP の型を使って返されるようになりました。
+    これは、ネイティブのプリペアドステートメントの振る舞いと一致します。
+    以前のバージョンの振る舞いは、
+    <constant>PDO::ATTR_STRINGIFY_FETCHES</constant>
+    オプションを有効にすることで再現できます。
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration81.incompatible.pdo.sqlite">
+   <title>SQLite ドライバ</title>
+
+   <para>
+    結果セットの整数と浮動小数点の値は、
+    ネイティブの PHP の型を使って返されるようになりました。
+    以前のバージョンの振る舞いは、
+    <constant>PDO::ATTR_STRINGIFY_FETCHES</constant>
+    オプションを有効にすることで再現できます。
+   </para>
+  </sect3>
+ </sect2>
+
+ <sect2 xml:id="migration81.incompatible.phar">
+  <title>Phar</title>
+
+  <para>
+   <interfacename>ArrayAccess</interfacename>
+   インターフェイスに準拠するため、
+   <methodname>Phar::offsetUnset</methodname> と、
+   <methodname>PharData::offsetUnset</methodname>
+   は &boolean; を返さなくなりました。
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration81.incompatible.standard">
+  <title>Standard</title>
+
+  <para>
+   <function>version_compare</function> は、
+   ドキュメントに書かれていない演算子の省略形を受け入れなくなりました。
+  </para>
+
+  <para>
+   <function>htmlspecialchars</function>,
+   <function>htmlentities</function>,
+   <function>htmlspecialchars_decode</function>,
+   <function>html_entity_decode</function>,
+   <function>get_html_translation_table</function> のデフォルト値が、
+   <constant>ENT_COMPAT</constant> から
+   <literal>ENT_QUOTES | ENT_SUBSTITUTE</literal> に変わりました。
+   これは、<literal>'</literal> が
+   <literal>&amp;#039;</literal> にエスケープされるようになるということです。
+   以前のバージョンでは、<literal>'</literal>
+   に対してはエスケープは行われていませんでした。
+   さらに、不正な UTF-8 文字列は、空文字列を返すのではなく、
+   Unicode 置換文字に置きかえられるようになっています。
+  </para>
+
+  <para>
+   <function>debug_zval_dump</function> は、
+   値の前に <literal>&amp;</literal> を付加する代わりに、
+   自身のリファレンスカウントだけでなく、
+   リファレンスラッパーのリファレンスカウントも表示するようになりました。
+   これは、PHP 7.0 以降のリファレンスの表現をより正確にモデル化したものです。
+  </para>
+
+  <para>
+   <function>debug_zval_dump</function> は、
+   インターン化された文字列や、
+   変更できない配列については、
+   ダミーのリファレンスカウントではなく、
+   <literal>interned</literal> と表示するようになりました。
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration81.incompatible.spl">
+  <title>Standard PHP Library (SPL)</title>
+
+  <para>
+   <classname>SplFixedArray</classname> は、
+   &array; のように JSON にエンコードできるようになりました。
+  </para>
+ </sect2>
+
+</sect1>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/appendices/migration81/new-classes.xml
+++ b/appendices/migration81/new-classes.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 4d2479dcf35d82aca39ee61f8ab36ceed78a869c Maintainer: mumumu Status: ready -->
+<sect1 xml:id="migration81.new-classes" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>新しいクラスとインターフェイス</title>
+
+ <sect2 xml:id="migration81.new-classes.intl">
+  <title>Intl</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     <classname>IntlDatePatternGenerator</classname>
+    </simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+</sect1>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/appendices/migration81/new-features.xml
+++ b/appendices/migration81/new-features.xml
@@ -1,0 +1,524 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 4d2479dcf35d82aca39ee61f8ab36ceed78a869c Maintainer: mumumu Status: ready -->
+<sect1 xml:id="migration81.new-features" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>新機能</title>
+
+ <sect2 xml:id="migration81.new-features.core">
+  <title>PHP コア</title>
+
+  <sect3 xml:id="migration81.new-features.core.octal-literal-prefix">
+   <title>8進数の整数リテラルのプレフィックス指定</title>
+
+   <para>
+    8進数の整数値の場合に、
+    数値リテラルのプレフィックスとして明示的に
+    <literal>0o</literal> や <literal>0O</literal>
+    を指定できるようになりました。
+    これは、2進数や16進数の整数リテラルの表記と似ています。
+    <informalexample>
+     <programlisting role="php">
+<![CDATA[
+<?php
+014;  // プレフィックス指定がない 8進数のリテラル
+0o14; // プレフィックスを指定した 8進数のリテラル
+?>
+]]>
+     </programlisting>
+    </informalexample>
+   </para>
+   <!-- RFC: https://wiki.php.net/rfc/explicit_octal_notation -->
+  </sect3>
+
+  <sect3 xml:id="migration81.new-features.core.unpacking-string-keys">
+   <title>文字列をキーとして持つ配列のアンパック</title>
+
+   <para>
+    文字列をキーとして持つ配列をアンパックできるようになりました。
+    <!-- TODO Add an example -->
+   </para>
+   <!-- RFC: https://wiki.php.net/rfc/array_unpacking_string_keys -->
+  </sect3>
+
+  <sect3 xml:id="migration81.new-features.core.named-arg-after-unpack">
+   <title>引数をアンパックした後の名前付き引数</title>
+
+   <para>
+    引数をアンパックした後に、名前付き引数を指定できるようになりました。
+    <!-- TODO Add an example -->
+    e.g.
+    foo(...$args, named: $arg).
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration81.new-features.core.upload-full-path-key">
+   <title>ファイルアップロード時の full-path キーのサポート</title>
+
+   <para>
+    ファイルアップロード時に、
+    追加で 
+    <literal>full_path</literal> キーを指定できるようになりました。
+    これにより、アップロードされるファイルの
+    (basename ではなく)
+    フルパスを指定できます。
+    これは、
+    "upload webkitdirectory"
+    と組み合わせて使うことを意図しています。
+   </para>
+   <!-- RFC: https://wiki.php.net/rfc/array_unpacking_string_keys -->
+  </sect3>
+
+  <sect3 xml:id="migration81.new-features.core.enums">
+   <title>列挙型</title>
+
+   <para>
+    <!--<link linkend="language.enumeration">-->列挙型<!--</link>-->
+    のサポートが追加されました。
+    <!-- RFC: https://wiki.php.net/rfc/enumerations -->
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration81.new-features.core.fibers">
+   <title>Fibers</title>
+
+   <para>
+    <!--<link linkend="language.fibers">-->Fibers<!--</link>-->
+    のサポートが追加されました。
+    <!-- RFC: https://wiki.php.net/rfc/fibers -->
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration81.new-features.core.callable-syntax">
+   <title>第一級の callable を生成する記法</title>
+
+   <para>
+    <code>myFunc(...)</code> という記法で、
+    callable から無名関数を生成できるようになりました。
+    これは、
+    <code>Closure::fromCallable('myFunc')</code> と同等です。
+    <!-- RFC: https://wiki.php.net/rfc/first_class_callable_syntax -->
+   </para>
+   <note>
+    <simpara>
+     <code>...</code> は文法の一部であり、省略形ではありません。
+    </simpara>
+   </note>
+  </sect3>
+
+  <sect3 xml:id="migration81.new-features.core.intersection-types">
+   <title>交差型</title>
+
+   <para>
+    <!--<link linkend="language.types.declarations.intersection">-->交差型<!--</link>-->のサポートが追加されました。
+    <!-- RFC: https://wiki.php.net/rfc/pure-intersection-types -->
+   </para>
+   <caution>
+    <simpara>
+     交差型は、
+     <link linkend="language.types.declarations.union">union 型</link>
+     と一緒に使うことはできません。
+    </simpara>
+   </caution>
+  </sect3>
+
+  <sect3 xml:id="migration81.new-features.core.never-type">
+   <title>Never 型</title>
+
+   <para>
+    戻り値にのみ指定できる型として、
+    新しく &never; 型が追加されました。
+    これは、関数が <function>exit</function> するか、
+    例外を投げるか、終了しないことを示します。
+    <!-- RFC: https://wiki.php.net/rfc/noreturn_type -->
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration81.new-features.core.new-in-initializer">
+   <title>初期化時の &new; 式の許可</title>
+
+   <para>
+    <code>new ClassName()</code> 式が、引数のデフォルト値の初期化時、
+    静的な変数の初期化時、グローバルな定数の初期化時、
+    およびアトリビュートの引数として許可されるようになりました。
+    オブジェクトが <function>define</function> に渡せるようにもなっています。
+    <!-- TODO Add an example -->
+   </para>
+   <!-- RFC: https://wiki.php.net/rfc/new_in_initializers -->
+  </sect3>
+
+  <sect3 xml:id="migration81.new-features.core.readonly">
+   <title>読み取り専用のプロパティ</title>
+
+   <para>
+    プロパティに <code>readonly</code> が指定できるようになりました。
+    <!-- RFC: https://wiki.php.net/rfc/readonly_properties_v2 -->
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration81.new-features.core.final-constants">
+   <title>クラス定数の final 指定</title>
+
+   <para>
+    クラスの定数に対して、
+    <modifier>final</modifier> が指定できるようになりました。
+    <!-- RFC: https://wiki.php.net/rfc/final_class_const -->
+   </para>
+  </sect3>
+
+ </sect2>
+
+ <sect2 xml:id="migration81.new-features.curl">
+  <title>CURL</title>
+  
+  <para>
+   <constant>CURLOPT_DOH_URL</constant> オプションが追加されました。
+  </para>
+
+  <para>
+   libcurl &gt;= 7.71.0 で、
+   証明書を blob 経由で扱うためのオプションが追加されました。
+  </para>
+  <itemizedlist>
+   <listitem>
+    <simpara><constant>CURLOPT_ISSUERCERT_BLOB</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>CURLOPT_PROXY_ISSUERCERT</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>CURLOPT_PROXY_ISSUERCERT_BLOB</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>CURLOPT_PROXY_SSLCERT_BLOB</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>CURLOPT_PROXY_SSLKEY_BLOB</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>CURLOPT_SSLCERT_BLOB</constant></simpara>
+   </listitem>
+   <listitem>
+    <simpara><constant>CURLOPT_SSLKEY_BLOB</constant></simpara>
+   </listitem>
+  </itemizedlist>
+
+  <para>
+   ファイルをファイル経由ではなく、
+   文字列で POST するために使える
+   <classname>CURLStringFile</classname> クラスが追加されました。
+   <informalexample>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$file = new CURLStringFile($data, 'filename.txt', 'text/plain');
+curl_setopt($curl, CURLOPT_POSTFIELDS, ['file' => $file]);
+?>
+]]>
+    </programlisting>
+   </informalexample>
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration81.new-features.fpm">
+  <title>FPM</title>
+
+  <para>
+   openmetrics statusフォーマットが追加されました。
+   これは、Prometheus が FPM のメトリクスを取得するのに使えます。
+  </para>
+  <para>
+   <literal>pm.max_spawn_rate</literal> と呼ばれる、
+   動的なプロセスマネージャーのための、
+   新しいプールオプションが追加されました。
+   これを指定することで、
+   動的なプロセスマネージャーを選択した場合に、
+   高速にたくさんの子プロセスが起動できるようになります。
+   これのデフォルト値は <literal>32</literal> で、
+   以前からハードコーディングされていたものです。
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration81.new-features.gd">
+  <title>GD</title>
+
+  <para>
+   libgd に Avix のサポートが組み込まれている場合に、
+   <function>imagecreatefromavif</function> と
+   <function>imageavif</function>
+   で Avix が使えるようになりました。
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration81.new-features.hash">
+  <title>Hash</title>
+
+  <para>
+   <function>hash</function>,
+   <function>hash_file</function>,
+   <function>hash_init</function> 関数に、
+   オプションの引数 <parameter>options</parameter> が追加されました。
+   これによって、ハッシュアルゴリズム特有のデータを渡せるようになります。
+  </para>
+
+  <sect3 xml:id="migration81.new-features.hash.murmurhash3">
+   <title>MurmurHash3</title>
+
+   <para>
+    ストリーミングをサポートした
+    <literal>MurmurHash3</literal> のサポートが追加されました。
+    以下のバリアントが実装されています:
+   </para>
+   <itemizedlist>
+    <listitem>
+     <simpara>murmur3a, 32-bit hash</simpara>
+    </listitem>
+    <listitem>
+     <simpara>murmur3c, 128-bit hash for x86</simpara>
+    </listitem>
+    <listitem>
+     <simpara>murmur3f, 128-bit hash for x64</simpara>
+    </listitem>
+   </itemizedlist>
+
+   <para>
+    ハッシュの初期ステートを
+    引数 <parameter>options</parameter> の
+    <literal>seed</literal> キーを通じて渡すことができます。
+    たとえば、以下のように書くことができます:
+
+    <informalexample>
+     <programlisting role="php">
+      <![CDATA[
+<?php
+$h = hash("murmur3f", $data, options: ["seed" => 42]);
+echo $h, "\n";
+?>
+]]>
+     </programlisting>
+    </informalexample>
+
+    有効な seed の値は
+    <literal>0</literal> から
+    プラットフォーム定義の <constant>UINT_MAX</constant> までです。
+    この値は、通常は <literal>4294967295</literal> です。
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration81.new-features.hash.xxhash">
+   <title>xxHash</title>
+
+   <para>
+    <literal>xxHash</literal> のサポートが追加されました。
+    以下のバリアントが実装されています:
+   </para>
+   <itemizedlist>
+    <listitem>
+     <simpara>xxh32, 32-bit hash</simpara>
+    </listitem>
+    <listitem>
+     <simpara>xxh64, 64-bit hash</simpara>
+    </listitem>
+    <listitem>
+     <simpara>xxh3, 64-bit hash</simpara>
+    </listitem>
+    <listitem>
+     <simpara>xxh128, 128-bit hash</simpara>
+    </listitem>
+   </itemizedlist>
+
+   <para>
+    ハッシュの初期ステートを
+    引数 <parameter>options</parameter> の
+    <literal>seed</literal> キーを通じて渡すことができます。
+    たとえば、以下のように書くことができます:
+
+    <informalexample>
+     <programlisting role="php">
+      <![CDATA[
+<?php
+$h = hash("xxh3", $data, options: ["seed" => 42]);
+echo $h, "\n";
+?>
+]]>
+     </programlisting>
+    </informalexample>
+
+    以下のようにして、シークレットを引数 <parameter>options</parameter> の
+    <literal>secret</literal> キーを通じて渡すこともできます:
+
+    <informalexample>
+     <programlisting role="php">
+      <![CDATA[
+<?php
+$h = hash("xxh3", $data, options: ["secret" => "at least 136 bytes long secret here"]);
+echo $h, "\n";
+?>
+]]>
+     </programlisting>
+    </informalexample>
+
+    カスタムのシークレットの品質が、
+    生成されるハッシュ値の品質に重大な影響を及ぼします。
+    できる限りエントロピーが高いシークレットを使うことを強く推奨します。
+   </para>
+  </sect3>
+ </sect2>
+
+ <sect2 xml:id="migration81.new-features.mysqli">
+  <title>MySQLi</title>
+
+  <sect3 xml:id="migration81.new-features.mysqli.local_infile_directory">
+   <title>新しい INI ディレクティブ <literal>mysqli.local_infile_directory</literal></title>
+
+   <para>
+    <link linkend="ini.mysqli.local-infile-directory">mysqlnd.local_infile_directory</link>
+    ディレクティブが追加されました。
+    これによって、ファイルを読み込むことを許可するディレクトリを指定できます。
+    これは、
+    <link linkend="ini.mysqli.allow-local-infile">mysqli.allow_local_infile</link>
+    が無効の場合にだけ意味があります。
+    なぜなら、
+    この場合に全てのディレクトリからのファイルの読み込みが許可されるからです。
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration81.new-features.mysqli.bind-in-execute">
+   <title>実行時に引数をバインド</title>
+
+   <para>
+    <methodname>mysqli_stmt::execute</methodname>
+    に配列を指定することで、引数をバインドできるようになりました。
+    全ての値が、文字列としてバインドされます。
+    (連想配列でない) リストだけを指定できます。
+    この新機能は、MySQLi を libmysqlclient
+    を使ってコンパイルしている場合には利用できません。
+    <!-- RFC: https://wiki.php.net/rfc/mysqli_bind_in_execute -->
+    <informalexample>
+     <programlisting role="php">
+<![CDATA[
+<?php
+$stmt = $mysqli->prepare('INSERT INTO users(id, name) VALUES(?,?)');
+$stmt->execute([1, $username]);
+?>
+]]>
+     </programlisting>
+    </informalexample>
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration81.new-features.mysqli.mysqli_fetch_column">
+   <title>新しいメソッド <methodname>mysqli_result::fetch_column</methodname></title>
+
+   <para>
+    <methodname>mysqli_result::fetch_column</methodname>
+    が追加されました。これによって、
+    結果セットから単一のスカラー値を取得することができるようになります。
+    この新しいメソッドは、
+    オプションの引数 <parameter>column</parameter>
+    に 0 から始まる整数値を指定することで、
+    どのカラムから情報を取得するかを指定できます。
+    <!-- RFC: https://wiki.php.net/rfc/mysqli_fetch_column -->
+    <informalexample>
+     <programlisting role="php">
+<![CDATA[
+<?php
+$result = $mysqli->query('SELECT username FROM users WHERE id = 123');
+echo $result->fetch_column();
+?>
+]]>
+     </programlisting>
+    </informalexample>
+   </para>
+  </sect3>
+
+ </sect2>
+
+ <sect2 xml:id="migration81.new-features.pdo_mysql">
+  <title>PDO</title>
+
+  <para>
+   <constant>PDO::MYSQL_ATTR_LOCAL_INFILE_DIRECTORY</constant>
+   属性が追加されました。
+   これによって、ファイルを読み込むことを許可するディレクトリを指定できます。
+   これは、
+   <constant>PDO::MYSQL_ATTR_LOCAL_INFILE</constant>
+   が無効の場合にだけ意味があります。
+   なぜなら、
+   この場合に全てのディレクトリからのファイルの読み込みが許可されるからです。
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration81.new-features.pdo_sqlite">
+  <title>PDO_SQLite</title>
+
+  <para>
+   SQLite の
+   <literal>"file:"</literal>
+   DSN 記法がサポートされるようになり、
+   追加のフラグも指定できるようになりました。
+   この機能は、open_basedir が設定されている場合は使えません。
+   <informalexample>
+    <programlisting role="php">
+<![CDATA[
+<?php
+new PDO('sqlite:file:path/to/sqlite.db?mode=ro')
+?>
+]]>
+    </programlisting>
+   </informalexample>
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration81.new-features.posix">
+  <title>POSIX</title>
+
+  <para>
+   <constant>POSIX_RLIMIT_KQUEUES</constant> と
+   <constant>POSIX_RLIMIT_NPTS</constant> が追加されました。
+   これらの rlimits は、FreeBSD でのみ利用可能です。
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration81.new-features.standard">
+  <title>Standard</title>
+
+  <para>
+   <function>fputcsv</function> は、
+   新しい引数 <parameter>eol</parameter> を受け入れるようになりました。
+   これによって、カスタムの改行文字を定義できるようになります。
+   デフォルトは以前と同じで、<literal>"\n"</literal> のままです。
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration81.new-features.spl">
+  <title>SPL</title>
+
+  <para>
+   <methodname>SplFileObject::fputcsv</methodname> は、
+   新しい引数 <parameter>eol</parameter> を受け入れるようになりました。
+   これによって、カスタムの改行文字を定義できるようになります。
+   デフォルトは以前と同じで、<literal>"\n"</literal> のままです。
+  </para>
+ </sect2>
+
+</sect1>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/appendices/migration81/new-functions.xml
+++ b/appendices/migration81/new-functions.xml
@@ -1,0 +1,191 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 4d2479dcf35d82aca39ee61f8ab36ceed78a869c Maintainer: mumumu Status: ready -->
+<sect1 xml:id="migration81.new-functions">
+ <title>新しく追加された関数</title>
+
+ <sect2 xml:id="migration81.new-functions.core">
+  <title>PHP コア</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     <function>array_is_list</function>
+    </simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+ <sect2 xml:id="migration81.new-functions.pcntl">
+  <title>プロセス制御</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     <function>pcntl_rfork</function>
+    </simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+ <sect2 xml:id="migration81.new-functions.reflection">
+  <title>リフレクション</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     <methodname>ReflectionFunctionAbstract::getClosureUsedVariables</methodname>
+    </simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+ <sect2 xml:id="migration81.new-functions.standard">
+  <title>Standard</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     <function>fsync</function>
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <function>fdatasync</function>
+    </simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+ <sect2 xml:id="migration81.new-functions.sodium">
+  <title>Sodium</title>
+
+  <sect3>
+   <title>XChaCha20</title>
+   <itemizedlist>
+    <listitem>
+     <simpara>
+      <function>sodium_crypto_stream_xchacha20</function>
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <function>sodium_crypto_stream_xchacha20_keygen</function>
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <function>sodium_crypto_stream_xchacha20_xor</function>
+     </simpara>
+    </listitem>
+   </itemizedlist>
+  </sect3>
+
+  <sect3>
+   <title>Ristretto255</title>
+
+   <para>
+    Ristretto255 関数は、libsodium 1.0.18 以降で利用可能です。
+   </para>
+
+   <itemizedlist>
+    <listitem>
+     <simpara>
+      <function>sodium_crypto_core_ristretto255_add</function>
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <function>sodium_crypto_core_ristretto255_from_hash</function>
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <function>sodium_crypto_core_ristretto255_is_valid_point</function>
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <function>sodium_crypto_core_ristretto255_random</function>
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <function>sodium_crypto_core_ristretto255_scalar_add</function>
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <function>sodium_crypto_core_ristretto255_scalar_complement</function>
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <function>sodium_crypto_core_ristretto255_scalar_invert</function>
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <function>sodium_crypto_core_ristretto255_scalar_mul</function>
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <function>sodium_crypto_core_ristretto255_scalar_negate</function>
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <function>sodium_crypto_core_ristretto255_scalar_random</function>
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <function>sodium_crypto_core_ristretto255_scalar_reduce</function>
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <function>sodium_crypto_core_ristretto255_scalar_sub</function>
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <function>sodium_crypto_core_ristretto255_sub</function>
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <function>sodium_crypto_scalarmult_ristretto255</function>
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <function>sodium_crypto_scalarmult_ristretto255_base</function>
+     </simpara>
+    </listitem>
+   </itemizedlist>
+  </sect3>
+ </sect2>
+
+</sect1>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/appendices/migration81/other-changes.xml
+++ b/appendices/migration81/other-changes.xml
@@ -1,0 +1,288 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 4d2479dcf35d82aca39ee61f8ab36ceed78a869c Maintainer: mumumu Status: ready -->
+<sect1 xml:id="migration81.other-changes" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>その他の変更</title>
+
+ <sect2 xml:id="migration81.other-changes.sapi">
+  <title>SAPI モジュールへの変更</title>
+
+  <sect3 xml:id="migration81.other-changes.sapi.cli">
+   <title>CLI</title>
+
+   <para>
+    <link linkend="book.readline">readline 拡張機能</link> 
+    が組み込まれていないのに、
+    <option>-a</option> オプションを使った場合、
+    エラーが発生するようになりました。
+    以前のバージョンでは、
+    readline が組み込まれていない時に <option>-a</option>
+    オプションを使うと、
+    <command>php</command>
+    コマンドを引数なしでコールしたのと同じ振る舞いをするのに、
+    <literal>"Interactive mode enabled"</literal>
+    というメッセージを追加で出力していました。
+    この場合のモードは、インタラクティブではありません
+    <emphasis>でした</emphasis>。
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration81.other-changes.sapi.phpdbg">
+   <title>PHPDBG</title>
+
+   <para>
+    <link linkend="book.phpdbg">phpdbg</link>
+    のリモート関連の機能が削除されました。
+   </para>
+  </sect3>
+ </sect2>
+
+ <sect2 xml:id="migration81.other-changes.functions">
+  <title>変更された関数</title>
+
+  <sect3 xml:id="migration81.other-changes.functions.core">
+   <title>PHP コア</title>
+
+   <para>
+    &foreach;、
+    <function>var_dump</function>、
+    <function>serialize</function>、
+    オブジェクトの比較時などで用いられるプロパティの順序が変更されました。
+    プロパティは宣言や継承に応じて、自然順に並ぶようになりました。
+    親クラスで宣言されたプロパティは、
+    子クラスのプロパティの前に並びます。
+   </para>
+   <para>
+    この順序は、
+    構造体 <code>zend_object</code> 
+    内部のレイアウトと一致しており、
+    <code>default_properties_table[]</code>
+    と
+    <code>properties_info_table[]</code>
+    でも同様の順序が用いられています。
+    以前のバージョンでは、
+    プロパティの順序がドキュメント化されておらず、
+    クラスの継承の実装の詳細に依存していました。
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration81.other-changes.functions.filter">
+   <title>Filter</title>
+
+   <para>
+    <constant>FILTER_VALIDATE_INT</constant>
+    フィルタの
+    <constant>FILTER_FLAG_ALLOW_OCTAL</constant> 
+    フラグは、
+    8進数のプレフィックス
+    (<literal>"0o"</literal>/<literal>"0O"</literal>)
+    が先頭についた8進文字列を受け入れるようになりました。
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration81.other-changes.functions.gmp">
+   <title>GMP</title>
+
+   <para>
+    全ての
+    <link linkend="book.gmp">GMP</link>
+    関数が、
+    8進数のプレフィックス
+    (<literal>"0o"</literal>/<literal>"0O"</literal>)
+    が先頭についた8進文字列を受け入れるようになりました。
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration81.other-changes.functions.pdo-odbc">
+   <title>PDO ODBC</title>
+
+   <para>
+    <methodname>PDO::getAttribute</methodname> に 
+    <constant>PDO::ATTR_SERVER_INFO</constant> や
+    <constant>PDO::ATTR_SERVER_VERSION</constant> を指定した場合でも、
+    値を返すようになりました。
+    以前のバージョンでは、
+    <classname>PDOException</classname> をスローしていました。
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration81.other-changes.functions.reflection">
+   <title>リフレクション</title>
+
+   <para>
+    <methodname>ReflectionProperty::setAccessible</methodname>
+    と
+    <methodname>ReflectionMethod::setAccessible</methodname>
+    は、もはや意味をなさなくなりました。
+    プロパティとメソッドは、
+    常にリフレクション経由でアクセス可能と見なされるようになっています。
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration81.other-changes.functions.standard">
+   <title>Standard</title>
+
+   <para>
+    <function>syslog</function> 関数は、バイナリセーフになりました。
+   </para>
+  </sect3>
+ </sect2>
+
+ <sect2 xml:id="migration81.other-changes.extensions">
+  <title>拡張機能へのその他の変更</title>
+
+  <sect3 xml:id="migration81.other-changes.extensions.gd">
+   <title>GD</title>
+
+   <para>
+    <function>imagewebp</function>
+    関数の quality 引数に
+    <constant>IMG_WEBP_LOSSLESS</constant>
+    を指定することで、
+    ロスレスエンコードが行えるようになりました。
+   </para>
+   <para>
+    システムが使っている libgd が
+    WebP のロスレスエンコーディングをサポートしている場合にのみ、
+    この定数は定義されます。
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration81.other-changes.extensions.mysqli">
+   <title>MySQLi</title>
+
+   <para>
+    libmysqlclient とリンクした場合に、
+    <methodname>mysqli_stmt::next_result</methodname>
+    と
+    <methodname>mysqli::fetch_all</methodname> が使えるようになりました。
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration81.other-changes.extensions.openssl">
+   <title>OpenSSL</title>
+
+   <itemizedlist>
+    <listitem>
+     <para>
+      <link linkend="book.openssl">OpenSSL 拡張機能</link>
+      は、OpenSSL 1.0.2 以降が必須になりました。
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      OpenSSL 3.0 がサポートされるようになりました。
+      多くの暗号が(レガシーなプロバイダの一部となっているため)
+      デフォルトで有効ではなくなり、
+      引数の検証 (たとえば鍵の最小サイズ) が厳しくなっています。
+     </para>
+    </listitem>
+   </itemizedlist>
+  </sect3>
+
+  <sect3 xml:id="migration81.other-changes.extensions.phar">
+   <title>Phar</title>
+
+   <itemizedlist>
+    <listitem>
+     <para>
+      SHA256 が、シグネチャのデフォルトとして使われるようになりました。
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      OpenSSL_SHA256 と OpenSSL_SHA512
+      シグネチャのサポートが追加されました。
+     </para>
+    </listitem>
+   </itemizedlist>
+  </sect3>
+
+  <sect3 xml:id="migration81.other-changes.extensions.snmp">
+   <title>SNMP</title>
+
+   <itemizedlist>
+    <listitem>
+     <para>
+      セキュリティプロトコルのために、
+      SHA256 と SHA512 のサポートが追加されました。
+     </para>
+    </listitem>
+   </itemizedlist>
+  </sect3>
+
+  <sect3 xml:id="migration81.other-changes.extensions.standard">
+   <title>Standard</title>
+
+   <para>
+    configure オプション
+    <code>--with-password-argon2</code> は、
+    libargon2 を検知するのに pkg-config を使うようになっています。
+    そのため、libargon2 のインストール先を指定するには、
+    <envar>PKG_CONFIG_PATH</envar> を使うべきです。
+   </para>
+  </sect3>
+ </sect2>
+
+ <sect2 xml:id="migration81.other-changes.ini">
+  <title>INI ファイルの扱いの変更</title>
+
+  <itemizedlist>
+   <listitem>
+    <para>
+     INI ディレクティブ
+     <link linkend="ini.log-errors-max-len">log_errors_max_len</link>
+     は削除されました。
+     PHP 8.0.0 以降、この設定は意味をなさなくなっていました。
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     クォートされた文字列の先頭にドル記号がある場合、
+     そのドル記号はエスケープされるようになりました。
+     つまり、
+     <literal>"\${"</literal>
+     は、
+     <literal>${</literal> という文字列として解釈されます。
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     ダブルクォートで囲まれた文字列中のバックスラッシュは、
+     エスケープ文字としてより一貫した形で扱われるようになりました。
+     以前のバージョンでは、
+     <literal>"foo\\"</literal> の後に改行文字以外の文字が続いた場合、
+     文字列の終端とは見なされませんでした。
+     PHP 8.1.0 以降では、<literal>foo\</literal>
+     という文字列として解釈されるようになります。
+     例外として、<literal>"foo\"</literal> の後に改行文字が続いた場合は、
+     <literal>foo\</literal> という文字列として解釈されます。
+     文字列が終端していないとは見なされません。
+     但し、<literal>"C:\foo\"</literal> のような、
+     Windows のファイルパスを使う場合には例外が存在します。
+    </para>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+</sect1>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
https://github.com/php/doc-en/pull/941 の日本語訳ですが、英語版でも引き続き調整が行われているため、WIP 扱いとしておきます。

* TODO
  -  [x] 新機能
  -  [x] 推奨されなくなる機能
  -  [x] 下位互換性のない変更点
  -  [x] その他の変更
  -  [x] 新しく追加された関数
  -  [x] 新しいクラスとインターフェイス
  -  [x] 新しいグローバル定数