### PR TITLE
fix: typo (シリアライズ化→ シリアライズ) 

### DIFF
--- a/appendices/migration71/incompatible.xml
+++ b/appendices/migration71/incompatible.xml
@@ -411,7 +411,7 @@ new DateTime() == new DateTime();
    Date 拡張モジュールでは、
    <classname>DateTime</classname> または <classname>DatePeriod</classname>
    クラス のシリアライズデータが不正だったり、
-   シリアライズ化したデータからタイムゾーンを初期化するのに失敗した場合、
+   シリアライズしたデータからタイムゾーンを初期化するのに失敗した場合、
    致命的なエラーにならず、
    <methodname>__wakeup</methodname> や <methodname>__set_state</methodname>
    メソッドから <classname>Error</classname> 例外をスローするようになりました。

--- a/appendices/migration71/incompatible.xml
+++ b/appendices/migration71/incompatible.xml
@@ -411,7 +411,7 @@ new DateTime() == new DateTime();
    Date 拡張モジュールでは、
    <classname>DateTime</classname> または <classname>DatePeriod</classname>
    クラス ののシリアライズデータが不正だったり、
-   シリアライズ化したデータからタイムゾーンを初期化するのに失敗した場合、
+   シリアライズしたデータからタイムゾーンを初期化するのに失敗した場合、
    致命的なエラーにならず、
    <methodname>__wakeup</methodname> や <methodname>__set_state</methodname>
    メソッドから <classname>Error</classname> 例外をスローするようになりました。

--- a/language/predefined/weakreference.xml
+++ b/language/predefined/weakreference.xml
@@ -16,7 +16,7 @@
     この機能は、キャッシュのようなデータ構造を実装するのに役立ちます。
    </para>
    <para>
-    <classname>WeakReference</classname> クラスはシリアライズ化できません。
+    <classname>WeakReference</classname> クラスはシリアライズできません。
    </para>
   </section>
 <!-- }}} -->

--- a/reference/phar/fileformat.xml
+++ b/reference/phar/fileformat.xml
@@ -299,7 +299,7 @@ __HALT_COMPILER();
     </row>
     <row>
      <entry>??</entry>
-     <entry>シリアライズ化された Phar メタデータ。<function>serialize</function> 形式で格納される。</entry>
+     <entry>シリアライズされた Phar メタデータ。<function>serialize</function> 形式で格納される。</entry>
     </row>
     <row>
      <entry>最低でも 24 * エントリ数ぶんのバイト</entry>

--- a/reference/var/functions/is-object.xml
+++ b/reference/var/functions/is-object.xml
@@ -59,7 +59,7 @@
        <entry>7.2.0</entry>
        <entry>
         クラス定義が存在せず (<classname>__PHP_Incomplete_Class</classname> クラス)、
-        かつシリアライズ化されていないオブジェクトに対して、
+        かつシリアライズされていないオブジェクトに対して、
         <function>is_object</function> 関数は &true; を返すようになりました。
         これより前のバージョンでは、&false; を返していました。
        </entry>


### PR DESCRIPTION
個人的に、「シリアライズ化」という単語に違和感があったので修正させていただきました。

`README_Glossary.md`にも、「シリアライズ / シリアル化」と記述されていました。

![image](https://github.com/php/doc-ja/assets/44424270/b2ce1721-0c4b-40fd-a682-a28b43bf2645)

シリアル化ではなくシリアライズを選択した理由は、こちらの方が英語の発音に近いためです。

ご検討ください🙇