### PR TITLE
DATETIME系定数の説明の翻訳

### DIFF
--- a/reference/datetime/constants.xml
+++ b/reference/datetime/constants.xml
@@ -56,7 +56,7 @@
    <term><constant>DATE_ATOM</constant></term>
    <listitem>
     <simpara>
-     Atom (example: <literal>2005-08-15T15:52:01+00:00</literal>)
+     Atom (例: <literal>2005-08-15T15:52:01+00:00</literal>)
     </simpara>
    </listitem>
   </varlistentry>
@@ -65,7 +65,7 @@
    <term><constant>DATE_COOKIE</constant></term>
    <listitem>
     <simpara>
-     HTTP Cookies (example: <literal>Monday, 15-Aug-2005 15:52:01 UTC</literal>)
+     HTTP Cookies (例: <literal>Monday, 15-Aug-2005 15:52:01 UTC</literal>)
     </simpara>
    </listitem>
   </varlistentry>
@@ -74,15 +74,16 @@
    <term><constant>DATE_ISO8601</constant></term>
    <listitem>
     <simpara>
-     ISO-8601 (example: <literal>2005-08-15T15:52:01+0000</literal>)
+     ISO-8601 (例: <literal>2005-08-15T15:52:01+0000</literal>)
     </simpara>
     <note>
      <simpara>
-      This format is not compatible with ISO-8601, but is left this way for
-      backward compatibility reasons. Use
+      このフォーマットは、ISO-8601 と互換性がありません。
+      しかし、後方互換性を保つために残されています。
+      ISO-8601 と互換性を保つためには、
       <constant>DATE_ISO8601_EXPANDED</constant>,
-      <constant>DATE_ATOM</constant> for compatibility with ISO-8601
-      instead. (ref ISO8601:2004 section 4.3.3 clause d)
+      <constant>DATE_ATOM</constant> を使うようにしてください。
+      (ISO8601:2004 section 4.3.3 clause d も参照ください)
      </simpara>
     </note>
    </listitem>
@@ -92,14 +93,14 @@
    <term><constant>DATE_ISO8601_EXPANDED</constant></term>
    <listitem>
     <simpara>
-     ISO-8601 Expanded (example: <literal>+10191-07-26T08:59:52+01:00</literal>)
+     ISO-8601 拡張形式 (例: <literal>+10191-07-26T08:59:52+01:00</literal>)
     </simpara>
     <note>
      <simpara>
-      This format allows for year ranges outside of ISO-8601's normal range
-      of <literal>0000</literal>-<literal>9999</literal> by always
-      including a sign character. It also addresses that that timezone part
-      (<literal>+01:00</literal>) is compatible with ISO-8601.
+      年に常に符号を含めることで、ISO-8601 の通常の範囲
+      <literal>0000</literal>-<literal>9999</literal> 以外の値が許されています。
+      タイムゾーンの部分 (<literal>+01:00</literal>) については、
+      ISO-8601 と互換性をとるようにもなっています。
      </simpara>
     </note>
    </listitem>
@@ -109,7 +110,7 @@
    <term><constant>DATE_RFC822</constant></term>
    <listitem>
     <simpara>
-     RFC 822 (example: <literal>Mon, 15 Aug 05 15:52:01 +0000</literal>)
+     RFC 822 (例: <literal>Mon, 15 Aug 05 15:52:01 +0000</literal>)
     </simpara>
    </listitem>
   </varlistentry>
@@ -118,7 +119,7 @@
    <term><constant>DATE_RFC850</constant></term>
    <listitem>
     <simpara>
-     RFC 850 (example: <literal>Monday, 15-Aug-05 15:52:01 UTC</literal>)
+     RFC 850 (例: <literal>Monday, 15-Aug-05 15:52:01 UTC</literal>)
     </simpara>
    </listitem>
   </varlistentry>
@@ -127,7 +128,7 @@
    <term><constant>DATE_RFC1036</constant></term>
    <listitem>
     <simpara>
-     RFC 1036 (example: <literal>Mon, 15 Aug 05 15:52:01 +0000</literal>)
+     RFC 1036 (例: <literal>Mon, 15 Aug 05 15:52:01 +0000</literal>)
     </simpara>
    </listitem>
   </varlistentry>
@@ -136,7 +137,7 @@
    <term><constant>DATE_RFC1123</constant></term>
    <listitem>
     <simpara>
-     RFC 1123 (example: <literal>Mon, 15 Aug 2005 15:52:01 +0000</literal>)
+     RFC 1123 (例: <literal>Mon, 15 Aug 2005 15:52:01 +0000</literal>)
     </simpara>
    </listitem>
   </varlistentry>
@@ -146,7 +147,7 @@
     <listitem>
      <simpara>
       RFC 7231 (as of PHP 7.0.19 and 7.1.5)
-      (example: <literal>Sat, 30 Apr 2016 17:52:13 GMT</literal>)
+      (例: <literal>Sat, 30 Apr 2016 17:52:13 GMT</literal>)
      </simpara>
     </listitem>
   </varlistentry>
@@ -155,7 +156,7 @@
    <term><constant>DATE_RFC2822</constant></term>
    <listitem>
     <simpara>
-     RFC 2822 (example: <literal>Mon, 15 Aug 2005 15:52:01 +0000</literal>)
+     RFC 2822 (例: <literal>Mon, 15 Aug 2005 15:52:01 +0000</literal>)
     </simpara>
    </listitem>
   </varlistentry>
@@ -164,7 +165,7 @@
    <term><constant>DATE_RFC3339</constant></term>
    <listitem>
     <simpara>
-     Same as <constant>DATE_ATOM</constant>.
+     <constant>DATE_ATOM</constant> と同じです
     </simpara>
    </listitem>
   </varlistentry>
@@ -173,8 +174,8 @@
    <term><constant>DATE_RFC3339_EXTENDED</constant></term>
    <listitem>
     <simpara>
-     RFC 3339 EXTENDED format
-     (example: <literal>2005-08-15T15:52:01.000+00:00</literal>)
+     RFC 3339 EXTENDED フォーマット
+     (例: <literal>2005-08-15T15:52:01.000+00:00</literal>)
     </simpara>
    </listitem>
   </varlistentry>
@@ -183,7 +184,7 @@
    <term><constant>DATE_RSS</constant></term>
    <listitem>
     <simpara>
-     RSS (example: <literal>Mon, 15 Aug 2005 15:52:01 +0000</literal>).
+     RSS (例: <literal>Mon, 15 Aug 2005 15:52:01 +0000</literal>).
      &Alias; <constant>DATE_RFC1123</constant>.
     </simpara>
    </listitem>
@@ -193,7 +194,7 @@
    <term><constant>DATE_W3C</constant></term>
    <listitem>
     <simpara>
-     World Wide Web Consortium (example: <literal>2005-08-15T15:52:01+00:00</literal>).
+     World Wide Web Consortium (例: <literal>2005-08-15T15:52:01+00:00</literal>).
      &Alias; <constant>DATE_RFC3339</constant>.
     </simpara>
    </listitem>


### PR DESCRIPTION
DATETIMEの定義済み定数に関して英語の文章が残っている箇所があったので、翻訳した記述をあてています。
翻訳の内容は、同等の説明がある[PHP: DateTimeInterface \- Manual](https://www.php.net/manual/ja/class.datetimeinterface.php#datetimeinterface.constants.atom)の表現をベースにしています。