### PR TITLE
誤訳の修正

### DIFF
--- a/appendices/migration73/incompatible.xml
+++ b/appendices/migration73/incompatible.xml
@@ -42,8 +42,8 @@ FOO;
     <literal>switch</literal> の制御フローを変更することを狙った 
     <literal>continue</literal> 文は、警告が出るようになりました。
     PHP では、このような <literal>continue</literal> 文は
-    <literal>break</literal> と同等で、他のプログラミング言語の
-    <literal>continue 2</literal> と同じように振る舞います。
+    <literal>break</literal> と同等で、他のプログラミング言語では
+    <literal>continue 2</literal> と同じように振る舞うのとは対照的です。
     <informalexample>
      <programlisting role="php">
 <![CDATA[


### PR DESCRIPTION
[原文](https://github.com/php/doc-en/blob/cf220d0944b207510abb5e3c7c262140b8ac082c/appendices/migration73/incompatible.xml#L45-L46)

`PHPのcontinue === 他の言語のcontinue 2`のように読める訳になっているが、 実際は`PHPのcontinue 2 === 他の言語のcontinue`である。