### PR TITLE
Number typo on set-error-handler.xml

### DIFF
--- a/reference/errorfunc/functions/set-error-handler.xml
+++ b/reference/errorfunc/functions/set-error-handler.xml
@@ -118,7 +118,7 @@
          <term><parameter>errcontext</parameter></term>
          <listitem>
           <simpara>
-           コールバックが第4引数 <parameter>errcontext</parameter> を受け入れる場合、
+           コールバックが第5引数 <parameter>errcontext</parameter> を受け入れる場合、
            エラーが発生した場所のアクティブシンボルテーブルが配列で渡されます。
            つまり、エラーが発生したスコープ内でのすべての変数の内容を格納した
            配列が <parameter>errcontext</parameter> だということです。


### PR DESCRIPTION
set_error_handlerのcallback関数の解説に第4引数が2つありました。
英語版ではこの部分はfifth parameterでした。