### PR TITLE
Remove 'i' prefix from interface name

### DIFF
--- a/language/oop5/interfaces.xml
+++ b/language/oop5/interfaces.xml
@@ -125,7 +125,7 @@
 <![CDATA[
 <?php
 
-// インターフェイス 'iTemplate' を宣言する
+// インターフェイス 'Template' を宣言する
 interface Template
 {
     public function setVariable($name, $var);


### PR DESCRIPTION
64c04ad79652575c1cf8c9f3c7cc20b2505853bd における変更漏れのようです。

原文: https://github.com/php/doc-en/blob/8734cc1232dfe9a0fc9e455f470c6bf000537402/language/oop5/interfaces.xml#LL100C1-L101C1