### PR TITLE
fix(var): unification of writing style in intval doc

### DIFF
--- a/reference/var/functions/intval.xml
+++ b/reference/var/functions/intval.xml
@@ -58,8 +58,7 @@
          </listitem>
          <listitem>
           <simpara>
-           そうではなく、文字列の先頭が "0" の場合は、基数を 8 (八進数) とします。
-           otherwise,
+           文字列の先頭が "0" の場合は、基数を 8 (八進数) とします。
           </simpara>
          </listitem>
          <listitem>


### PR DESCRIPTION
不要な `otherwise,` を削除しました。
また後から追加された二進数の記述に合わせて `そうではなく、` という記述も削除しました。