### PR TITLE
arithmeticの訳を「算術」にする

### DIFF
--- a/appendices/migration80/incompatible.xml
+++ b/appendices/migration80/incompatible.xml
@@ -609,7 +609,7 @@ $array["key"];
      </para>
      <para>
       <simplelist>
-       <member>代数演算</member>
+       <member>算術演算</member>
        <member>ビット演算</member>
       </simplelist>
      </para>

--- a/appendices/tokens.xml
+++ b/appendices/tokens.xml
@@ -653,14 +653,14 @@ defined('T_FN') || define('T_FN', 10001);
      <entry><constant>T_POW</constant></entry>
      <entry>**</entry>
      <entry>
-      <link linkend="language.operators.arithmetic">代数演算子</link>
+      <link linkend="language.operators.arithmetic">算術演算子</link>
      </entry>
     </row>
     <row>
      <entry><constant>T_POW_EQUAL</constant></entry>
      <entry>**=</entry>
      <entry>
-      <link linkend="language.operators.assignment">代数演算子</link>
+      <link linkend="language.operators.assignment">代入演算子</link>
      </entry>
     </row>
     <row>

--- a/language/operators.xml
+++ b/language/operators.xml
@@ -15,7 +15,7 @@
    <literal>++</literal> (
    <link linkend="language.operators.increment">加算子</link>)
    などです。二項演算子はふたつの値を受け取ります。おなじみの
-   <link linkend="language.operators.arithmetic">代数演算子</link> である
+   <link linkend="language.operators.arithmetic">算術演算子</link> である
    <literal>+</literal> (加算) や <literal>-</literal> (減算)
    など PHP の演算子の大半はこの分類に含まれます。最後は三つの値を受け取る
    <link linkend="language.operators.comparison.ternary">三項演算子</link>
@@ -96,7 +96,7 @@
        <row>
         <entry>right</entry>
         <entry><literal>**</literal></entry>
-        <entry><link linkend="language.operators.arithmetic">代数演算子</link></entry>
+        <entry><link linkend="language.operators.arithmetic">算術演算子</link></entry>
        </row>
        <row>
         <entry>(n/a)</entry>
@@ -115,7 +115,7 @@
          <literal>@</literal>
         </entry>
         <entry>
-         <link linkend="language.operators.arithmetic">代数演算子</link> (単項の <literal>+</literal> と <literal>-</literal>),
+         <link linkend="language.operators.arithmetic">算術演算子</link> (単項の <literal>+</literal> と <literal>-</literal>),
          <link linkend="language.operators.increment">加算子/減算子</link>,
          <link linkend="language.operators.bitwise">ビット演算子</link>,
          <link linkend="language.types.typecasting">型の相互変換</link>&listendand;
@@ -144,7 +144,7 @@
          <literal>%</literal>
         </entry>
         <entry>
-         <link linkend="language.operators.arithmetic">代数演算子</link>
+         <link linkend="language.operators.arithmetic">算術演算子</link>
         </entry>
        </row>
        <row>
@@ -155,7 +155,7 @@
          <literal>.</literal>
         </entry>
         <entry>
-         <link linkend="language.operators.arithmetic">代数演算子</link> (単項の <literal>+</literal> と <literal>-</literal>),
+         <link linkend="language.operators.arithmetic">算術演算子</link> (単項の <literal>+</literal> と <literal>-</literal>),
          <link linkend="language.operators.array">配列演算子</link>&listendand;
          <link linkend="language.operators.string">文字列演算子</link> (PHP 8.0.0 より前のバージョンの<literal>.</literal>)
         </entry>
@@ -405,7 +405,7 @@ x minus one equals 3, or so I hope
         <entry>
          文字列の連結 (<literal>.</literal>) 
          の優先順位は、
-         代数演算子の加算/減算
+         算術演算子の加算/減算
          (<literal>+</literal> および <literal>-</literal>)
          と ビットシフト演算子
          (<literal>&lt;&lt;</literal> および <literal>&gt;&gt;</literal>);
@@ -436,7 +436,7 @@ x minus one equals 3, or so I hope
         <entry>7.4.0</entry>
         <entry>
          文字列の連結 (<literal>.</literal>) 演算と、
-         代数演算子の加算/減算
+         算術演算子の加算/減算
          (<literal>+</literal> および <literal>-</literal>)
          と ビットシフト演算子
          (<literal>&lt;&lt;</literal> および <literal>&gt;&gt;</literal>);
@@ -451,13 +451,13 @@ x minus one equals 3, or so I hope
   </sect1>
   
   <sect1 xml:id="language.operators.arithmetic">
-   <title>代数演算子</title>
+   <title>算術演算子</title>
    <simpara>
-    学校で習った基礎代数を憶えていますか?
+    学校で習った初等算術を憶えていますか?
     この演算子はそれらと同様に動作します。
    </simpara>
    <table>
-    <title>代数演算子</title>
+    <title>算術演算子</title>
     <tgroup cols="3">
      <thead>
       <row>

--- a/reference/gmp/book.xml
+++ b/reference/gmp/book.xml
@@ -32,7 +32,7 @@
     PHP 5.6 以降は、
     <function>gmp_init</function> やその他の GMP 関数が返す
     <classname>GMP</classname> オブジェクトに対して、
-    <link linkend="language.operators.arithmetic">代数演算子</link>や
+    <link linkend="language.operators.arithmetic">算術演算子</link>や
     <link linkend="language.operators.bitwise">ビット演算子</link>そして
     <link linkend="language.operators.comparison">比較演算子</link>
     が使えるようになります。

--- a/reference/gmp/gmp.xml
+++ b/reference/gmp/gmp.xml
@@ -12,7 +12,7 @@
    &reftitle.intro;
    <para>
     GMP 数。このオブジェクトは、オーバーロードされた
-    <link linkend="language.operators.arithmetic">代数演算子</link>,
+    <link linkend="language.operators.arithmetic">算術演算子</link>,
     <link linkend="language.operators.bitwise">ビット演算子</link>,
     <link linkend="language.operators.comparison">比較演算子</link> をサポートしています。
    </para>

--- a/reference/imagick/imagick/functionimage.xml
+++ b/reference/imagick/imagick/functionimage.xml
@@ -17,7 +17,7 @@
    <methodparam choice="opt"><type>int</type><parameter>channel</parameter><initializer>Imagick::CHANNEL_DEFAULT</initializer></methodparam>
   </methodsynopsis>
   <para>
-   代数演算、関係演算、論理演算などを疑似画像に適用します。
+   算術演算、関係演算、論理演算などを疑似画像に適用します。
   </para>
   <para>
    <link xlink:href="&url.imagemagick.usage.transform.function;">ImageMagick


### PR DESCRIPTION
"arithmetic"が「代数」と約されているところが多数ありますが、おそらく"algebraic"と勘違いして訳されたと思います。
英文が"arithmetic"になっていることを確認した上で「算術」に置き換えました。一箇所は"assignment"だったので、そこは「代入」にしています。