### PR TITLE
Fix typo

### DIFF
--- a/reference/url/functions/parse-url.xml
+++ b/reference/url/functions/parse-url.xml
@@ -140,7 +140,7 @@ http://example.com/foo?# → query = "",   fragment = ""
    </informalexample>
   </para>
   <para>
-    8.1.0 より前のバージョンでは、上記の場合は query も fragment も共に
+    8.0.0 より前のバージョンでは、上記の場合は query も fragment も共に
     &null; になっていました。
   </para>
   <para>


### PR DESCRIPTION
同じページの変更履歴にもある通り、`parse_url`に変更が入ったのは8.0.0です。
https://3v4l.org/c6SA0