### PR TITLE
count() の翻訳を修正

### DIFF
--- a/reference/array/functions/count.xml
+++ b/reference/array/functions/count.xml
@@ -68,8 +68,7 @@
    パラメータが配列でもなく
    <interfacename>Countable</interfacename> インターフェイスを
    実装したオブジェクトでもない場合、<literal>1</literal> が返されていました。
-   <parameter>value</parameter> に含まれる要素の数を返します。
-   ひとつ例外があり、<parameter>value</parameter> が &null; の場合、
+   ただし、<parameter>value</parameter> が &null; の場合、
    <literal>0</literal> が返されていました。
   </para>
  </refsect1>


### PR DESCRIPTION
いつも翻訳ありがとうございます。

[原文](https://github.com/php/doc-en/blob/master/reference/array/functions/count.xml)が
```xml
<para>
   Returns the number of elements in <parameter>value</parameter>.
   Prior to PHP 8.0.0, if the parameter was neither an &array; nor an &object; that
   implements the <interfacename>Countable</interfacename> interface,
   <literal>1</literal> would be returned,
   unless <parameter>value</parameter> was &null;, in which case
   <literal>0</literal> would be returned.
</para>
```

なので不必要な一文を削除しました。
おまけで「ひとつ例外があり、」も「ただし、」に変えました。

## 関連しそうなコミット
https://github.com/php/doc-en/commit/3ef3e56c80f7ae6b6a7291b7eb57dc6250b50801
https://github.com/php/doc-ja/commit/d67e39ad7ad8131ca32cbc23fc0a98caa0c54d2a