### PR TITLE
Convert curl-getinfo() constant list to table

### DIFF
--- a/reference/curl/functions/curl-getinfo.xml
+++ b/reference/curl/functions/curl-getinfo.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: f3d1cec9e549e5ac7bfbb076295537668ceb0e4a Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 8b3f89ed6171cb711b00afb0fcacbea3462537b9 Maintainer: haszi Status: ready -->
+<!-- Reviewed: no -->
 <!-- CREDITS: takagi,mumumu -->
 <refentry xml:id="function.curl-getinfo" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/curl/functions/curl-getinfo.xml
+++ b/reference/curl/functions/curl-getinfo.xml
@@ -7,7 +7,7 @@
   <refname>curl_getinfo</refname>
   <refpurpose>指定した伝送に関する情報を得る</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
@@ -30,357 +30,433 @@
      <listitem>
       <para>
        これは、以下のいずれかの定数となります。
-       <itemizedlist>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CAINFO</constant> - デフォルトの組み込みCA証明書のパス
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CAPATH</constant> - デフォルトの組み込みCAのパスの文字列
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_EFFECTIVE_URL</constant> - 直近の有効な URL
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_HTTP_CODE</constant> - 最後に受け取った HTTP コード。cURL 7.10.8 以降では　<constant>CURLINFO_RESPONSE_CODE</constant>　の別名になりました。
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_FILETIME</constant> - ドキュメントを取得するのにかかった時間。
-          <constant>CURLOPT_FILETIME</constant> が有効な状態で用いる。
-          取得できなかった場合は -1
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_TOTAL_TIME</constant> - 直近の伝送にかかった秒数
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_NAMELOOKUP_TIME</constant> - 名前解決が完了するまでにかかった秒数
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CONNECT_TIME</constant> - 接続を確立するまでにかかった秒数
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_PRETRANSFER_TIME</constant> - 開始からファイル伝送がはじまるまでにかかった秒数
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_STARTTRANSFER_TIME</constant> - 最初のバイトの伝送がはじまるまでの秒数
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_REDIRECT_COUNT</constant> - リダイレクト処理の回数 (<constant>CURLOPT_FOLLOWLOCATION</constant> オプションが有効な場合)
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_REDIRECT_TIME</constant> - 伝送が始まるまでのリダイレクト処理の秒数 (<constant>CURLOPT_FOLLOWLOCATION</constant> オプションが有効な場合)
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_REDIRECT_URL</constant> - <constant>CURLOPT_FOLLOWLOCATION</constant> オプションが無効な場合:
-          直近のトランザクションで見つかったリダイレクト先 URL。これを、次に手動でリクエストしなければいけません。
-          <constant>CURLOPT_FOLLOWLOCATION</constant> オプションが有効な場合: これは空になります。
-          この場合のリダイレクト先 URL は、<constant>CURLINFO_EFFECTIVE_URL</constant> となります。
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_PRIMARY_IP</constant> - 直近の接続の IP アドレス
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_PRIMARY_PORT</constant> - 直近の接続の接続先ポート
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_LOCAL_IP</constant> - 直近の接続の接続元 IP アドレス
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_LOCAL_PORT</constant> - 直近の接続の接続元ポート
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SIZE_UPLOAD</constant> - アップロードされたバイト数
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SIZE_DOWNLOAD</constant> - ダウンロードされたバイト数
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SPEED_DOWNLOAD</constant> - 平均のダウンロード速度
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SPEED_UPLOAD</constant> - 平均のアップロード速度
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_HEADER_SIZE</constant> - 受信したヘッダのサイズ
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_HEADER_OUT</constant> - 送信したリクエスト文字列。
-          これを動作させるには、<function>curl_setopt</function> をコールする際に
-          <constant>CURLINFO_HEADER_OUT</constant> オプションを使うようにしておく必要があります。
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_REFERER</constant> - リファラヘッダ
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_REQUEST_SIZE</constant> - 発行されたリクエストのサイズ。現在は
-          HTTP リクエストの場合のみ
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_RETRY_AFTER</constant> - <literal>Retry-After:</literal> ヘッダから得られる情報。有効なヘッダがない場合はゼロ。
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SSL_VERIFYRESULT</constant> - <constant>CURLOPT_SSL_VERIFYPEER</constant>
-          を設定した際に要求される SSL 証明書の認証結果
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CONTENT_LENGTH_DOWNLOAD</constant> - ダウンロードされるサイズ。
-          <literal>Content-Length:</literal> フィールドの内容を取得する
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CONTENT_LENGTH_UPLOAD</constant> - アップロードされるサイズ。
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          直近の転送が <constant>CURLE_PROXY</constant>
-          を返したときの (SOCKS) プロキシの詳細なエラーコード。
-          返される値は、
-          <constant>CURLPX_<replaceable>*</replaceable></constant>
-          のうちのひとつです。
-          レスポンスコードが利用できない場合、
-          エラーコードは <constant>CURLPX_OK</constant> になります。
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CONTENT_TYPE</constant> - 要求されたドキュメントの
-          <literal>Content-Type:</literal> ヘッダ。
-          NULL の場合は、サーバーが適切な <literal>Content-Type:</literal> ヘッダを返さなかったことを示す。
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_PRIVATE</constant> - この cURL ハンドルに関連づけられたプライベートデータ。
-          事前に <function>curl_setopt</function> の <constant>CURLOPT_PRIVATE</constant> オプションで設定したもの。
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_RESPONSE_CODE</constant> - 直近のレスポンスコード。
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_HTTP_CONNECTCODE</constant> - CONNECT のレスポンスコード。
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_HTTPAUTH_AVAIL</constant> - 直前のレスポンスから判断する、利用可能な認証方式のビットマスク。
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_PROXYAUTH_AVAIL</constant> - 直前のレスポンスから判断する、プロキシ認証方式のビットマスク。
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_OS_ERRNO</constant> - 接続に失敗したときのエラー番号。OS やシステムによって異なります。
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_NUM_CONNECTS</constant> - curl が直前の転送を実行するために要した接続数。
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SSL_ENGINES</constant> - サポートする OpenSSL 暗号エンジン。
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_COOKIELIST</constant> - すべての既知のクッキー。
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_FTP_ENTRY_PATH</constant> - FTP サーバーのエントリパス。
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_APPCONNECT_TIME</constant> - リモートホストとの SSL/SSH 接続／ハンドシェイク が完了するまでに要した秒数。
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CERTINFO</constant> - TLS 証明書チェイン。
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CONDITION_UNMET</constant> - 時間の条件が満たされなかったことに関する情報。
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_RTSP_CLIENT_CSEQ</constant> - 次の RTSP クライアントの CSeq。
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_RTSP_CSEQ_RECV</constant> - 直前に受け取った CSeq。
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_RTSP_SERVER_CSEQ</constant> - 次の RTSP サーバーの CSeq。
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_RTSP_SESSION_ID</constant> - RTSP セッション ID。
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CONTENT_LENGTH_DOWNLOAD_T</constant> - ダウンロードの content-length の値。これは <literal>Content-Length:</literal> フィールドから読み取った値です。-1 はサイズが不明であることを示します。
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CONTENT_LENGTH_UPLOAD_T</constant> - 指定されたアップロードのサイズ。-1 はサイズが不明であることを示します。
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_HTTP_VERSION</constant> - 直近のHTTP接続で使われたバージョン。返される値は、<constant>CURL_HTTP_VERSION_*</constant> で定義されたうちのひとつです。バージョンが特定できない場合は、0 が返されます。
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_PROTOCOL</constant> - 直近のHTTP接続で使われたプロトコル。返される値は、<constant>CURLPROTO_*</constant> で定義されたうちのひとつです。
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_PROXY_SSL_VERIFYRESULT</constant> - (<constant>CURLOPT_PROXY_SSL_VERIFYPEER</constant> オプションを使って) リクエストされた証明書の検証結果です。 HTTPS プロキシを使った場合にのみ有効です。
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SCHEME</constant> - 直近の接続で使われたURLスキーム
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SIZE_DOWNLOAD_T</constant> - ダウンロードした合計のバイト数。この数値は直近の転送のみの値です。新しい転送が行われるたびにリセットされます。
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SIZE_UPLOAD_T</constant> - アップロードされた合計サイズ(バイト単位)
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SPEED_DOWNLOAD_T</constant> - ダウンロードが完了した際にcurlが計測した、平均ダウンロード速度(バイト/毎秒)
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SPEED_UPLOAD_T</constant> - アップロードが完了した際にcurlが計測した、平均アップロード速度(バイト/毎秒)
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_APPCONNECT_TIME_T</constant> - リモートホストと SSL/SSH の接続/ハンドシェイクを開始してから完了するまでにかかった時間 (マイクロ秒)
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CONNECT_TIME_T</constant> - リモートホスト(またはプロキシ) と接続を開始して、完了するまでにかかった合計時間(マイクロ秒)
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_FILETIME_T</constant> - 文書を取得したリモートの時間(Unixタイムスタンプ)。これは <constant>CURLINFO_FILETIME</constant> の代替であり、32ビットのタイムスタンプの範囲から外れた日付を32ビットのシステムで変数に展開することができます。
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_NAMELOOKUP_TIME_T</constant> - 名前解決が完了するまでにかかった時間(マイクロ秒)
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_PRETRANSFER_TIME_T</constant> - ファイルの転送が始まるまでにかかった時間(マイクロ秒)
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_REDIRECT_TIME_T</constant> - リダイレクトのステップ全てにかかった合計時間(マイクロ秒)。これには、名前解決や接続、事前の転送や最後のトランザクションが開始されるまでの転送処理を含みます。
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_STARTTRANSFER_TIME_T</constant> - 最初のバイトを受信するまでにかかった時間(マイクロ秒)
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_TOTAL_TIME_T</constant> - 名前解決, TCP 接続などを含む、以前の転送にかかった合計時間(マイクロ秒)
-         </simpara>
-        </listitem>
-       </itemizedlist>
+       <informaltable>
+        <tgroup cols="2">
+         <thead>
+          <row>
+           <entry valign="top">Option</entry>
+           <entry valign="top">&Description;</entry>
+          </row>
+         </thead>
+         <tbody>
+          <row>
+           <entry><constant>CURLINFO_CAINFO</constant></entry>
+           <entry>
+            デフォルトの組み込みCA証明書のパス
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_CAPATH</constant></entry>
+           <entry>
+            デフォルトの組み込みCAのパスの文字列
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_EFFECTIVE_URL</constant></entry>
+           <entry>
+            直近の有効な URL
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_HTTP_CODE</constant></entry>
+           <entry>
+            最後に受け取った HTTP コード。cURL 7.10.8 以降では　<constant>CURLINFO_RESPONSE_CODE</constant>　の別名になりました。
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_FILETIME</constant></entry>
+           <entry>
+            ドキュメントを取得するのにかかった時間。
+            <constant>CURLOPT_FILETIME</constant> が有効な状態で用いる。
+            取得できなかった場合は -1
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_TOTAL_TIME</constant></entry>
+           <entry>
+            直近の伝送にかかった秒数
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_NAMELOOKUP_TIME</constant></entry>
+           <entry>
+            名前解決が完了するまでにかかった秒数
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_CONNECT_TIME</constant></entry>
+           <entry>
+            接続を確立するまでにかかった秒数
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_PRETRANSFER_TIME</constant></entry>
+           <entry>
+            開始からファイル伝送がはじまるまでにかかった秒数
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_STARTTRANSFER_TIME</constant></entry>
+           <entry>
+            最初のバイトの伝送がはじまるまでの秒数
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_REDIRECT_COUNT</constant></entry>
+           <entry>
+            リダイレクト処理の回数 (<constant>CURLOPT_FOLLOWLOCATION</constant> オプションが有効な場合)
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_REDIRECT_TIME</constant></entry>
+           <entry>
+            伝送が始まるまでのリダイレクト処理の秒数 (<constant>CURLOPT_FOLLOWLOCATION</constant> オプションが有効な場合)
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_REDIRECT_URL</constant></entry>
+           <entry>
+            <constant>CURLOPT_FOLLOWLOCATION</constant> オプションが無効な場合:
+            直近のトランザクションで見つかったリダイレクト先 URL。これを、次に手動でリクエストしなければいけません。
+            <constant>CURLOPT_FOLLOWLOCATION</constant> オプションが有効な場合: これは空になります。
+            この場合のリダイレクト先 URL は、<constant>CURLINFO_EFFECTIVE_URL</constant> となります。
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_PRIMARY_IP</constant></entry>
+           <entry>
+            直近の接続の IP アドレス
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_PRIMARY_PORT</constant></entry>
+           <entry>
+            直近の接続の接続先ポート
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_LOCAL_IP</constant></entry>
+           <entry>
+            直近の接続の接続元 IP アドレス
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_LOCAL_PORT</constant></entry>
+           <entry>
+            直近の接続の接続元ポート
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_SIZE_UPLOAD</constant></entry>
+           <entry>
+            アップロードされたバイト数
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_SIZE_DOWNLOAD</constant></entry>
+           <entry>
+            ダウンロードされたバイト数
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_SPEED_DOWNLOAD</constant></entry>
+           <entry>
+            平均のダウンロード速度
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_SPEED_UPLOAD</constant></entry>
+           <entry>
+            平均のアップロード速度
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_HEADER_SIZE</constant></entry>
+           <entry>
+            受信したヘッダのサイズ
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_HEADER_OUT</constant></entry>
+           <entry>
+            送信したリクエスト文字列。
+            これを動作させるには、<function>curl_setopt</function> をコールする際に
+            <constant>CURLINFO_HEADER_OUT</constant> オプションを使うようにしておく必要があります。
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_REFERER</constant></entry>
+           <entry>
+            リファラヘッダ
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_REQUEST_SIZE</constant></entry>
+           <entry>
+            発行されたリクエストのサイズ。現在は
+            HTTP リクエストの場合のみ
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_RETRY_AFTER</constant></entry>
+           <entry>
+            <literal>Retry-After:</literal> ヘッダから得られる情報。有効なヘッダがない場合はゼロ。
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_SSL_VERIFYRESULT</constant></entry>
+           <entry>
+            <constant>CURLOPT_SSL_VERIFYPEER</constant>
+            を設定した際に要求される SSL 証明書の認証結果
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_CONTENT_LENGTH_DOWNLOAD</constant></entry>
+           <entry>
+            ダウンロードされるサイズ。
+            <literal>Content-Length:</literal> フィールドの内容を取得する
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_CONTENT_LENGTH_UPLOAD</constant></entry>
+           <entry>
+            アップロードされるサイズ。
+           </entry>
+          </row>
+          <row>
+           <entry valign="top"><constant>CURLINFO_PROXY_ERROR</constant></entry>
+           <entry>
+            直近の転送が <constant>CURLE_PROXY</constant>
+            を返したときの (SOCKS) プロキシの詳細なエラーコード。
+            返される値は、
+            <constant>CURLPX_<replaceable>*</replaceable></constant>
+            のうちのひとつです。
+            レスポンスコードが利用できない場合、
+            エラーコードは <constant>CURLPX_OK</constant> になります。
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_CONTENT_TYPE</constant></entry>
+           <entry>
+            要求されたドキュメントの
+            <literal>Content-Type:</literal> ヘッダ。
+            NULL の場合は、サーバーが適切な <literal>Content-Type:</literal> ヘッダを返さなかったことを示す。
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_PRIVATE</constant></entry>
+           <entry>
+            この cURL ハンドルに関連づけられたプライベートデータ。
+            事前に <function>curl_setopt</function> の <constant>CURLOPT_PRIVATE</constant> オプションで設定したもの。
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_RESPONSE_CODE</constant></entry>
+           <entry>
+            直近のレスポンスコード。
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_HTTP_CONNECTCODE</constant></entry>
+           <entry>
+            CONNECT のレスポンスコード。
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_HTTPAUTH_AVAIL</constant></entry>
+           <entry>
+            直前のレスポンスから判断する、利用可能な認証方式のビットマスク。
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_PROXYAUTH_AVAIL</constant></entry>
+           <entry>
+            直前のレスポンスから判断する、プロキシ認証方式のビットマスク。
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_OS_ERRNO</constant></entry>
+           <entry>
+            接続に失敗したときのエラー番号。OS やシステムによって異なります。
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_NUM_CONNECTS</constant></entry>
+           <entry>
+            curl が直前の転送を実行するために要した接続数。
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_SSL_ENGINES</constant></entry>
+           <entry>
+            サポートする OpenSSL 暗号エンジン。
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_COOKIELIST</constant></entry>
+           <entry>
+            すべての既知のクッキー。
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_FTP_ENTRY_PATH</constant></entry>
+           <entry>
+            FTP サーバーのエントリパス。
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_APPCONNECT_TIME</constant></entry>
+           <entry>
+            リモートホストとの SSL/SSH 接続／ハンドシェイク が完了するまでに要した秒数。
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_CERTINFO</constant></entry>
+           <entry>
+            TLS 証明書チェイン。
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_CONDITION_UNMET</constant></entry>
+           <entry>
+            時間の条件が満たされなかったことに関する情報。
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_RTSP_CLIENT_CSEQ</constant></entry>
+           <entry>
+            次の RTSP クライアントの CSeq。
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_RTSP_CSEQ_RECV</constant></entry>
+           <entry>
+            直前に受け取った CSeq。
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_RTSP_SERVER_CSEQ</constant></entry>
+           <entry>
+            次の RTSP サーバーの CSeq。
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_RTSP_SESSION_ID</constant></entry>
+           <entry>
+            RTSP セッション ID。
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_CONTENT_LENGTH_DOWNLOAD_T</constant></entry>
+           <entry>
+            ダウンロードの content-length の値。これは <literal>Content-Length:</literal> フィールドから読み取った値です。-1 はサイズが不明であることを示します。
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_CONTENT_LENGTH_UPLOAD_T</constant></entry>
+           <entry>
+            指定されたアップロードのサイズ。-1 はサイズが不明であることを示します。
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_HTTP_VERSION</constant></entry>
+           <entry>
+            直近のHTTP接続で使われたバージョン。返される値は、<constant>CURL_HTTP_VERSION_*</constant> で定義されたうちのひとつです。バージョンが特定できない場合は、0 が返されます。
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_PROTOCOL</constant></entry>
+           <entry>
+            直近のHTTP接続で使われたプロトコル。返される値は、<constant>CURLPROTO_*</constant> で定義されたうちのひとつです。
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_PROXY_SSL_VERIFYRESULT</constant></entry>
+           <entry>
+            (<constant>CURLOPT_PROXY_SSL_VERIFYPEER</constant> オプションを使って) リクエストされた証明書の検証結果です。 HTTPS プロキシを使った場合にのみ有効です。
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_SCHEME</constant></entry>
+           <entry>
+            直近の接続で使われたURLスキーム
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_SIZE_DOWNLOAD_T</constant></entry>
+           <entry>
+            ダウンロードした合計のバイト数。この数値は直近の転送のみの値です。新しい転送が行われるたびにリセットされます。
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_SIZE_UPLOAD_T</constant></entry>
+           <entry>
+            アップロードされた合計サイズ(バイト単位)
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_SPEED_DOWNLOAD_T</constant></entry>
+           <entry>
+            ダウンロードが完了した際にcurlが計測した、平均ダウンロード速度(バイト/毎秒)
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_SPEED_UPLOAD_T</constant></entry>
+           <entry>
+            アップロードが完了した際にcurlが計測した、平均アップロード速度(バイト/毎秒)
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_APPCONNECT_TIME_T</constant></entry>
+           <entry>
+            リモートホストと SSL/SSH の接続/ハンドシェイクを開始してから完了するまでにかかった時間 (マイクロ秒)
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_CONNECT_TIME_T</constant></entry>
+           <entry>
+            リモートホスト(またはプロキシ) と接続を開始して、完了するまでにかかった合計時間(マイクロ秒)
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_FILETIME_T</constant></entry>
+           <entry>
+            文書を取得したリモートの時間(Unixタイムスタンプ)。これは <constant>CURLINFO_FILETIME</constant> の代替であり、32ビットのタイムスタンプの範囲から外れた日付を32ビットのシステムで変数に展開することができます。
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_NAMELOOKUP_TIME_T</constant></entry>
+           <entry>
+            名前解決が完了するまでにかかった時間(マイクロ秒)
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_PRETRANSFER_TIME_T</constant></entry>
+           <entry>
+            ファイルの転送が始まるまでにかかった時間(マイクロ秒)
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_REDIRECT_TIME_T</constant></entry>
+           <entry>
+            リダイレクトのステップ全てにかかった合計時間(マイクロ秒)。これには、名前解決や接続、事前の転送や最後のトランザクションが開始されるまでの転送処理を含みます。
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_STARTTRANSFER_TIME_T</constant></entry>
+           <entry>
+            最初のバイトを受信するまでにかかった時間(マイクロ秒)
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_TOTAL_TIME_T</constant></entry>
+           <entry>
+            名前解決, TCP 接続などを含む、以前の転送にかかった合計時間(マイクロ秒)
+           </entry>
+          </row>
+         </tbody>
+        </tgroup>
+       </informaltable>
       </para>
      </listitem>
     </varlistentry>
