### PR TITLE
[PHP 8.4] Add manual for `pg_result_memory_syze()`

### DIFF
--- a/reference/pgsql/functions/pg-result-memory-size.xml
+++ b/reference/pgsql/functions/pg-result-memory-size.xml
@@ -1,71 +1,74 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 <refentry xml:id="function.pg-result-memory-size" xmlns="http://docbook.org/ns/docbook">
-    <refnamediv>
-        <refname>pg_result_memory_size</refname>
-        <refpurpose>クエリーの結果に割り当てられたメモリ使用量を返します</refpurpose>
-    </refnamediv>
+ <refnamediv>
+  <refname>pg_result_memory_size</refname>
+  <refpurpose>クエリーの結果に割り当てられたメモリ使用量を返します</refpurpose>
+ </refnamediv>
 
-    <refsect1 role="description">
-        &reftitle.description;
-        <methodsynopsis>
-            <type>int</type><methodname>pg_result_memory_size</methodname>
-            <methodparam><type>PgSql\Result</type><parameter>result</parameter></methodparam>
-        </methodsynopsis>
-        <simpara>
-            指定されたクエリ結果 <classname>PgSql\Result</classname> インスタンスに割り当てられたメモリ使用量をバイト単位で返します。
-            この値は、 <function>pg_free_result</function> によって解放されるメモリ使用量と同じです。
-        </simpara>
-    </refsect1>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>int</type><methodname>pg_result_memory_size</methodname>
+   <methodparam><type>PgSql\Result</type><parameter>result</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   指定されたクエリ結果 <classname>PgSql\Result</classname> インスタンスに割り当てられたメモリ使用量をバイト単位で返します。
+   この値は、 <function>pg_free_result</function> によって解放されるメモリ使用量と同じです。
+  </simpara>
+ </refsect1>
 
-    <refsect1 role="parameters">
-        &reftitle.parameters;
-        <variablelist>
-            <varlistentry>
-                <term><parameter>result</parameter></term>
-                <listitem>
-                    &pgsql.parameter.result;
-                </listitem>
-            </varlistentry>
-        </variablelist>
-    </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>result</parameter></term>
+    <listitem>
+     &pgsql.parameter.result;
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
 
-    <refsect1 role="returnvalues">
-        &reftitle.returnvalues;
-        <simpara>
-            メモリ使用量をバイト単位で返します。
-        </simpara>
-    </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   メモリ使用量をバイト単位で返します。
+  </simpara>
+ </refsect1>
 
