### PR TITLE
🔧 add: role="php"

### DIFF
--- a/language/variables.xml
+++ b/language/variables.xml
@@ -870,7 +870,7 @@ echo $_REQUEST['username'];
     <para>
      <example>
       <title>より複雑なフォーム変数</title>
-      <programlisting>
+      <programlisting role="php">
 <![CDATA[
 <?php
 if ($_POST) {


### PR DESCRIPTION
コードブロックに言語の指定がなかったので追記しました。

英語版にも`role="php"`が付与されています。

https://github.com/php/doc-en/blob/8d9f64a25665cde23e1ebeea0ef0c58cc7cb408a/language/variables.xml#L875