### PR TITLE
`include_once`の説明の修正

### DIFF
--- a/language/control-structures/include-once.xml
+++ b/language/control-structures/include-once.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: af6fdf16ab44bcf4d045407963e43c3d9dd2ff29 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 89d80c92a1154a2903fff371f0d056bf2ac8ba27 Maintainer: takagi Status: ready -->
 
 <sect1 xml:id="function.include-once" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>include_once</title>
  <?phpdoc print-version-for="include_once"?>
  <para>
-  <literal>include_once</literal> 命令は、スクリプトの実行時に指定
-  したファイルを読み込み評価します。この動作は、
-  <function>include</function> 命令と似ていますが、ファイルからのコー
-  ドが既に読み込まれている場合は、再度読み込まれないという重要な違い
-  があります。また、include_once は &true; を返します。その名が示す通り、ファイルは一度しか読み込まれません。
+  <literal>include_once</literal> 式は、スクリプトの実行時に指定
+  したファイルを読み込み評価します。この動作は
+  <function>include</function> 式と似ていますが、ファイルからのコー
+  ドが既に読み込まれている場合は、再度読み込まれずに include_once は
+  &true; を返すという点のみが異なります。その名が示す通り、ファイルは一度しか読み込まれません。
  </para>
  <para>
   <literal>include_once</literal> は、スクリプトの実行時に同じファイ


### PR DESCRIPTION
https://github.com/php/doc-en/pull/3790 を日本語版に反映しています。

また、ついでにはなりますが、[原文](https://github.com/php/doc-en/blob/c8564726a0289d0d685fad368df1ff15c292ff3d/language/control-structures/include-once.xml#L10-L13)と比較して日本語訳がやや異なっている部分を修正しています。

- 原文の"include_once returns true."の部分は前の文から続いており、「既に読み込まれている場合」の説明の一部であるはず
- 「重要な違い」というニュアンスは原文にはなさそう