-    <refsect1 role="examples">
-        &reftitle.examples;
-        <example>
-            <title><function>pg_result_memory_size</function> の例</title>
-            <programlisting role="php">
-                <![CDATA[
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><function>pg_result_memory_size</function> の例</title>
+   <programlisting role="php">
+<![CDATA[
 <?php
 $db = pg_connect("dbname=users user=me");
+
 $res = pg_query($db, 'SELECT 1');
+
 $size = pg_result_memory_size($res);
+
 var_dump($size);
 ?>
 ]]>
-            </programlisting>
-            &example.outputs.similar;
-            <screen>
-                <![CDATA[
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
 int(3288)
 ]]>
-            </screen>
-        </example>
-    </refsect1>
+   </screen>
+  </example>
+ </refsect1>
 
-    <refsect1 role="seealso">
-        &reftitle.seealso;
-        <simplelist>
-            <member><function>pg_free_result</function></member>
-        </simplelist>
-    </refsect1>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>pg_free_result</function></member>
+  </simplelist>
+ </refsect1>
 </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/reference/pgsql/functions/pg-result-memory-size.xml
+++ b/reference/pgsql/functions/pg-result-memory-size.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
+<!-- EN-Revision: 0e3624a28232422c0e6741b93f93599726479bb3 Maintainer: KentarouTakeda Status: ready -->
+<!-- CREDITS: KentarouTakeda -->
 <refentry xml:id="function.pg-result-memory-size" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>pg_result_memory_size</refname>

--- a/reference/pgsql/functions/pg-result-memory-size.xml
+++ b/reference/pgsql/functions/pg-result-memory-size.xml
@@ -20,16 +20,14 @@
 
     <refsect1 role="parameters">
         &reftitle.parameters;
-        <para>
-            <variablelist>
-                <varlistentry>
-                    <term><parameter>result</parameter></term>
-                    <listitem>
-                        &pgsql.parameter.result;
-                    </listitem>
-                </varlistentry>
-            </variablelist>
-        </para>
+        <variablelist>
+            <varlistentry>
+                <term><parameter>result</parameter></term>
+                <listitem>
+                    &pgsql.parameter.result;
+                </listitem>
+            </varlistentry>
+        </variablelist>
     </refsect1>
 
     <refsect1 role="returnvalues">
@@ -64,11 +62,9 @@ int(3288)
 
     <refsect1 role="seealso">
         &reftitle.seealso;
-        <para>
-            <simplelist>
-                <member><function>pg_free_result</function></member>
-            </simplelist>
-        </para>
+        <simplelist>
+            <member><function>pg_free_result</function></member>
+        </simplelist>
     </refsect1>
 </refentry>
 

--- a/reference/pgsql/functions/pg-result-memory-size.xml
+++ b/reference/pgsql/functions/pg-result-memory-size.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="function.pg-result-memory-size" xmlns="http://docbook.org/ns/docbook">
+    <refnamediv>
+        <refname>pg_result_memory_size</refname>
+        <refpurpose>クエリーの結果に割り当てられたメモリ使用量を返します</refpurpose>
+    </refnamediv>
+
+    <refsect1 role="description">
+        &reftitle.description;
+        <methodsynopsis>
+            <type>int</type><methodname>pg_result_memory_size</methodname>
+            <methodparam><type>PgSql\Result</type><parameter>result</parameter></methodparam>
+        </methodsynopsis>
+        <simpara>
+            指定されたクエリ結果 <classname>PgSql\Result</classname> インスタンスに割り当てられたメモリ使用量をバイト単位で返します。
+            この値は、 <function>pg_free_result</function> によって解放されるメモリ使用量と同じです。
+        </simpara>
+    </refsect1>
+
+    <refsect1 role="parameters">
+        &reftitle.parameters;
+        <para>
+            <variablelist>
+                <varlistentry>
+                    <term><parameter>result</parameter></term>
+                    <listitem>
+                        &pgsql.parameter.result;
+                    </listitem>
+                </varlistentry>
+            </variablelist>
+        </para>
+    </refsect1>
+
+    <refsect1 role="returnvalues">
+        &reftitle.returnvalues;
+        <simpara>
+            メモリ使用量をバイト単位で返します。
+        </simpara>
+    </refsect1>
+
+    <refsect1 role="examples">
+        &reftitle.examples;
+        <example>
+            <title><function>pg_result_memory_size</function> の例</title>
+            <programlisting role="php">
+                <![CDATA[
+<?php
+$db = pg_connect("dbname=users user=me");
+$res = pg_query($db, 'SELECT 1');
+$size = pg_result_memory_size($res);
+var_dump($size);
+?>
+]]>
+            </programlisting>
+            &example.outputs.similar;
+            <screen>
+                <![CDATA[
+int(3288)
+]]>
+            </screen>
+        </example>
+    </refsect1>
+
+    <refsect1 role="seealso">
+        &reftitle.seealso;
+        <para>
+            <simplelist>
+                <member><function>pg_free_result</function></member>
+            </simplelist>
+        </para>
+    </refsect1>
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
php/doc-en#3972 の変更を取り込みました。

[reference/pgsql/version.xml](https://github.com/KentarouTakeda/php-doc-en/blob/31ddb1f14f03df4ce5044adf3e4b3692775aa649/reference/pgsql/versions.xml) はja側に存在しなかったので、不要だと思いコピーしていません。必要であれば、コピーして作成します。