### PR TITLE
Fix encryption mode name

### DIFF
--- a/reference/openssl/functions/openssl-encrypt.xml
+++ b/reference/openssl/functions/openssl-encrypt.xml
@@ -81,7 +81,7 @@
      <term><parameter>tag</parameter></term>
      <listitem>
       <para>
-       AEAD 暗号モード (GCM または LCM) を使う場合の
+       AEAD 暗号モード (GCM または CCM) を使う場合の
        認証タグを参照で渡します。
       </para>
      </listitem>


### PR DESCRIPTION
[英語版では`GCM or CCM`となっている](https://github.com/php/doc-en/blob/2fa74a5512c0a7d3eabe39b1060646fc32f253f5/reference/openssl/functions/openssl-encrypt.xml#L80)ため`CCM`に修正しました。