### PR TITLE
🔧 fix: add missing description ( これは例 → これは例です。 )

### DIFF
--- a/language/basic-syntax.xml
+++ b/language/basic-syntax.xml
@@ -222,7 +222,7 @@ echo '最後のテストです'; # シェル型の単一行用のコメント
    <informalexample>
     <programlisting role="php">
 <![CDATA[
-<h1>これは <?php # echo 'シンプルな';?> 例</h1>
+<h1>これは <?php # echo 'シンプルな';?> 例です。</h1>
 <p>上の見出しは 'これは  例です。' となります。
 ]]>
     </programlisting>


### PR DESCRIPTION
I found a missing part of the description and have corrected it.

足りない記述があったので追記しました。