### PR TITLE
`hash_pbkdf2()`の訳を修正

### DIFF
--- a/reference/hash/functions/hash-pbkdf2.xml
+++ b/reference/hash/functions/hash-pbkdf2.xml
@@ -46,7 +46,7 @@
      <term><parameter>password</parameter></term>
      <listitem>
       <para>
-       派生に使うパスワード
+       導出に使うパスワード
       </para>
      </listitem>
     </varlistentry>
@@ -54,7 +54,7 @@
      <term><parameter>salt</parameter></term>
      <listitem>
       <para>
-       派生に使うソルト。ランダムに生成した値でなければいけません。
+       導出に使うソルト。ランダムに生成した値でなければいけません。
       </para>
      </listitem>
     </varlistentry>
@@ -62,7 +62,7 @@
      <term><parameter>iterations</parameter></term>
      <listitem>
       <para>
-       派生の実行の際の内部の反復回数
+       導出の実行の際の内部の反復回数
       </para>
      </listitem>
     </varlistentry>
@@ -71,9 +71,12 @@
      <listitem>
       <para>
        出力する文字列の長さ。<parameter>binary</parameter> が &true;
-       の場合、これは派生キーのバイト長になります。
+       の場合、これは導出鍵のバイト長になります。
        <parameter>binary</parameter> が &false; の場合、
-       これは派生キーのバイト長の二倍になります (キーの全バイトが十六進二桁で返されるからです)。
+       これは導出鍵のバイト長の二倍になります (キーの全バイトが十六進二桁で返されるからです)。
+      </para>
+      <para>
+       <literal>0</literal>が渡された場合、与えられたアルゴリズムの出力全体が使われます。
       </para>
      </listitem>
     </varlistentry>
@@ -81,7 +84,7 @@
      <term><parameter>binary</parameter></term>
      <listitem>
       <para>
-       &true; にセットされている場合、名前のバイナリデータが出力されます。&false; の場合、小文字の16進数が出力されます。
+       &true; にセットされている場合、生のバイナリデータが出力されます。&false; の場合、小文字の16進数が出力されます。
       </para>
      </listitem>
     </varlistentry>
@@ -102,7 +105,7 @@
  <refsect1 role="returnvalues"><!-- {{{ -->
   &reftitle.returnvalues;
   <para>
-   小文字の16進数を含む文字列が返されます。<parameter>binary</parameter> が &true; の場合、派生キーの生のバイナリ表現が返されます。
+   小文字の16進数を含む文字列が返されます。<parameter>binary</parameter> が &true; の場合、導出鍵の生のバイナリ表現が返されます。
   </para>
  </refsect1><!-- }}} -->
 
@@ -112,7 +115,7 @@
     アルゴリズムが未知である場合、
     <parameter>iterations</parameter> パラメータが
     <literal>0</literal> 以下である場合、
-    <parameter>length</parameter> が <literal>0</literal> 以下である場合、
+    <parameter>length</parameter> が <literal>0</literal> よりも小さい場合、
     <parameter>salt</parameter> が長すぎる場合
    (<constant>INT_MAX</constant><literal> - 4</literal> よりも大きい) に、
    <classname>ValueError</classname> がスローされます。


### PR DESCRIPTION
derive, derivationは「派生させる、派生」「導き出す、導出」のいずれの意味もありますが、PBKDF2の文脈では「導出」とするのが比較的一般的なようです（かつ、日本語としてもしっくり来ると思います）。

参考：https://ja.wikipedia.org/wiki/PBKDF2

また英語版と見比べていて、`$length = 0`の場合の説明がすっぽり抜けていることに気付いたので合わせて追加を行っています。

https://github.com/php/doc-en/blob/e0352653179c355a6b9c353629147b06a2069f24/reference/hash/functions/hash-pbkdf2.xml#L75-L78