### PR TITLE
Fix property names of Error class

### DIFF
--- a/language/predefined/error.xml
+++ b/language/predefined/error.xml
@@ -119,19 +119,19 @@
        </listitem>
       </varlistentry>
       <varlistentry xml:id="error.props.previous">
-       <term><varname>line</varname></term>
+       <term><varname>previous</varname></term>
        <listitem>
         <para>直前にスローされた例外</para>
        </listitem>
       </varlistentry>
       <varlistentry xml:id="error.props.string">
-       <term><varname>line</varname></term>
+       <term><varname>string</varname></term>
        <listitem>
         <para>スタックトレースを示す文字列</para>
        </listitem>
       </varlistentry>
       <varlistentry xml:id="error.props.trace">
-       <term><varname>line</varname></term>
+       <term><varname>trace</varname></term>
        <listitem>
         <para>スタックトレースを示す配列</para>
        </listitem>


### PR DESCRIPTION
# 問題

`Error` クラスのプロパティ名のうちのいくつかが、誤って `line` になっていました。

# 変更内容

英語版を参考に、`line` を適切なプロパティ名へ置き換えました。

Refs:

* https://www.php.net/manual/ja/class.error.php#error.props
* https://www.php.net/manual/en/class.error.php#error.props

-----------

追記: #38 と同じ修正です