### PR TITLE
関数名の正規表現に不要なピリオドを削除

### DIFF
--- a/language/functions.xml
+++ b/language/functions.xml
@@ -36,7 +36,7 @@ function foo($arg_1, $arg_2, /* ..., */ $arg_n)
     関数名は、PHP の他のラベルと同じ規則に従います。関数名として有効な
     形式は、まず文字かアンダースコアで始まり、その後に任意の数の文字・
     数字・あるいはアンダースコアが続くものです。正規表現で表すと、
-    <code>^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*$</code>.
+    <code>^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*$</code>
     となります。
    </para>
    &tip.userlandnaming;


### PR DESCRIPTION
ユーザー定義関数 https://www.php.net/manual/ja/functions.user-defined.php についてのプルリクエストです。
>正規表現で表すと、 ^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*$. となります。 

とありますが、正規表現で末尾を表す`$`の**直後のピリオドが不要**と思われました。

## 不要と判断した理由

英文：https://www.php.net/manual/en/functions.user-defined.php
>As a regular expression, it would be expressed thus: ^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*$. 

`$`の直後のピリオドは、正規表現の一部ではなく、英文の終わりを示すものと考えています

中国語訳：https://www.php.net/manual/zh/functions.user-defined.php
>可以用正则表达式表示为: ^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*$。 

`$`の後にはピリオドを翻訳した「。」が来ています