### PR TITLE
`EXTR_IF_EXISTS`の説明の訳を修正

### DIFF
--- a/reference/array/functions/extract.xml
+++ b/reference/array/functions/extract.xml
@@ -105,7 +105,7 @@
          <listitem>
           <simpara>
            現在のシンボルテーブルに既に存在する場合にのみ上書きします。
-           例えば <varname>$_REQUEST</varname> 以外にあなたが定義した変数のみを展開し
+           例えば <varname>$_REQUEST</varname> からあなたが定義した変数のみを展開し
            有効な変数としたいような場合に有用です。
           </simpara>
          </listitem>


### PR DESCRIPTION
[原文](https://www.php.net/manual/en/function.extract.php):
> This is useful for defining a list of valid variables and then extracting only those variables you have defined out of $_REQUEST, for example.

元の訳は out of の意味を取り違えているように見えます。