### PR TITLE
Modify a comment of enum's method more correctly

### DIFF
--- a/language/enumerations.xml
+++ b/language/enumerations.xml
@@ -345,7 +345,7 @@ enum Suit implements Colorful
         };
     }
 
-    // インターフェイスの一部ではないので、正しいコード
+    // インターフェイスの一部ではないが、正しいコード
     public function shape(): string
     {
         return "Rectangle";


### PR DESCRIPTION
## About

- 英語マニュアルの以下の部分の翻訳についての提案です
    - https://github.com/php/doc-en/blob/930b6389f99eaa62e5bbd935cfc2b1b90645f615/language/enumerations.xml#L296
    > Not part of an interface; that's fine.
- 原文のこの部分は「Enum では Interface 定義したメソッド以外も書ける」という説明だと思います
    - 「インターフェイスの一部ではないので、正しいコード」では意味が少し違うのではないでしょうか
    - 「インターフェイスの一部ではないが、正しいコード」という表現を提案します



