### PR TITLE
名前空間内での`assert()`についての説明を修正

### DIFF
--- a/reference/info/functions/assert.xml
+++ b/reference/info/functions/assert.xml
@@ -224,16 +224,16 @@
        <entry>8.0.0</entry>
        <entry>
         名前空間の内部で、
-        <literal>assert()</literal> をコールすることはできなくなりました。
-        コールした場合、<constant>E_COMPILE_ERROR</constant> が発生します。
+        <literal>assert()</literal> という名前の関数を定義することはできなくなりました。
+        定義しようとした場合、<constant>E_COMPILE_ERROR</constant> が発生します。
        </entry>
       </row>
       <row>
        <entry>7.3.0</entry>
        <entry>
         名前空間の内部で、
-        <literal>assert()</literal> をコールすることは推奨されなくなりました。
-        コールした場合、
+        <literal>assert()</literal> という名前の関数を定義することは推奨されなくなりました。
+        定義した場合、
         <constant>E_DEPRECATED</constant> が発生するようになっています。
        </entry>
       </row>


### PR DESCRIPTION
`assert()`の Changelog の説明を、[英語版](https://www.php.net/manual/en/function.assert.php#refsect1-function.assert-changelog)と合うようにしています。