### PR TITLE
floor の説明を修正

### DIFF
--- a/reference/math/functions/floor.xml
+++ b/reference/math/functions/floor.xml
@@ -15,7 +15,7 @@
   </methodsynopsis>
   <simpara>
    必要に応じて <parameter>num</parameter> を丸めることにより、
-   <parameter>value</parameter> をこえない最大の整数の値を (float 型で) 返します。
+   <parameter>num</parameter> をこえない最大の整数の値を (float 型で) 返します。
   </simpara>
  </refsect1>
  <refsect1 role="parameters">


### PR DESCRIPTION
英語版がこうなので

> Returns the next lowest integer value (as float) by rounding down num if necessary.

この "value" が残ったものかと思われますが、意味からするとここは "num" ではないでしょうか。