### PR TITLE
Fix typo in datetime construct document

### DIFF
--- a/reference/datetime/datetime/construct.xml
+++ b/reference/datetime/datetime/construct.xml
@@ -77,7 +77,7 @@
     無効な日付/時刻の文字列が渡された場合、
     <exceptionname>DateMalformedStringException</exceptionname> がスローされます。
     PHP 8.3 より前のバージョンでは、
-    <exceptionname>Еxception</exceptionname> がスローされていました。
+    <exceptionname>Exception</exceptionname> がスローされていました。
   </para>
  </refsect1>
 

--- a/reference/datetime/datetimeimmutable/construct.xml
+++ b/reference/datetime/datetimeimmutable/construct.xml
@@ -82,7 +82,7 @@
    無効な日付/時刻の文字列が渡された場合、
    <exceptionname>DateMalformedStringException</exceptionname> がスローされます。
    PHP 8.3 より前のバージョンでは、
-   <exceptionname>Еxception</exceptionname> がスローされていました。
+   <exceptionname>Exception</exceptionname> がスローされていました。
   </para>
  </refsect1>
 


### PR DESCRIPTION
`DateTime` と `DateTimeImmutable` のコンストラクタの説明中に現れる `Exception` の E がマルチバイト文字だったのを修正しました。