### PR TITLE
「失敗した場合にfalseを返します」の後に句点を追加

### DIFF
--- a/reference/datetime/functions/date-sunrise.xml
+++ b/reference/datetime/functions/date-sunrise.xml
@@ -156,7 +156,7 @@
   &reftitle.returnvalues;
   <para>
    日の出時刻を、指定した <parameter>returnFormat</parameter> で返します。
-   &return.falseforfailure;
+   &return.falseforfailure;。
    失敗する潜在的な可能性があります。太陽が全く昇らない場合です。
    これは一年のある時期、極圏の中にある場合に起こります。
   </para>

--- a/reference/datetime/functions/date-sunset.xml
+++ b/reference/datetime/functions/date-sunset.xml
@@ -156,7 +156,7 @@
   &reftitle.returnvalues;
   <para>
    日の入り時刻を、指定した <parameter>returnFormat</parameter> で返します。
-   &return.falseforfailure;
+   &return.falseforfailure;。
    失敗する潜在的な可能性があります。太陽が全く昇らない場合です。
    これは一年のある時期、極圏の中にある場合に起こります。
   </para>

--- a/reference/eio/functions/eio-readdir.xml
+++ b/reference/eio/functions/eio-readdir.xml
@@ -74,7 +74,7 @@
   &reftitle.returnvalues;
   <para>
    <function>eio_readdir</function>
-   は、成功した場合にリクエストリソースを返します。&return.falseforfailure;
+   は、成功した場合にリクエストリソースを返します。&return.falseforfailure;。
    <parameter>callback</parameter> 関数の <parameter>result</parameter>
    に設定される内容は <parameter>flags</parameter> によって変わります。
   </para>

--- a/reference/eio/functions/eio-stat.xml
+++ b/reference/eio/functions/eio-stat.xml
@@ -64,7 +64,7 @@
   &reftitle.returnvalues;
   <para>
    <function>eio_stat</function>
-   は、成功した場合にリクエストリソースを返します。&return.falseforfailure;
+   は、成功した場合にリクエストリソースを返します。&return.falseforfailure;。
    成功した場合は、<parameter>callback</parameter> の
    <parameter>result</parameter> 引数に配列が格納されます。
   </para>

--- a/reference/eio/functions/eio-statvfs.xml
+++ b/reference/eio/functions/eio-statvfs.xml
@@ -61,7 +61,7 @@
   &reftitle.returnvalues;
   <para>
   <function>eio_statvfs</function>
-  は、成功した場合にリクエストリソースを返します。&return.falseforfailure;
+  は、成功した場合にリクエストリソースを返します。&return.falseforfailure;。
   成功した場合は、<parameter>callback</parameter> の
   <parameter>result</parameter> 引数に配列が格納されます。
   </para>

--- a/reference/filesystem/functions/filemtime.xml
+++ b/reference/filesystem/functions/filemtime.xml
@@ -38,7 +38,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   ファイルの最終更新時刻を返し、&return.falseforfailure;
+   ファイルの最終更新時刻を返し、&return.falseforfailure;。
    時間は Unix タイムスタンプとして返されます。
    この関数の結果は <function>date</function> 等で使用できます。
   </para>

--- a/reference/imap/functions/imap-bodystruct.xml
+++ b/reference/imap/functions/imap-bodystruct.xml
@@ -47,7 +47,7 @@
   &reftitle.returnvalues;
   <para>
    オブジェクトの情報を返します。
-   &return.falseforfailure;
+   &return.falseforfailure;。
    オブジェクトの構造やプロパティについての詳細は
    <function>imap_fetchstructure</function> を参照ください。
   </para>

--- a/reference/imap/functions/imap-status.xml
+++ b/reference/imap/functions/imap-status.xml
@@ -87,7 +87,7 @@
   &reftitle.returnvalues;
   <para>
    この関数は、ステータス情報を含むオブジェクトを返します。
-   &return.falseforfailure;
+   &return.falseforfailure;。
    このオブジェクトには
    <literal>messages</literal>、
    <literal>recent</literal>、<literal>unseen</literal>、

--- a/reference/oci8/functions/oci-password-change.xml
+++ b/reference/oci8/functions/oci-password-change.xml
@@ -88,11 +88,11 @@
    <parameter>connection</parameter> が指定された場合、
    <function>oci_password_change</function> は
    成功時に &true; を返します。
-   &return.falseforfailure;
+   &return.falseforfailure;。
    <parameter>connection</parameter> が指定された場合、
    <function>oci_password_change</function> は
    成功時に接続リソースを返します。
-   &return.falseforfailure;
+   &return.falseforfailure;。
   </para>
  </refsect1>
 

--- a/reference/posix/functions/posix-getgrnam.xml
+++ b/reference/posix/functions/posix-getgrnam.xml
@@ -36,7 +36,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   成功したときは <type>array</type> を返します。&return.falseforfailure;
+   成功したときは <type>array</type> を返します。&return.falseforfailure;。
    配列で返される要素は下記のとおりです。
    <table>
     <title>グループ情報の配列</title>

--- a/reference/session/sessionhandler/gc.xml
+++ b/reference/session/sessionhandler/gc.xml
@@ -57,7 +57,7 @@
   &reftitle.returnvalues;
   <para>
    成功時には、削除されたセッションの数を返します。
-   &return.falseforfailure;
+   &return.falseforfailure;。
    この値は、処理を続けるために PHP の内部にも返される点に注意して下さい。
   </para>
  </refsect1>

--- a/reference/session/sessionhandlerinterface/gc.xml
+++ b/reference/session/sessionhandlerinterface/gc.xml
@@ -42,7 +42,7 @@
   &reftitle.returnvalues;
   <para>
    成功時に、削除したセッションの数を返します。
-   &return.falseforfailure;
+   &return.falseforfailure;。
    この値は、処理を続けるために PHP の内部にも返される点に注意して下さい。
   </para>
  </refsect1>


### PR DESCRIPTION
[`filemtime()`](https://www.php.net/manual/ja/function.filemtime)のように、戻り値の説明で「失敗した場合に false を返します」の後に句点がなく、かつその後に文章が続くケースにおいて、句点を追加しています。

下記コマンドで出てきたファイルは全て修正したので、おそらく他に同じ問題があるファイルはないと思います。
```console
$ cd doc-ja/reference
$ grep -l -Pr '&return\.falseforfailure;(?![.。])' . | php -R '$a = explode("&return.falseforfailure;", file_get_contents($argn)); array_shift($a); foreach ($a as $s) { if (!str_starts_with(trim($s), "</para>")) { echo $argn, PHP_EOL; break; } }'
```