### PR TITLE
error_log() message_type=0の説明の修正

### DIFF
--- a/reference/errorfunc/functions/error-log.xml
+++ b/reference/errorfunc/functions/error-log.xml
@@ -48,11 +48,10 @@
           <row>
            <entry>0</entry>
            <entry>
-            <parameter>message</parameter> は、オペレーティング・システム
-            のシステムログのメカニズムまたはファイルのいずれかを使って
-            PHP のシステム・ロガーに送られます。どちらが使われるかは、
+            <parameter>message</parameter> はPHP のシステム・ロガーに送られ、
             設定ディレクティブ <link linkend="ini.error-log">error_log</link> 
-            の内容により決定されます。これはデフォルトのオプションです。
+            の内容によりオペレーティング・システムのシステムログ機構を使用するか、
+            またはファイルに保存されます。これはデフォルトのオプションです。
            </entry>
           </row>
           <row>


### PR DESCRIPTION
ここではPHPのシステムロガーがerror_logによってOSのシステムログを使用するか、またはファイルに保存するという内容だと思います。訳として順序が逆になっていたようなので修正をしてみました。ご確認お願いします。


多分 [ここ](https://github.com/php/php-src/blob/605ac4649c1e8cf845dbe2bff575ad0b0469b5fe/main/main.c#L782) がPHPのシステムロガーに当たるもので、ここでの処理について書いてるものですかね。
