### PR TITLE
fix p tag in sample html

### DIFF
--- a/chapters/tutorial.xml
+++ b/chapters/tutorial.xml
@@ -105,7 +105,7 @@
   <title>PHP Test</title>
  </head>
  <body>
- Hello World<p>
+ <p>Hello World</p>
  </body>
 </html>
 ]]>


### PR DESCRIPTION
サンプルの `<p>` の出力結果が誤っていたため修正しました

対応する英語 doc: <https://github.com/php/doc-en/blob/e892ba1a975cc9cfee85cfdd33ce56ecd5fd243b/chapters/tutorial.xml#L98>
