### PR TITLE
Added about SJIS and Unicode conversion map in PHP 8.1

### DIFF
--- a/reference/mbstring/functions/mb-convert-encoding.xml
+++ b/reference/mbstring/functions/mb-convert-encoding.xml
@@ -109,6 +109,14 @@
     </thead>
     <tbody>
      <row>
+      <entry>8.1.0</entry>
+      <entry>
+       SJISの<emphasis>\</emphasis>(<literal>\x5C</literal>) と <emphasis>~</emphasis>(<literal>\x7E</literal>) が
+       <emphasis>¥</emphasis>(<literal>\u{00A5}</literal>) と <emphasis>‾</emphasis>(<literal>\u{203E}</literal>) に
+       マッピングされるようになりました。SJIS-WINとしても知られるCP932はこの変更の影響を受けません。
+      </entry>
+     </row>
+     <row>
       <entry>8.0.0</entry>
       <entry>
        <parameter>to_encoding</parameter> に不正なエンコーディングが渡された場合、
@@ -160,6 +168,9 @@ $str = mb_convert_encoding($str, "UCS-2LE", "JIS, eucjp-win, sjis-win");
 
 /* mbstring.language が "Japanese" の場合 "auto" は、"ASCII,JIS,UTF-8,EUC-JP,SJIS" に展開される */
 $str = mb_convert_encoding($str, "EUC-JP", "auto");
+
+/* PHP 8.0以前と互換性のあるSJISからUTF-8への変換 */
+$str = strtr(mb_convert_encoding($input, 'UTF-8', 'SJIS'), ['¥' => '\\', '‾' => '~']);
 ?>
 ]]>
     </programlisting>


### PR DESCRIPTION
This PR is based on discussions in https://github.com/php/php-src/issues/8281#issuecomment-1089033545, so I'm still working on it. 

Since this issue is related to Japanese, I am submitting a proposal in doc-ja before doc-en.
And my English is poor, so I made a draft in Japanese first.