### PR TITLE
fix(pdo): In line with the latest specifications

### DIFF
--- a/reference/pdo/pdo/lastinsertid.xml
+++ b/reference/pdo/pdo/lastinsertid.xml
@@ -21,7 +21,7 @@
    あるいはシーケンスオブジェクトから次の値をを返します。
    これは、構成しているドライバに依存します。例えば
    <link linkend="ref.pdo-pgsql">PDO_PGSQL</link> の場合、<parameter>name</parameter>
-   パラメータにシーケンスオブジェクト名を指定する必要があります。
+   パラメータにシーケンスオブジェクト名を指定することができます。
   </para>
   <note>
    <para>


### PR DESCRIPTION
PostgreSQL から `PDO::lastInsertId()` を使用する場合の古い説明を修正しました。

https://github.com/php/doc-en/pull/2986 でマージされた修正への日本語版への反映です。