### PR TITLE
文言修正（変換語 -> 変換後）

### DIFF
--- a/reference/strings/functions/htmlspecialchars.xml
+++ b/reference/strings/functions/htmlspecialchars.xml
@@ -44,7 +44,7 @@
      <thead>
       <row>
        <entry>変換前</entry>
-       <entry>変換語</entry>
+       <entry>変換後</entry>
       </row>
      </thead>
      <tbody>


### PR DESCRIPTION
htmlspecialchars ページの文言修正

そもそも直訳ではないが、`変換前` に対しては `変換後` が自然だと思います。

英語ページ

![image](https://user-images.githubusercontent.com/16895409/141262972-7b6bd7ff-67a1-4c67-bf4a-9fd997f8d821.png)

日本語ページ

![image](https://user-images.githubusercontent.com/16895409/141263020-926cd4a2-f5c7-43c1-a6db-994fa88ca447.png)
