### PR TITLE
🔧 add: language specification in code block

### DIFF
--- a/language/variables.xml
+++ b/language/variables.xml
@@ -49,6 +49,7 @@
     <informalexample>
      <programlisting role="php"> 
 <![CDATA[
+<?php
 $var = 'Bob';
 $Var = 'Joe';
 echo "$var, $Var";      // "Bob, Joe"を出力します。
@@ -56,6 +57,7 @@ echo "$var, $Var";      // "Bob, Joe"を出力します。
 $4site = 'not yet';     // 無効：数字で始まっている。
 $_4site = 'not yet';    // 有効：アンダースコアで始まっている。
 $tayte = 'mansikka';    // 有効：'a' はアスキーコード228です。
+?>
 ]]>
      </programlisting>
     </informalexample>


### PR DESCRIPTION
I have added the language designation to the code block.

コードブロックに言語の指定がなかったので、追記しました。