### PR TITLE
フォーマット文字列の数値に関する表記の変更

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -3163,19 +3163,19 @@ local: {
       <row>
        <entry><literal>b</literal></entry>
        <entry>
-        引数は数値として扱われ、バイナリ値として表現されます。
+        引数は整数として扱われ、バイナリ値として表現されます。
        </entry>
       </row>
       <row>
        <entry><literal>c</literal></entry>
        <entry>
-        引数は数値として扱われ、ASCII文字として表現されます。
+        引数は整数として扱われ、ASCII文字として表現されます。
        </entry>
       </row>
       <row>
        <entry><literal>d</literal></entry>
        <entry>
-        引数は数値として扱われ、(符号付き)小数値として表現されます。
+        引数は整数として扱われ、(符号付き)10進数値として表現されます。
        </entry>
       </row>
       <row>
@@ -3194,13 +3194,13 @@ local: {
       <row>
        <entry><literal>f</literal></entry>
        <entry>
-        引数は小数として扱われ、浮動小数値として表現されます(ロケールを考慮します)。
+        引数は小数として扱われ、浮動小数点数値として表現されます(ロケールを考慮します)。
        </entry>
       </row>
       <row>
        <entry><literal>F</literal></entry>
        <entry>
-        引数は小数として扱われ、浮動小数値として表現されます(ロケールを考慮しません)。
+        引数は小数として扱われ、浮動小数点数値として表現されます(ロケールを考慮しません)。
        </entry>
       </row>
       <row>
@@ -3250,7 +3250,7 @@ local: {
       <row>
        <entry><literal>o</literal></entry>
        <entry>
-        引数は数値として扱われ、8進数値として表現されます。
+        引数は整数として扱われ、8進数値として表現されます。
        </entry>
       </row>
       <row>
@@ -3262,19 +3262,19 @@ local: {
       <row>
        <entry><literal>u</literal></entry>
        <entry>
-        引数は数値として扱われ、符号なし小数値として表現されます。
+        引数は整数として扱われ、符号なし10進数値として表現されます。
        </entry>
       </row>
       <row>
        <entry><literal>x</literal></entry>
        <entry>
-        引数は数値として扱われ、16進数値(小文字)として表現されます。
+        引数は整数として扱われ、16進数値(小文字)として表現されます。
        </entry>
       </row>
       <row>
        <entry><literal>X</literal></entry>
        <entry>
-        引数は数値として扱われ、16進数値(大文字)として表現されます。
+        引数は整数として扱われ、16進数値(大文字)として表現されます。
        </entry>
       </row>
      </tbody>


### PR DESCRIPTION
フォーマット文字列の数値に関する指定子の説明に、表記揺れと誤訳と思わしきものがありましたので修正しました。
https://www.php.net/manual/ja/function.printf.php

`integer` を「数値」から「整数」へ
`decimal number` を「小数値」から「10進数値」へ
`floating-point number` を「浮動小数値」から「浮動小数点数値」へ