@@ -576,7 +652,7 @@
        <entry>7.3.0</entry>
        <entry>
         <constant>CURLINFO_CONTENT_LENGTH_DOWNLOAD_T</constant>,
-        <constant>CURLINFO_CONTENT_LENGTH_UPLOAD_T</constant>, 
+        <constant>CURLINFO_CONTENT_LENGTH_UPLOAD_T</constant>,
         <constant>CURLINFO_HTTP_VERSION</constant>,
         <constant>CURLINFO_PROTOCOL</constant>,
         <constant>CURLINFO_PROXY_SSL_VERIFYRESULT</constant>,
@@ -600,7 +676,7 @@
    </informaltable>
   </para>
  </refsect1>
- 
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -658,7 +734,7 @@ curl_close($ch);
    </example>
   </para>
  </refsect1>
- 
+
  <refsect1 role="notes">
   &reftitle.notes;
   <note>

--- a/reference/curl/functions/curl-getinfo.xml
+++ b/reference/curl/functions/curl-getinfo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 8b3f89ed6171cb711b00afb0fcacbea3462537b9 Maintainer: haszi Status: ready -->
+<!-- EN-Revision: 8b3f89ed6171cb711b00afb0fcacbea3462537b9 Maintainer: hirokawa Status: ready -->
 <!-- Reviewed: no -->
 <!-- CREDITS: takagi,mumumu -->
 <refentry xml:id="function.curl-getinfo" xmlns="http://docbook.org/ns/docbook">


### PR DESCRIPTION
This PR converts the constant list for the second (`option`) parameter of `curl_getinfo()` to a table (as it was done in `doc-en` [here](https://github.com/php/doc-en/pull/3130)).