### PR TITLE
fix: typo (のの → の)

### DIFF
--- a/appendices/configure/php.xml
+++ b/appendices/configure/php.xml
@@ -55,7 +55,7 @@
     <listitem>
      <para>
       Zend Thread Safety を有効にします。
-      PHP 8.0.0 より前ののバージョン、かつ Windows 以外のシステムでは、
+      PHP 8.0.0 より前のバージョン、かつ Windows 以外のシステムでは、
       このオプションは
       <option role="configure">--enable-maintainer-zts</option>
       と呼ばれていました。

--- a/appendices/migration71/incompatible.xml
+++ b/appendices/migration71/incompatible.xml
@@ -410,7 +410,7 @@ new DateTime() == new DateTime();
   <para>
    Date 拡張モジュールでは、
    <classname>DateTime</classname> または <classname>DatePeriod</classname>
-   クラス ののシリアライズデータが不正だったり、
+   クラス のシリアライズデータが不正だったり、
    シリアライズ化したデータからタイムゾーンを初期化するのに失敗した場合、
    致命的なエラーにならず、
    <methodname>__wakeup</methodname> や <methodname>__set_state</methodname>


### PR DESCRIPTION
I have found the typo and have corrected it.

タイポを見つけたので修正しました。