### PR TITLE
Update language-snippets.ent

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -4414,7 +4414,7 @@ local: {
       <row>
        <entry><literal>b</literal></entry>
        <entry>
-        引数は整数として扱われ、バイナリ値として表現されます。
+        引数は整数として扱われ、2進数値として表現されます。
        </entry>
       </row>
       <row>


### PR DESCRIPTION
バイナリ値だと理解しにくいため、8進数などとあわせて2進数と表記しました