### PR TITLE
Ubuntu-latest workflows will use Ubuntu-22.04, temporary workaround.

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -12,7 +12,7 @@ jobs:
   build:
     name: "Build"
 
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-20.04"
 
     strategy:
       matrix:


### PR DESCRIPTION
phpdoc を CI するための github action が軒並み様々なロケールで落ちている。現在 ubuntu-latest が 22.04 に移行中とのことなので、とりあえずこのPRで回避する

----

ubuntu-latest is currently transitioning to ubuntu-22.04. During this time, you may experience some jobs running on either an ubuntu-20.04 or ubuntu-22.04 runner. You can specify `runs-on: ubuntu-20.04` in your workflow if you need the previous version.

https://github.com/actions/runner-images
https://github.com/actions/runner-images/issues/6399