### PR TITLE
「NAN を他の値を比較しては」と助詞 "を" が重複しているのを修正

### DIFF
--- a/language/types/float.xml
+++ b/language/types/float.xml
@@ -161,7 +161,7 @@ if(abs($a-$b) < $epsilon) {
   </para>
   <para>
    <constant>NAN</constant> はさまざまな値の数を表すものなので、
-   <constant>NAN</constant> を他の値を比較してはいけません。たとえ自分自身とであってもです。
+   <constant>NAN</constant> を他の値と比較してはいけません。たとえ自分自身とであってもです。
    チェックをする場合には、かわりに <function>is_nan</function> を使います。
   </para>
  </sect2>


### PR DESCRIPTION
> NAN should not be compared to other values
https://www.php.net/manual/en/language.types.float.php#language.types.float.nan

なので、 「NAN を他の値と比較しては」に修正しています