### PR TITLE
Fix the return.callbacksort translation about the word "an integer" from "数" to "整数"

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -731,7 +731,7 @@ DLL ファイルを PHP のフォルダから Windows のシステムディレ�
 
 <!ENTITY return.true.always '常に &true; を返します。'>
 
-<!ENTITY return.callbacksort '比較関数は、最初の引数と二番目の引数の比較結果を返します。最初の引数のほうが二番目の引数より大きい場合は正の数を、二番目の引数と等しい場合はゼロを、そして二番目の引数より小さい場合は負の数を返す必要があります。'>
+<!ENTITY return.callbacksort '比較関数は、最初の引数と二番目の引数の比較結果を返します。最初の引数のほうが二番目の引数より大きい場合は正の整数を、二番目の引数と等しい場合はゼロを、そして二番目の引数より小さい場合は負の整数を返す必要があります。'>
 
 <!ENTITY return.falseproblem '<warning xmlns="http://docbook.org/ns/docbook"><simpara>この関数は論理値
 &false; を返す可能性がありますが、&false; として評価される値を返す可能性もあります。


### PR DESCRIPTION
ソートの比較関数の戻り値が `float` だと `int` に変換されてしまい正しく動かないようなので、"an integer" の訳は「数」ではなく「整数」が適切ではないでしょうか。

https://github.com/php/doc-en/blob/6f9e433f4b4a591801c3a49fc459550ea1b5f613/language-snippets.ent#L761

```php
<?php
$x = [
    ['score' => 8.5],
    ['score' => 9.2],
    ['score' => 8.4],
];

usort($x, function($a,$b) {
  return $b['score'] - $a['score'];
});
var_dump($x);

usort($x, function($a,$b) {
  return $b['score'] <=> $a['score'];
});
var_dump($x);
```

```
array(3) {
  [0]=>
  array(1) {
    ["score"]=>
    float(8.5)
  }
  [1]=>
  array(1) {
    ["score"]=>
    float(9.2)
  }
  [2]=>
  array(1) {
    ["score"]=>
    float(8.4)
  }
}
array(3) {
  [0]=>
  array(1) {
    ["score"]=>
    float(9.2)
  }
  [1]=>
  array(1) {
    ["score"]=>
    float(8.5)
  }
  [2]=>
  array(1) {
    ["score"]=>
    float(8.4)
  }
}
```

この挙動に関して、 `usort()` 関数から、以前あった注意書きが失われているようですが、これについては `doc-en` に issue (`php/doc-en#2365`) を作成しました。