### PR TITLE
Fix filetype()'s doc: 例示ソースコード中の翻訳すべきでない箇所が翻訳されている

### DIFF
--- a/reference/filesystem/functions/filetype.xml
+++ b/reference/filesystem/functions/filetype.xml
@@ -63,8 +63,8 @@
 <![CDATA[
 <?php
 
-echo filetype('/etc/passwd');  // ファイル
-echo filetype('/etc/');        // ディレクトリ
+echo filetype('/etc/passwd');  // file
+echo filetype('/etc/');        // dir
 
 ?>
 ]]>


### PR DESCRIPTION
## 概要

`filetype()` 関数の例示ソースコードの中で、翻訳すべきではない箇所が翻訳されてしまっていました。

## 詳細

この `filetype()` 関数は、引数に渡されたファイルの種類を返すもので、次のような戻り値を取ります ([日本語版](https://www.php.net/manual/ja/function.filetype.php) ドキュメントから引用)。

> 返される値は fifo、char、dir、 block、link、file、socket および unknown のいずれかです。

現在の日本語版の例示コードは、

```php
<?php

echo filetype('/etc/passwd');  // ファイル
echo filetype('/etc/');        // ディレクトリ

?>
```

のように、"file" および "dir" という単語を翻訳しています。しかし、この部分は、ソースコードを実行して実際に出力される値を示したものであり、"file"、"dir" とそのまま書くのが適切ではないでしょうか。

[英語版](https://www.php.net/manual/en/function.filetype.php) の例示コードにも、

```php
<?php

echo filetype('/etc/passwd');  // file
echo filetype('/etc/');        // dir

?>
```

とあります。ここで、"directory" ではなく "dir" と書いていることからも、このコメントは自然言語として書いたのではなく、関数の戻り値の例として書いたものと思われます。
