### PR TITLE
simplexml_import_dom() は false を返さないため「この関数は論理値 false を返す可能性が......」を削除

### DIFF
--- a/reference/simplexml/functions/simplexml-import-dom.xml
+++ b/reference/simplexml/functions/simplexml-import-dom.xml
@@ -54,7 +54,6 @@
    <type>SimpleXMLElement</type> を返します。
    失敗時に &null; を返します。
   </para>
-  &return.falseproblem;
  </refsect1>
 
  <refsect1 role="examples">


### PR DESCRIPTION
英語バージョンにはこの文言が含まれておらず、実際この関数も `false` は返さないようです。