### PR TITLE
array_rand() may throw ValueError since 8.0

### DIFF
--- a/reference/array/functions/array-rand.xml
+++ b/reference/array/functions/array-rand.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: fc1e94a9c2e271c7cefd86f28a1cb5bc30a52664 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 4a1dedc24b1e085f298ab1d5dadefe306373691b Maintainer: hirokawa Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="function.array-rand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -79,10 +79,19 @@
       <row>
        <entry>8.0.0</entry>
        <entry>
-        <parameter>array</parameter> が空か <parameter>num</parameter> が範囲外の値の場合に、
+        <parameter>num</parameter> が範囲外の値の場合に、
         <classname>ValueError</classname> がスローされるようになりました。
         これより前のバージョンでは、
-        <constant>E_WARNING</constant> が発生し、&false; を返していました。
+        <constant>E_WARNING</constant> が発生し、&null; を返していました。
+       </entry>
+      </row>
+      <row>
+       <entry>8.0.0</entry>
+       <entry>
+        <parameter>array</parameter> が空の場合に、
+        <classname>ValueError</classname> がスローされるようになりました。
+        これより前のバージョンでは、
+        <constant>E_WARNING</constant> が発生し、&null; を返していました。
        </entry>
       </row>
       <row>

--- a/reference/array/functions/array-rand.xml
+++ b/reference/array/functions/array-rand.xml
@@ -29,6 +29,7 @@
      <listitem>
       <para>
        入力の配列。
+       空配列にはできません。
       </para>
      </listitem>
     </varlistentry>
@@ -37,6 +38,7 @@
      <listitem>
       <para>
        取得するエントリの数を指定します。
+       1以上 <parameter>array</parameter> の要素数以下である必要があります。
       </para>
      </listitem>
     </varlistentry>
@@ -51,10 +53,17 @@
    その他の場合は、ランダムなエントリのキーの配列を返します。
    これにより、ランダムな値だけではなくランダムなキーも配列から取得できるようになります。
    複数のキーが返される場合、配列に格納された順番と同じ順で返されます。
-   配列の中にある要素数より多くの要素を取り出そうとすると
-   <constant>E_WARNING</constant> レベルのエラーが発生し、NULL を返します。
   </para>
  </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   <parameter>array</parameter> が空か <parameter>num</parameter> が範囲外の値の場合に、
+   <classname>ValueError</classname> がスローされます。
+  </para>
+ </refsect1>
+
  <refsect1 role="changelog">
   &reftitle.changelog;
   <para>
@@ -67,6 +76,15 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.0.0</entry>
+       <entry>
+        <parameter>array</parameter> が空か <parameter>num</parameter> が範囲外の値の場合に、
+        <classname>ValueError</classname> がスローされるようになりました。
+        これより前のバージョンでは、
+        <constant>E_WARNING</constant> が発生し、&false; を返していました。
+       </entry>
+      </row>
       <row>
        <entry>7.1.0</entry>
        <entry>


### PR DESCRIPTION
php/doc-en#3230 の日本語版への反映です

~~（doc-en側でマージされ次第Draftを外します）~~ 外しました