### PR TITLE
🔧 fix: typo in array (これはは、→これは、)

### DIFF
--- a/language/types/array.xml
+++ b/language/types/array.xml
@@ -1242,7 +1242,7 @@ $a = array( 'color' => 'red',
 
 $b = array('a', 'b', 'c');
 
-// は、完全にこれと同じです。
+// 完全にこれと同じです。
 $a = array();
 $a['color'] = 'red';
 $a['taste'] = 'sweet';


### PR DESCRIPTION
I have found the typo and have corrected it.

タイポを見つけたので修正しました。