### PR TITLE
Fix description of debug_backtrace()'s parameters

### DIFF
--- a/reference/errorfunc/functions/debug-backtrace.xml
+++ b/reference/errorfunc/functions/debug-backtrace.xml
@@ -77,7 +77,6 @@
             <row>
              <entry><code>debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS)</code></entry>
              <entry morerows="1" valign="middle">
-              Omits index <literal>"object"</literal> <emphasis>and</emphasis> index <literal>"args"</literal>.
               インデックス <literal>"object"</literal> と <literal>"args"</literal> を <emphasis>両方</emphasis>省略します。
              </entry>
             </row>
@@ -87,7 +86,7 @@
             <row>
              <entry><code>debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT|DEBUG_BACKTRACE_IGNORE_ARGS)</code></entry>
              <entry morerows="1" valign="middle">
-              インデックス <literal>"object"</literal> と <literal>"args"</literal> を <emphasis>両方</emphasis>収集します。
+              インデックス <literal>"object"</literal> を収集し、<literal>"args"</literal> を省略します。
              </entry>
             </row>
             <row>


### PR DESCRIPTION
# 概要

`debug_backtrace()` における `$options` パラメータについての説明を修正しました。

# 発生している問題

現在のテキストには 2点の問題があります。

## 余計な文章

**英語**:
> Omits index "object" and index "args".

**日本語**:
> Omits index "object" and index "args". インデックス "object" と "args" を 両方省略します。

日本語版に英語版の文章が残ってしまっています。

## 誤った説明

**英語**:
> Populate index "object" and omit index "args".

**日本語**:
> インデックス "object" と "args" を 両方収集します。

"args" は "omit" なので、収集されません。

# 変更内容

上記の問題について、以下のように変更しました。

## 余計な文章

削除しました。

## 誤った説明

修正対象のテキストに対して「収集」・「省略」がちょうど逆になっている以下のテキストがすでに存在していました。

> Omits index "object" and populates index "args".

> インデックス "object" を省略し、"args" を収集します。

この翻訳の文構造をそのまま使って、「収集」・「省略」を入れ替えた文章を作り、誤った説明を書き換えました。