### PR TITLE
rangeの引数はintだけでなくfloat, stringも受け取るため、rangeは整数の範囲を返すとは限らない

### DIFF
--- a/reference/array/functions/range.xml
+++ b/reference/array/functions/range.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="function.range" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>range</refname>
-  <refpurpose>ある範囲の整数を有する配列を作成する</refpurpose>
+  <refpurpose>ある範囲の要素を含む配列を作成する</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -16,7 +16,7 @@
    <methodparam choice="opt"><type class="union"><type>int</type><type>float</type></type><parameter>step</parameter><initializer>1</initializer></methodparam>
   </methodsynopsis>
   <para>
-   ある範囲の整数を有する配列を作成します。
+   ある範囲の要素を含む配列を作成します。
   </para>
  </refsect1>
  <refsect1 role="parameters">


### PR DESCRIPTION
英語は range of elements

https://rakus.connpass.com/event/290984/ にてPHP8.3でのrange()の挙動変更を議論していて発見したものです。