### PR TITLE
refactor(ext/pgsql): 不要なエラーハンドリングをコード例より削除

### DIFF
--- a/reference/pgsql/functions/pg-fetch-result.xml
+++ b/reference/pgsql/functions/pg-fetch-result.xml
@@ -112,7 +112,7 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-$db = pg_connect("dbname=users user=me") || die();
+$db = pg_connect("dbname=users user=me");
 
 $res = pg_query($db, "SELECT 1 UNION ALL SELECT 2");
 

--- a/reference/pgsql/functions/pg-free-result.xml
+++ b/reference/pgsql/functions/pg-free-result.xml
@@ -78,7 +78,7 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-$db = pg_connect("dbname=users user=me") || die();
+$db = pg_connect("dbname=users user=me");
 
 $res = pg_query($db, "SELECT 1 UNION ALL SELECT 2");
 


### PR DESCRIPTION
小さな修正で php/doc-en#3973 の日本語版への展開です。

現在はほぼ書かれないコードと思われるので、php-8.4で新設予定の php/doc-en#3972 含め不要なエラーハンドリングを削除しました。