### PR TITLE
SplTempFileObject クラス のタイトルを修正

### DIFF
--- a/reference/spl/spltempfileobject.xml
+++ b/reference/spl/spltempfileobject.xml
@@ -3,7 +3,7 @@
 <!-- EN-Revision: 9eb4ef92afb4f70c5000d1ba772410d55e3026b8 Maintainer: mumumu Status: ready -->
 <phpdoc:classref xml:id="class.spltempfileobject" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
- <title>The SplTempFileObject クラス</title>
+ <title>SplTempFileObject クラス</title>
  <titleabbrev>SplTempFileObject</titleabbrev>
 
  <partintro>


### PR DESCRIPTION
[SplFileInfo](https://www.php.net/manual/ja/class.splfileinfo.php), [SplFileObject](https://www.php.net/manual/ja/class.splfileobject.php) と比較して、
SplTempFileObject にだけタイトルに "The" が残っていたため、
統一感のために修正いたしました。

該当ページ: https://www.php.net/manual/ja/class.spltempfileobject.php