### PR TITLE
Exception（class.exception）のプロパティ名の誤りを修正

### DIFF
--- a/language/predefined/exception.xml
+++ b/language/predefined/exception.xml
@@ -121,19 +121,19 @@
      </listitem>
     </varlistentry>
     <varlistentry xml:id="exception.props.previous">
-     <term><varname>line</varname></term>
+     <term><varname>previous</varname></term>
      <listitem>
       <para>直前にスローされた例外</para>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="exception.props.string">
-     <term><varname>line</varname></term>
+     <term><varname>string</varname></term>
      <listitem>
       <para>スタックトレースを示す文字列</para>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="exception.props.trace">
-     <term><varname>line</varname></term>
+     <term><varname>trace</varname></term>
      <listitem>
       <para>スタックトレースを示す配列</para>
      </listitem>


### PR DESCRIPTION
プロパティ名が間違っている箇所を修正いたしました。

該当ページ: https://www.php.net/manual/ja/class.exception.php