### PR TITLE
Imagick::getResourceLimit、setResourceLimitの説明を修正

### DIFF
--- a/reference/imagick/imagick/getresourcelimit.xml
+++ b/reference/imagick/imagick/getresourcelimit.xml
@@ -28,7 +28,6 @@
      <listitem>
       <para>
        <link linkend="imagick.constants.resourcetypes">リソース型定数</link> のうちのひとつ。
-       単位は制限されるリソースのタイプに依存します。
       </para>
      </listitem>
     </varlistentry>
@@ -39,7 +38,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   指定したリソースの制限をメガバイト単位で返します。
+   指定したリソースの制限を返します。
+   単位は制限されるリソースのタイプに依存します。
   </para>
  </refsect1>
 

--- a/reference/imagick/imagick/setresourcelimit.xml
+++ b/reference/imagick/imagick/setresourcelimit.xml
@@ -30,7 +30,6 @@
       <para>
        <link 
        linkend="imagick.constants.resourcetypes">リソースタイプ定数</link> のうちのひとつ。
-       単位は制限されるリソースのタイプに依存します。
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
php/doc-en#2037 の変更を取り込んでImagick::getResourceLimitの説明を調整しました。

また、その確認をしていて対になるsetResourceLimitの説明に英語版と差異があることを見つけたので修正しています。

![Screenshot_2024-09-29_201207@2x](https://github.com/user-attachments/assets/d3a3f678-a1fc-4cf2-8bfe-52cd71f94b2a)  
https://www.php.net/manual/en/imagick.setresourcelimit.php

![Screenshot_2024-09-29_201229@2x](https://github.com/user-attachments/assets/b1d1c4d8-4f44-410f-b392-1b6c9afd21f7)  
https://www.php.net/manual/ja/imagick.setresourcelimit.php

setResourceLimitはtypeに応じてlimitの単位が変わってくるので、単位についての記載はlimit側にのみあるのが適切ではないかと考えました。

（setResourceLimitの引数limitの説明を英語版に揃えて「異なります」から「依存します」にした方が良いのだろうか、と思いましたがそこまで調整すると話が広がる気がしたのでtypeの説明から単位についての記載を取り除くのみにしています。）