### PR TITLE
fix: normalize Javascript to JavaScript

### DIFF
--- a/chapters/tutorial.xml
+++ b/chapters/tutorial.xml
@@ -425,7 +425,7 @@ if (strpos($_SERVER['HTTP_USER_AGENT'], 'Firefox') !== false) {
     <function>htmlspecialchars</function> および
     <literal>(int)</literal> の部分以外は、何を行っているかは明らかでしょう。
     <function>htmlspecialchars</function> は、html での特殊な文字を適切にエンコードし、
-    HTML タグや Javascript をページ内に仕込めないようにします。
+    HTML タグや JavaScript をページ内に仕込めないようにします。
     また、age フィールドには数値が入ることがわかっているので、これを
     <type>int</type> 型に <link linkend="language.types.typecasting">変換</link> 
     します。これにより、おかしな文字が入力されることを防ぎます。

--- a/faq/html.xml
+++ b/faq/html.xml
@@ -284,25 +284,25 @@ variable = document.forms[0].elements['var[]'];
    <qandaentry xml:id="faq.html.javascript-variable">
     <question>
      <para>
-      Javascript から PHP に変数を渡すには?
+      JavaScript から PHP に変数を渡すには?
      </para>
     </question>
     <answer>
      <para>
-      Javascript は（普通は）クライアントサイド技術であり、一方 PHP は（普通は）
+      JavaScript は（普通は）クライアントサイド技術であり、一方 PHP は（普通は）
       サーバーサイド技術です。また HTTP は"ステートレスな"プロトコルです。
       そのため、この二つの言語はダイレクトに変数を共有することができません。
      </para>
      <para>
       しかしながら、この二つの言語の間で変数を渡すことは可能です。
-      一つの方法は PHP と一緒に Javascript のコードを生成し、
+      一つの方法は PHP と一緒に JavaScript のコードを生成し、
       ブラウザに自動的にリフレッシュ（再ロード）させることです。
       以下の例はまさにそれで、PHP に画面の高さと幅を認識させています。
       これは通常はクライアントサイドでしかできないことです。
      </para>
      <para>
       <example>
-       <title>PHP による Javascript の生成</title>
+       <title>PHP による JavaScript の生成</title>
        <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/v8js/book.xml
+++ b/reference/v8js/book.xml
@@ -4,13 +4,13 @@
 
 <book xml:id="book.v8js" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <?phpdoc extension-membership="pecl" ?>
- <title>V8 Javascript Engine 統合</title>
+ <title>V8 JavaScript Engine 統合</title>
  <titleabbrev>V8js</titleabbrev>
 
  <preface xml:id="intro.v8js">
   &reftitle.intro;
   <para>
-   この拡張モジュールは、<link xlink:href="&url.v8engine;">V8 Javascript Engine</link> を PHP に組み込みます。
+   この拡張モジュールは、<link xlink:href="&url.v8engine;">V8 JavaScript Engine</link> を PHP に組み込みます。
   </para>
  </preface>
 

--- a/reference/v8js/examples.xml
+++ b/reference/v8js/examples.xml
@@ -8,7 +8,7 @@
   基本的な使用例
  </para>
  <example>
-  <title>基本的な Javascript の実行</title>
+  <title>基本的な JavaScript の実行</title>
   <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/v8js/v8js.xml
+++ b/reference/v8js/v8js.xml
@@ -75,7 +75,7 @@
     <varlistentry xml:id="v8js.constants.v8-version">
      <term><constant>V8Js::V8_VERSION</constant></term>
      <listitem>
-      <para>V8 Javascript Engine のバージョン。</para>
+      <para>V8 JavaScript Engine のバージョン。</para>
      </listitem>
     </varlistentry>
 

--- a/reference/v8js/v8js/construct.xml
+++ b/reference/v8js/v8js/construct.xml
@@ -30,7 +30,7 @@
     <term><parameter>object_name</parameter></term>
     <listitem>
      <para>
-      Javascript に渡すオブジェクトの名前。
+      JavaScript に渡すオブジェクトの名前。
      </para>
     </listitem>
    </varlistentry>
@@ -38,7 +38,7 @@
     <term><parameter>variables</parameter></term>
     <listitem>
      <para>
-      Javascript の中で使う PHP の変数のマップ。
+      JavaScript の中で使う PHP の変数のマップ。
       <literal>array("js で使うときの名前" =&gt; "php の変数名")</literal>
       形式の連想配列でなければなりません。デフォルトは空の配列です。
      </para> 
@@ -49,7 +49,7 @@
     <listitem>
      <para>
       <function>V8Js::registerExtension</function> で登録した拡張の一覧。
-      作成した <classname>V8Js</classname> オブジェクトの Javascript コンテキストで利用可能なものでなければなりません。
+      作成した <classname>V8Js</classname> オブジェクトの JavaScript コンテキストで利用可能なものでなければなりません。
       <note>
        <para>
         自動的に有効にするように登録した拡張については、この配列で指定する必要はありません。
@@ -63,7 +63,7 @@
     <term><parameter>report_uncaught_exceptions</parameter></term>
     <listitem>
      <para>
-      キャッチできなかった Javascript の例外をその場ですぐに報告するかどうかを制御します。
+      キャッチできなかった JavaScript の例外をその場ですぐに報告するかどうかを制御します。
       デフォルトは &true; です。&false; にしたときは、キャッチできなかった例外へのアクセスには
       <function>V8Js::getPendingException</function> を使います。
      </para>

--- a/reference/v8js/v8js/executestring.xml
+++ b/reference/v8js/v8js/executestring.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="v8js.executestring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>V8Js::executeString</refname>
-  <refpurpose>文字列を Javascript のコードとして実行する</refpurpose>
+  <refpurpose>文字列を JavaScript のコードとして実行する</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -17,7 +17,7 @@
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer><constant>V8Js::FLAG_NONE</constant></initializer></methodparam>
   </methodsynopsis>
   <para>
-   <parameter>script</parameter> で渡した文字列を Javascript のコードとしてコンパイルし、実行します。
+   <parameter>script</parameter> で渡した文字列を JavaScript のコードとしてコンパイルし、実行します。
   </para>
  </refsect1>
 
@@ -69,7 +69,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Javascript のコード内で最後に生成された変数の値を PHP の変数の型に変換して返します。
+   JavaScript のコード内で最後に生成された変数の値を PHP の変数の型に変換して返します。
   </para>
  </refsect1>
 </refentry>

--- a/reference/v8js/v8js/getextensions.xml
+++ b/reference/v8js/v8js/getextensions.xml
@@ -15,7 +15,7 @@
    <void />
   </methodsynopsis>
   <para>
-   この関数は、<function>V8Js::registerExtension</function> で登録された Javascript 拡張の配列を返します。
+   この関数は、<function>V8Js::registerExtension</function> で登録された JavaScript 拡張の配列を返します。
   </para>
  </refsect1>
 

--- a/reference/v8js/v8js/getpendingexception.xml
+++ b/reference/v8js/v8js/getpendingexception.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="v8js.getpendingexception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>V8Js::getPendingException</refname>
-  <refpurpose>キャッチされなかった Javascript 例外の中で未処理のものを返す</refpurpose>
+  <refpurpose>キャッチされなかった JavaScript 例外の中で未処理のものを返す</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,7 +15,7 @@
    <void />
   </methodsynopsis>
   <para>
-   <function>V8Js::executeString</function> をコールしたときに発生した Javascript の例外の中で未処理のものを
+   <function>V8Js::executeString</function> をコールしたときに発生した JavaScript の例外の中で未処理のものを
    <classname>V8JsException</classname> で返します。
   </para>
  </refsect1>

--- a/reference/v8js/v8js/registerextension.xml
+++ b/reference/v8js/v8js/registerextension.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="v8js.registerextension" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>V8Js::registerExtension</refname>
-  <refpurpose>V8Js で使う Javascript の拡張を登録する</refpurpose>
+  <refpurpose>V8Js で使う JavaScript の拡張を登録する</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -18,7 +18,7 @@
    <methodparam choice="opt"><type>bool</type><parameter>auto_enable</parameter><initializer>&false;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   渡された Javascript <parameter>script</parameter> を
+   渡された JavaScript <parameter>script</parameter> を
    <classname>V8Js</classname> コンテキストで利用する拡張として登録します。
   </para>
  </refsect1>
@@ -38,7 +38,7 @@
     <term><parameter>script</parameter></term>
     <listitem>
      <para>
-      登録する Javascript コード。
+      登録する JavaScript コード。
      </para>
     </listitem>
    </varlistentry>

--- a/reference/yaf/yaf_request_http/isxmlhttprequest.xml
+++ b/reference/yaf/yaf_request_http/isxmlhttprequest.xml
@@ -19,7 +19,7 @@
     <note>
      <para>
       このメソッドはリクエストヘッダーの HTTP_X_REQUESTED_WITH を見て判断しますが、
-      Javascript ライブラリの中には、Ajax リクエストの際にこのヘッダーをセットしないものがあります。
+      JavaScript ライブラリの中には、Ajax リクエストの際にこのヘッダーをセットしないものがあります。
      </para>
     </note>
   </para>


### PR DESCRIPTION
以下の通り用語を統一しました。

`Javascript` -> `JavaScript`