### PR TITLE
[PHP 8.4] 「PHP 8.3.x から PHP 8.4.x への移行」の翻訳

### DIFF
--- a/appendices/migration84.xml
+++ b/appendices/migration84.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appendix xml:id="migration84" xmlns="http://docbook.org/ns/docbook">
+ <title>Migrating from PHP 8.3.x to PHP 8.4.x</title>
+
+ <para>
+  This new minor version brings with it a number of
+  <link linkend="migration84.new-features">new features</link> and a
+  <link linkend="migration84.incompatible">few incompatibilities</link>
+  that should be tested for before switching PHP versions in production
+  environments.
+ </para>
+
+ <para>
+  &manual.migration.seealso;
+  <link linkend="migration71">7.1.x</link>,
+  <link linkend="migration72">7.2.x</link>,
+  <link linkend="migration73">7.3.x</link>,
+  <link linkend="migration74">7.4.x</link>,
+  <link linkend="migration80">8.0.x</link>,
+  <link linkend="migration81">8.1.x</link>,
+  <link linkend="migration82">8.2.x</link>,
+  <link linkend="migration83">8.3.x</link>.
+ </para>
+
+ &appendices.migration84.new-features;
+ &appendices.migration84.new-classes;
+ &appendices.migration84.new-functions;
+ &appendices.migration84.constants;
+ &appendices.migration84.incompatible;
+ &appendices.migration84.deprecated;
+ &appendices.migration84.removed-extensions;
+ &appendices.migration84.other-changes;
+ &appendices.migration84.windows-support;
+
+</appendix>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/appendices/migration84.xml
+++ b/appendices/migration84.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: d64e811eac61a5c7c744312d8bc6e2244de81488 Maintainer: KentarouTakeda Status: ready -->
+<!-- Credits: KentarouTakeda -->
 <appendix xml:id="migration84" xmlns="http://docbook.org/ns/docbook">
- <title>Migrating from PHP 8.3.x to PHP 8.4.x</title>
+ <title>PHP 8.3.x から PHP 8.4.x への移行</title>
 
  <para>
-  This new minor version brings with it a number of
-  <link linkend="migration84.new-features">new features</link> and a
-  <link linkend="migration84.incompatible">few incompatibilities</link>
-  that should be tested for before switching PHP versions in production
-  environments.
+  この新しいマイナーバージョンには、たくさんの <link linkend="migration84.new-features">新機能</link> と <link linkend="migration84.incompatible">互換性のない変更がいくつか</link> あります。実運用環境の PHP をこのバージョンにあげる前に、これらの変更を必ずテストすべきです。
  </para>
 
  <para>

--- a/appendices/migration84/constants.xml
+++ b/appendices/migration84/constants.xml
@@ -1,0 +1,337 @@
+<?xml version="1.0" encoding="utf-8"?>
+<sect1 xml:id="migration84.constants">
+ <title>New Global Constants</title>
+
+ <sect2 xml:id="migration84.constants.core">
+  <title>Core</title>
+
+  <simplelist>
+   <member>
+    <constant>PHP_OUTPUT_HANDLER_PROCESSED</constant>
+   </member>
+   <member>
+    <constant>PHP_SBINDIR</constant>
+   </member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration84.constants.curl">
+  <title>cURL</title>
+
+  <simplelist>
+   <member>
+    <constant>CURL_HTTP_VERSION_3</constant>
+   </member>
+   <member>
+    <constant>CURL_HTTP_VERSION_3ONLY</constant>
+   </member>
+   <member>
+    <constant>CURL_TCP_KEEPCNT</constant>
+   </member>
+   <member>
+    <constant>CURLOPT_PREREQFUNCTION</constant>
+   </member>
+   <member>
+    <constant>CURL_PREREQFUNC_OK</constant>
+   </member>
+   <member>
+    <constant>CURL_PREREQFUNC_ABORT</constant>
+   </member>
+   <member>
+    <constant>CURLOPT_SERVER_RESPONSE_TIMEOUT</constant>
+   </member>
+   <member>
+    <constant>CURLOPT_DEBUGFUNCTION</constant>
+   </member>
+   <member>
+    <constant>CURLINFO_TEXT</constant>
+   </member>
+   <member>
+    <constant>CURLINFO_HEADER_IN</constant>
+   </member>
+   <member>
+    <constant>CURLINFO_DATA_IN</constant>
+   </member>
+   <member>
+    <constant>CURLINFO_DATA_OUT</constant>
+   </member>
+   <member>
+    <constant>CURLINFO_SSL_DATA_OUT</constant>
+   </member>
+   <member>
+    <constant>CURLINFO_SSL_DATA_IN</constant>
+   </member>
+   <member>
+    <constant>CURLINFO_POSTTRANSFER_TIME_T</constant>
+   </member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration84.constants.intl">
+  <title>Intl</title>
+
+  <simplelist>
+   <member>
+    <constant>PATTERN</constant>
+     (<classname>IntlDateFormatter</classname>)
+   </member>
+   <member>
+    <constant>PROPERTY_IDS_UNARY_OPERATOR</constant>
+     (<classname>IntlChar</classname>)
+   </member>
+   <member>
+    <constant>PROPERTY_ID_COMPAT_MATH_START</constant>
+     <!-- for mathematical identifier profiling purpose -->
+   </member>
+   <member>
+    <constant>PROPERTY_ID_COMPAT_MATH_CONTINUE</constant>
+     <!-- for mathematical identifier profiling purpose -->
+   </member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration84.constants.ldap">
+  <title>LDAP</title>
+
+  <simplelist>
+   <member>
+    <constant>LDAP_OPT_X_TLS_PROTOCOL_MAX</constant>
+   </member>
+   <member>
+    <constant>LDAP_OPT_X_TLS_PROTOCOL_TLS1_3</constant>
+   </member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration84.constants.libxml">
+  <title>libxml</title>
+
+  <simplelist>
+   <member>
+    <constant>LIBXML_RECOVER</constant>
+   </member>
+   <member>
+    <constant>LIBXML_NO_XXE</constant>.
+     This is used together with <constant>LIBXML_NOENT</constant>
+     when entity substitution should be performed,
+     while disallowing external entity loading.
+     This constant is available as of libxml2 2.13.
+   </member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration84.constants.mysqli">
+  <title>MySQLi</title>
+
+  <simplelist>
+   <member>
+    <constant>MYSQLI_TYPE_VECTOR</constant>
+   </member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration84.constants.openssl">
+  <title>OpenSSL</title>
+
+  <simplelist>
+   <member><constant>X509_PURPOSE_OCSP_HELPER</constant></member>
+   <member><constant>X509_PURPOSE_TIMESTAMP_SIGN</constant></member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration84.constants.pcntl">
+  <title>PCNTL</title>
+
+  <simplelist>
+   <member>
+    <constant>SIGCKPT</constant> (DragonFlyBSD only)
+   </member>
+   <member>
+    <constant>SIGCKPTEXIT</constant> (DragonFlyBSD only)
+   </member>
+   <member>
+    <constant>WEXITED</constant>
+   </member>
+   <member>
+    <constant>WSTOPPED</constant>
+   </member>
+   <member>
+    <constant>WNOWAIT</constant>
+   </member>
+   <member>
+    <constant>P_ALL</constant>
+   </member>
+   <member>
+    <constant>P_PID</constant>
+   </member>
+   <member>
+    <constant>P_PGID</constant>
+   </member>
+   <member>
+    <constant>P_PIDFD</constant> (Linux only)
+   </member>
+   <member>
+    <constant>P_UID</constant> (NetBSD/FreeBSD only)
+   </member>
+   <member>
+    <constant>P_GID</constant> (NetBSD/FreeBSD only)
+   </member>
+   <member>
+    <constant>P_SID</constant> (NetBSD/FreeBSD only)
+   </member>
+   <member>
+    <constant>P_JAILID</constant> (FreeBSD only)
+   </member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration84.constants.pgsql">
+  <title>PGSQL</title>
+
+  <simplelist>
+   <member><constant>PGSQL_TUPLES_CHUNK</constant></member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration84.constants.posix">
+  <title>POSIX</title>
+
+  <simplelist>
+   <member><constant>POSIX_SC_CHILD_MAX</constant></member>
+   <member><constant>POSIX_SC_CLK_TCK</constant></member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration84.constants.sockets">
+  <title>Sockets</title>
+
+  <simpara>
+   The following socket options are now defined if they are supported:
+  </simpara>
+
+  <simplelist>
+   <member>
+    <constant>SO_EXCLUSIVEADDRUSE</constant> (Windows only)
+   </member>
+   <member>
+    <constant>SOCK_CONN_DGRAM</constant> (NetBSD only)
+   </member>
+   <member>
+    <constant>SOCK_DCCP</constant> (NetBSD only)
+   </member>
+   <member>
+    <constant>TCP_SYNCNT</constant> (Linux only)
+   </member>
+   <member>
+    <constant>SO_EXCLBIND</constant> (Solaris/Illumos only)
+   </member>
+   <member>
+    <constant>SO_NOSIGPIPE</constant> (macOS and FreeBSD)
+   </member>
+   <member>
+    <constant>SO_LINGER_SEC</constant> (macOS only)
+   </member>
+   <member>
+    <constant>IP_PORTRANGE</constant> (FreeBSD/NetBSD/OpenBSD only)
+   </member>
+   <member>
+    <constant>IP_PORTRANGE_DEFAULT</constant> (FreeBSD/NetBSD/OpenBSD only)
+   </member>
+   <member>
+    <constant>IP_PORTRANGE_HIGH</constant> (FreeBSD/NetBSD/OpenBSD only)
+   </member>
+   <member>
+    <constant>IP_PORTRANGE_LOW</constant> (FreeBSD/NetBSD/OpenBSD only)
+   </member>
+   <member>
+    <constant>SOCK_NONBLOCK</constant>
+   </member>
+   <member>
+    <constant>SOCK_CLOEXEC</constant>
+   </member>
+   <member>
+    <constant>SO_BINDTOIFINDEX</constant>
+   </member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration84.constants.sodium">
+  <title>Sodium</title>
+
+  <simplelist>
+   <member>
+    <constant>SODIUM_CRYPTO_AEAD_AEGIS128L_KEYBYTES</constant>
+   </member>
+   <member>
+    <constant>SODIUM_CRYPTO_AEAD_AEGIS128L_NSECBYTES</constant>
+   </member>
+   <member>
+    <constant>SODIUM_CRYPTO_AEAD_AEGIS128L_NPUBBYTES</constant>
+   </member>
+   <member>
+    <constant>SODIUM_CRYPTO_AEAD_AEGIS128L_ABYTES</constant>
+   </member>
+   <member>
+    <constant>SODIUM_CRYPTO_AEAD_AEGIS256_KEYBYTES</constant>
+   </member>
+   <member>
+    <constant>SODIUM_CRYPTO_AEAD_AEGIS256_NSECBYTES</constant>
+   </member>
+   <member>
+    <constant>SODIUM_CRYPTO_AEAD_AEGIS256_NPUBBYTES</constant>
+   </member>
+   <member>
+    <constant>SODIUM_CRYPTO_AEAD_AEGIS256_ABYTES</constant>
+   </member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration84.constants.tokenizer">
+  <title>Tokenizer</title>
+  <simplelist>
+   <member>
+    <constant>T_PUBLIC_SET</constant>
+   </member>
+   <member>
+    <constant>T_PROTECTED_SET</constant>
+   </member>
+   <member>
+    <constant>T_PRIVATE_SET</constant>
+   </member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration84.constants.xml">
+  <title>XML</title>
+
+  <simplelist>
+   <member>
+    <constant>XML_OPTION_PARSE_HUGE</constant>
+     which allows parsing large inputs with
+     <function>xml_parse</function> and
+     <function>xml_parse_into_struct</function>.
+   </member>
+  </simplelist>
+ </sect2>
+
+</sect1>
+ <!-- Keep this comment at the end of the file
+ Local variables:
+ mode: sgml
+ sgml-omittag:t
+ sgml-shorttag:t
+ sgml-minimize-attributes:nil
+ sgml-always-quote-attributes:t
+ sgml-indent-step:1
+ sgml-indent-data:t
+ indent-tabs-mode:nil
+ sgml-parent-document:nil
+ sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+ sgml-exposed-tags:nil
+ sgml-local-catalogs:nil
+ sgml-local-ecat-files:nil
+ End:
+ vim600: syn=xml fen fdm=syntax fdl=2 si
+ vim: et tw=78 syn=sgml
+ vi: ts=1 sw=1
+ -->

--- a/appendices/migration84/constants.xml
+++ b/appendices/migration84/constants.xml
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 8a6397d39aefd23c61d64aa4e9af919772541e2a Maintainer: KentarouTakeda Status: ready -->
+<!-- Credits: KentarouTakeda -->
 <sect1 xml:id="migration84.constants">
- <title>New Global Constants</title>
+ <title>新しいグローバル定数</title>
 
  <sect2 xml:id="migration84.constants.core">
-  <title>Core</title>
+  <title>PHP コア</title>
 
   <simplelist>
    <member>
@@ -111,11 +114,11 @@
     <constant>LIBXML_RECOVER</constant>
    </member>
    <member>
-    <constant>LIBXML_NO_XXE</constant>.
-     This is used together with <constant>LIBXML_NOENT</constant>
-     when entity substitution should be performed,
-     while disallowing external entity loading.
-     This constant is available as of libxml2 2.13.
+    <constant>LIBXML_NO_XXE</constant>
+    これは、外部エンティティの読み込みを許可せず
+    エンティティの置換を行うために、
+    <constant>LIBXML_NOENT</constant>と一緒に使用されます。
+    この定数はlibxml2 2.13から利用可能です。
    </member>
   </simplelist>
  </sect2>
@@ -144,10 +147,10 @@
 
   <simplelist>
    <member>
-    <constant>SIGCKPT</constant> (DragonFlyBSD only)
+    <constant>SIGCKPT</constant> (DragonFlyBSDのみ)
    </member>
    <member>
-    <constant>SIGCKPTEXIT</constant> (DragonFlyBSD only)
+    <constant>SIGCKPTEXIT</constant> (DragonFlyBSDのみ)
    </member>
    <member>
     <constant>WEXITED</constant>
@@ -168,19 +171,19 @@
     <constant>P_PGID</constant>
    </member>
    <member>
-    <constant>P_PIDFD</constant> (Linux only)
+    <constant>P_PIDFD</constant> (Linuxのみ)
    </member>
    <member>
-    <constant>P_UID</constant> (NetBSD/FreeBSD only)
+    <constant>P_UID</constant> (NetBSD/FreeBSDのみ)
    </member>
    <member>
-    <constant>P_GID</constant> (NetBSD/FreeBSD only)
+    <constant>P_GID</constant> (NetBSD/FreeBSDのみ)
    </member>
    <member>
-    <constant>P_SID</constant> (NetBSD/FreeBSD only)
+    <constant>P_SID</constant> (NetBSD/FreeBSDのみ)
    </member>
    <member>
-    <constant>P_JAILID</constant> (FreeBSD only)
+    <constant>P_JAILID</constant> (FreeBSDのみ)
    </member>
   </simplelist>
  </sect2>
@@ -206,42 +209,42 @@
   <title>Sockets</title>
 
   <simpara>
-   The following socket options are now defined if they are supported:
+   サポートされている場合、次のソケットオプションが新たに定義されます:
   </simpara>
 
   <simplelist>
    <member>
-    <constant>SO_EXCLUSIVEADDRUSE</constant> (Windows only)
+    <constant>SO_EXCLUSIVEADDRUSE</constant> (Windowsのみ)
    </member>
    <member>
-    <constant>SOCK_CONN_DGRAM</constant> (NetBSD only)
+    <constant>SOCK_CONN_DGRAM</constant> (NetBSDのみ)
    </member>
    <member>
-    <constant>SOCK_DCCP</constant> (NetBSD only)
+    <constant>SOCK_DCCP</constant> (NetBSDのみ)
    </member>
    <member>
-    <constant>TCP_SYNCNT</constant> (Linux only)
+    <constant>TCP_SYNCNT</constant> (Linuxのみ)
    </member>
    <member>
-    <constant>SO_EXCLBIND</constant> (Solaris/Illumos only)
+    <constant>SO_EXCLBIND</constant> (Solaris/Illumosのみ)
    </member>
    <member>
-    <constant>SO_NOSIGPIPE</constant> (macOS and FreeBSD)
+    <constant>SO_NOSIGPIPE</constant>（macOSおよびFreeBSD）
    </member>
    <member>
-    <constant>SO_LINGER_SEC</constant> (macOS only)
+    <constant>SO_LINGER_SEC</constant> (macOSのみ)
    </member>
    <member>
-    <constant>IP_PORTRANGE</constant> (FreeBSD/NetBSD/OpenBSD only)
+    <constant>IP_PORTRANGE</constant> (FreeBSD/NetBSD/OpenBSDのみ)
    </member>
    <member>
-    <constant>IP_PORTRANGE_DEFAULT</constant> (FreeBSD/NetBSD/OpenBSD only)
+    <constant>IP_PORTRANGE_DEFAULT</constant> (FreeBSD/NetBSD/OpenBSDのみ)
    </member>
    <member>
-    <constant>IP_PORTRANGE_HIGH</constant> (FreeBSD/NetBSD/OpenBSD only)
+    <constant>IP_PORTRANGE_HIGH</constant> (FreeBSD/NetBSD/OpenBSDのみ)
    </member>
    <member>
-    <constant>IP_PORTRANGE_LOW</constant> (FreeBSD/NetBSD/OpenBSD only)
+    <constant>IP_PORTRANGE_LOW</constant> (FreeBSD/NetBSD/OpenBSDのみ)
    </member>
    <member>
     <constant>SOCK_NONBLOCK</constant>
@@ -307,9 +310,9 @@
   <simplelist>
    <member>
     <constant>XML_OPTION_PARSE_HUGE</constant>
-     which allows parsing large inputs with
-     <function>xml_parse</function> and
-     <function>xml_parse_into_struct</function>.
+      <function>xml_parse</function>や
+      <function>xml_parse_into_struct</function>
+      を使用して大きな入力を解析することを可能にします。
    </member>
   </simplelist>
  </sect2>

--- a/appendices/migration84/deprecated.xml
+++ b/appendices/migration84/deprecated.xml
@@ -1,0 +1,491 @@
+<?xml version="1.0" encoding="utf-8"?>
+<sect1 xml:id="migration84.deprecated">
+ <title>Deprecated Features</title>
+
+ <sect2 xml:id="migration84.deprecated.core">
+  <title>PHP Core</title>
+
+  <sect3 xml:id="migration84.deprecated.core.implicitly-nullable-parameter">
+   <!-- RFC: https://wiki.php.net/rfc/deprecate-implicitly-nullable-types -->
+   <title>Implicitly nullable parameter</title>
+
+   <simpara>
+    A parameter's type is implicitly widened to accept <type>null</type>
+    if the default value for it is &null;.
+   </simpara>
+
+   <para>
+    The following code:
+    <informalexample>
+     <programlisting role="php">
+<![CDATA[
+<?php
+function foo(T1 $a = null) {}
+]]>
+     </programlisting>
+    </informalexample>
+    should be converted to:
+    <informalexample>
+     <programlisting role="php">
+<![CDATA[
+<?php
+function foo(T1|null $a = null) {}
+]]>
+     </programlisting>
+    </informalexample>
+    or
+    <informalexample>
+     <programlisting role="php">
+<![CDATA[
+<?php
+function foo(?T1 $a = null) {}
+]]>
+     </programlisting>
+    </informalexample>
+   </para>
+
+   <para>
+    However, if such a parameter declaration is followed by a mandatory
+    parameter:
+    <informalexample>
+     <programlisting role="php">
+<![CDATA[
+<?php
+function foo(T1 $a, T2 $b = null, T3 $c) {}
+]]>
+     </programlisting>
+    </informalexample>
+    It must be converted to:
+    <informalexample>
+     <programlisting role="php">
+<![CDATA[
+<?php
+function foo(T1 $a, T2|null $b, T3 $c) {}
+]]>
+     </programlisting>
+    </informalexample>
+    or
+    <informalexample>
+     <programlisting role="php">
+<![CDATA[
+<?php
+function foo(T1 $a, ?T2 $b, T3 $c) {}
+]]>
+     </programlisting>
+    </informalexample>
+    as optional parameter before required ones are deprecated.
+   </para>
+  </sect3>
+
+  <sect3>
+   <!-- RFC: https://wiki.php.net/rfc/raising_zero_to_power_of_negative_number -->
+   <title>Raising zero to the power of negative number</title>
+
+   <simpara>
+    Raising a number to the power of a negative number is equivalent to taking
+    the reciprocal of the number raised to the positive opposite of the power.
+    Therefore raising <literal>0</literal> to the power of a negative number
+    corresponds to dividing by <literal>0</literal>.
+    Thus, this behaviour has been deprecated.
+   </simpara>
+
+   <simpara>
+    This affects the exponentiation operator <literal>**</literal>
+    and the <function>pow</function> function.
+   </simpara>
+
+   <simpara>
+    If the IEEE 754 semantics are desired one should use the new
+    <function>fpow</function> function.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.deprecated.core.underscore-class-name">
+   <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_using_a_single_underscore_as_a_class_name -->
+   <title>Using underscore <literal>_</literal> as class name</title>
+
+   <para>
+    Naming a class <literal>_</literal> is now deprecated:
+    <informalexample>
+     <programlisting role="php">
+<![CDATA[
+<?php
+class _ {}
+]]>
+     </programlisting>
+    </informalexample>
+   </para>
+
+   <note>
+    <para>
+     Classes whose names start with an underscore are <emphasis>not</emphasis>
+     deprecated:
+     <informalexample>
+      <programlisting role="php">
+<![CDATA[
+<?php
+class _MyClass {}
+]]>
+      </programlisting>
+     </informalexample>
+    </para>
+   </note>
+  </sect3>
+
+  <sect3>
+   <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_passing_e_user_error_to_trigger_error -->
+   <title>
+    Using <function>trigger_error</function> with
+    <constant>E_USER_ERROR</constant>
+   </title>
+
+   <simpara>
+    Calling <function>trigger_error</function> with
+    <parameter>error_level</parameter> being equal to
+    <constant>E_USER_ERROR</constant> is now deprecated.
+   </simpara>
+
+   <simpara>
+    Such usages should be replaced by either throwing an exception,
+    or calling <function>exit</function>, whichever is more appropriate.
+   </simpara>
+  </sect3>
+
+  <sect3>
+   <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_4#remove_e_strict_error_level_and_deprecate_e_strict_constant -->
+   <title>
+    The <constant>E_STRICT</constant> constant
+   </title>
+
+   <simpara>
+    Because the <constant>E_STRICT</constant> error level was removed,
+    this constant is now deprecated.
+   </simpara>
+  </sect3>
+ </sect2>
+
+ <sect2 xml:id="migration84.deprecated.core.curl">
+  <title>cURL</title>
+
+  <simpara>
+   The <constant>CURLOPT_BINARYTRANSFER</constant> constant is now deprecated.
+  </simpara>
+ </sect2>
+
+ <sect2 xml:id="migration84.deprecated.core.date">
+  <title>Date</title>
+
+  <simpara>
+   The <code> DatePeriod::__construct(string $isostr, int $options = 0)</code>
+   signature has been deprecated.
+   Use <methodname>DatePeriod::createFromISO8601String</methodname> instead.
+  </simpara>
+
+  <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_4#constants_sunfuncs_ret_string_sunfuncs_ret_double_sunfuncs_ret_timestamp -->
+  <simpara>
+   The <constant>SUNFUNCS_RET_TIMESTAMP</constant>,
+   <constant>SUNFUNCS_RET_STRING</constant>,
+   and <constant>SUNFUNCS_RET_DOUBLE</constant> constants are now deprecated.
+   This follows from the deprecation of the <function>date_sunset</function> and
+   <function>date_sunrise</function> functions in PHP 8.1.0.
+  </simpara>
+ </sect2>
+
+ <sect2 xml:id="migration84.deprecated.core.dba">
+  <title>DBA</title>
+
+  <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_passing_null_and_false_to_dba_key_split -->
+  <simpara>
+   Passing &null; or &false; to <function>dba_key_split</function> is now
+   deprecated.
+   It would always return &false; in those cases.
+  </simpara>
+ </sect2>
+
+ <sect2 xml:id="migration84.deprecated.core.dom">
+  <title>DOM</title>
+
+  <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_dom_php_err_constant -->
+  <simpara>
+   The <constant>DOM_PHP_ERR</constant> constant is now deprecated.
+  </simpara>
+
+  <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_4#formally_deprecate_soft-deprecated_domdocument_and_domentity_properties -->
+  <para>
+   The following properties have been formally deprecated:
+   <simplelist>
+    <member><property>DOMDocument::$actualEncoding</property></member>
+    <member><property>DOMDocument::$config</property></member>
+    <member><property>DOMEntity::$actualEncoding</property></member>
+    <member><property>DOMEntity::$encoding</property></member>
+    <member><property>DOMEntity::$version</property></member>
+   </simplelist>
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration84.deprecated.core.hash">
+  <title>Hash</title>
+
+  <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_passing_incorrect_data_types_for_options_to_exthash_functions -->
+  <simpara>
+   Passing invalid options to hash functions is now deprecated.
+  </simpara>
+ </sect2>
+
+ <sect2 xml:id="migration84.deprecated.intl">
+  <title>Intl</title>
+
+  <simpara>
+   Calling <function>intlcal_set</function> or
+   <methodname>IntlCalendar::set</methodname>
+   with more than two arguments is deprecated.
+   Use either <methodname>IntlCalendar::setDate</methodname> or
+   <methodname>IntlCalendar::setDateTime</methodname> instead.
+  </simpara>
+
+  <simpara>
+   Calling <function>intlgregcal_create_instance</function> or
+   <methodname>IntlGregorianCalendar::__construct</methodname>
+   with more than two arguments is deprecated.
+   Use either <methodname>IntlGregorianCalendar::createFromDate</methodname> or
+   <methodname>IntlGregorianCalendar::createFromDateTime</methodname> instead.
+  </simpara>
+ </sect2>
+
+ <sect2 xml:id="migration84.deprecated.ldap">
+  <title>LDAP</title>
+
+  <simpara>
+   Calling <function>ldap_connect</function>
+   with more than two arguments is deprecated.
+   Use <function>ldap_connect_wallet</function> instead.
+  </simpara>
+
+  <simpara>
+   Calling <function>ldap_exop</function>
+   with more than four arguments is deprecated.
+   Use <function>ldap_exop_sync</function> instead.
+  </simpara>
+ </sect2>
+
+ <sect2 xml:id="migration84.deprecated.core.mysqli">
+  <title>MySQLi</title>
+
+  <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_4#mysqli_ping_and_mysqliping -->
+  <simpara>
+   The <function>mysqli_ping</function> function and
+   <methodname>mysqli::ping</methodname> method
+   are now deprecated as the reconnect feature was removed in PHP 8.2.0.
+  </simpara>
+
+  <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_mysqli_kill -->
+  <simpara>
+   The <function>mysqli_kill</function> function and
+   <methodname>mysqli::kill</methodname> method
+   are now deprecated.
+   If this functionality is needed a SQL <literal>KILL</literal> command
+   can be used instead.
+  </simpara>
+
+  <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_mysqli_refresh -->
+  <simpara>
+   The <function>mysqli_refresh</function> function and
+   <methodname>mysqli::refresh</methodname> method
+   are now deprecated.
+   If this functionality is needed a SQL <literal>FLUSH</literal> command
+   can be used instead.
+   All <constant>MYSQLI_REFRESH_<replaceable>*</replaceable></constant>
+   constants have been deprecated as well.
+  </simpara>
+
+  <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_the_second_parameter_to_mysqli_store_result -->
+  <simpara>
+   Passing the <parameter>mode</parameter> parameter to
+   <function>mysqli_store_result</function> explicitly has been deprecated.
+   As the <constant>MYSQLI_STORE_RESULT_COPY_DATA</constant> constant was
+   only used in conjunction with this function it has also been deprecated.
+  </simpara>
+ </sect2>
+
+ <sect2 xml:id="migration84.deprecated.core.pdo-pgsql">
+  <title>PDO_PGSQL</title>
+
+  <simpara>
+   Using escaped question marks (<literal>??</literal>) inside
+   dollar-quoted strings is deprecated.
+   Because PDO_PGSQL now has its own SQL parser with dollar-quoted strings
+   support, it is no longer necessary to escape question marks inside them.
+  </simpara>
+ </sect2>
+
+ <sect2 xml:id="migration84.deprecated.core.pgsql">
+  <title>PGSQL</title>
+
+  <simpara>
+   The 2 arguments signature of <function>pg_fetch_result</function>,
+   <function>pg_field_prtlen</function>, and
+   <function>pg_field_is_null</function> is now deprecated.
+   Use the 3 arguments signature with <parameter>row</parameter> set to
+   &null; instead.
+  </simpara>
+ </sect2>
+
+ <sect2 xml:id="migration84.deprecated.random">
+  <title>Random</title>
+
+  <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_lcg_value -->
+  <simpara>
+   <function>lcg_value</function> is now deprecated,
+   as the function is broken in multiple ways.
+   Use <methodname>Random\Randomizer::getFloat</methodname> instead.
+  </simpara>
+ </sect2>
+
+ <sect2 xml:id="migration84.deprecated.reflection">
+  <title>Reflection</title>
+
+  <simpara>
+   Calling <methodname>ReflectionMethod::__construct</methodname>
+   with one arguments is deprecated.
+   Use <methodname>ReflectionMethod::createFromMethodName</methodname> instead.
+  </simpara>
+ </sect2>
+
+ <sect2 xml:id="migration84.deprecated.session">
+  <title>Session</title>
+
+  <simpara>
+   Calling <function>session_set_save_handler</function>
+   with more than two arguments is deprecated.
+   Use the two arguments signature instead.
+  </simpara>
+
+  <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_4#sessionsid_length_and_sessionsid_bits_per_character -->
+  <simpara>
+   Changing the value of the
+   <link linkend="ini.session.sid-length"><literal>session.sid_length</literal></link> and
+   <link linkend="ini.session.sid-bits-per-character"><literal>session.sid_bits_per_character</literal></link>
+   INI settings is deprecated.
+   Update the session storage backend to accept 32 character hexadecimal
+   session IDs and stop changing these two INI settings instead.
+  </simpara>
+
+  <!-- RFC: https://wiki.php.net/rfc/deprecate-get-post-sessions -->
+  <simpara>
+   Changing the value of the
+   <link linkend="ini.session.use-only-cookies"><literal>session.use_only_cookies</literal></link>,
+   <link linkend="ini.session.use-trans-sid"><literal>session.use_trans_sid</literal></link>,
+   <link linkend="ini.session.trans-sid-tags"><literal>session.trans_sid_tags</literal></link>,
+   <link linkend="ini.session.trans-sid-hosts"><literal>session.trans_sid_hosts</literal></link>, and
+   <link linkend="ini.session.referer-check"><literal>session.referer_check</literal></link>
+   INI settings is deprecated.
+   The <constant>SID</constant> constant is also deprecated.
+  </simpara>
+ </sect2>
+
+ <sect2 xml:id="migration84.deprecated.core.soap">
+  <title>SOAP</title>
+
+  <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_soap_functions_all_constant_and_passing_it_to_soapserveraddfunction -->
+  <simpara>
+   Passing an <type>int</type> to
+   <methodname>SoapServer::addFunction</methodname> is now deprecated.
+   If all PHP functions need to be provided flatten the array returned by
+   <function>get_defined_functions</function>.
+  </simpara>
+
+  <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_soap_functions_all_constant_and_passing_it_to_soapserveraddfunction -->
+  <simpara>
+   The <constant>SOAP_FUNCTIONS_ALL</constant> constant is now deprecated.
+  </simpara>
+ </sect2>
+
+ <sect2 xml:id="migration84.deprecated.core.spl">
+  <title>SPL</title>
+
+  <simpara>
+   The <methodname>SplFixedArray::__wakeup</methodname> method is now
+   deprecated, as it implements
+   <methodname>SplFixedArray::__serialize</methodname> and
+   <methodname>SplFixedArray::__unserialize</methodname>
+   which need to be overwritten instead.
+  </simpara>
+
+  <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_proprietary_csv_escaping_mechanism -->
+  <simpara>
+   Using the default value for the <parameter>escape</parameter> parameter for the
+   <methodname>SplFileObject::setCsvControl</methodname>,
+   <methodname>SplFileObject::fputcsv</methodname>, and
+   <methodname>SplFileObject::fgetcsv</methodname> is now deprecated.
+   <!-- TODO: Link to named arguments feature -->
+   It must be passed explicitly either positionally or via named arguments.
+   This does not apply to <methodname>SplFileObject::fputcsv</methodname>
+   and <methodname>SplFileObject::fgetcsv</methodname> if
+   <methodname>SplFileObject::setCsvControl</methodname> was used to set a
+   new default value.
+  </simpara>
+ </sect2>
+
+ <sect2 xml:id="migration84.deprecated.standard">
+  <title>Standard</title>
+
+  <simpara>
+   Calling <function>stream_context_set_option</function>
+   with two arguments is deprecated.
+   Use <function>stream_context_set_options</function> instead.
+  </simpara>
+
+  <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_4#unserialize_s_s_tag -->
+  <simpara>
+   Unserializing strings using the uppercase <literal>S</literal> tag
+   with <function>unserialize</function> is deprecated.
+  </simpara>
+
+  <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_proprietary_csv_escaping_mechanism -->
+  <simpara>
+   Using the default value for the <parameter>escape</parameter> parameter for the
+   <function>fputcsv</function>,
+   <function>fgetcsv</function>, and
+   <function>str_getcsv</function>  is now deprecated.
+   <!-- TODO: Link to named arguments feature -->
+   It must be passed explicitly either positionally or via named arguments.
+  </simpara>
+ </sect2>
+
+ <sect2 xml:id="migration84.deprecated.core.xml">
+  <title>XML</title>
+
+  <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_4#xml_set_object_and_xml_set_handler_with_string_method_names -->
+  <simpara>
+   The <function>xml_set_object</function> function has been deprecated.
+  </simpara>
+
+  <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_4#xml_set_object_and_xml_set_handler_with_string_method_names -->
+  <simpara>
+   Passing non-<type>callable</type> strings to the
+   <function>xml_set_<replaceable>*</replaceable></function>
+   functions is now deprecated.
+  </simpara>
+ </sect2>
+
+</sect1>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/appendices/migration84/deprecated.xml
+++ b/appendices/migration84/deprecated.xml
@@ -1,21 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: e3fc9c49817a5249d1efb9c79c93307ecebf2f53 Maintainer: KentarouTakeda Status: ready -->
+<!-- Credits: KentarouTakeda -->
 <sect1 xml:id="migration84.deprecated">
- <title>Deprecated Features</title>
+ <title>PHP 8.4.x で推奨されなくなる機能</title>
 
  <sect2 xml:id="migration84.deprecated.core">
-  <title>PHP Core</title>
+  <title>PHP コア</title>
 
   <sect3 xml:id="migration84.deprecated.core.implicitly-nullable-parameter">
    <!-- RFC: https://wiki.php.net/rfc/deprecate-implicitly-nullable-types -->
-   <title>Implicitly nullable parameter</title>
+   <title>暗黙的な nullable パラメータ</title>
 
    <simpara>
-    A parameter's type is implicitly widened to accept <type>null</type>
-    if the default value for it is &null;.
+    パラメータのデフォルト値が &null; の場合、
+    その型は暗黙的に <type>null</type> を受け入れるように拡張されます。
    </simpara>
 
    <para>
-    The following code:
+    次のコードは:
     <informalexample>
      <programlisting role="php">
 <![CDATA[
@@ -24,7 +27,7 @@ function foo(T1 $a = null) {}
 ]]>
      </programlisting>
     </informalexample>
-    should be converted to:
+    このように:
     <informalexample>
      <programlisting role="php">
 <![CDATA[
@@ -33,7 +36,7 @@ function foo(T1|null $a = null) {}
 ]]>
      </programlisting>
     </informalexample>
-    or
+    またはこのように修正する必要があります。
     <informalexample>
      <programlisting role="php">
 <![CDATA[
@@ -45,8 +48,7 @@ function foo(?T1 $a = null) {}
    </para>
 
    <para>
-    However, if such a parameter declaration is followed by a mandatory
-    parameter:
+    しかし、そのようなパラメータ宣言の後に必須パラメータが続く場合:
     <informalexample>
      <programlisting role="php">
 <![CDATA[
@@ -55,7 +57,7 @@ function foo(T1 $a, T2 $b = null, T3 $c) {}
 ]]>
      </programlisting>
     </informalexample>
-    It must be converted to:
+    このように:
     <informalexample>
      <programlisting role="php">
 <![CDATA[
@@ -64,7 +66,7 @@ function foo(T1 $a, T2|null $b, T3 $c) {}
 ]]>
      </programlisting>
     </informalexample>
-    or
+    またはこのように修正する必要があります。
     <informalexample>
      <programlisting role="php">
 <![CDATA[
@@ -73,39 +75,43 @@ function foo(T1 $a, ?T2 $b, T3 $c) {}
 ]]>
      </programlisting>
     </informalexample>
-    as optional parameter before required ones are deprecated.
+    なぜなら、必須パラメータの前に任意パラメータを置くことは非推奨だからです。
    </para>
   </sect3>
 
   <sect3>
    <!-- RFC: https://wiki.php.net/rfc/raising_zero_to_power_of_negative_number -->
-   <title>Raising zero to the power of negative number</title>
+   <title>ゼロを負の数でべき乗</title>
 
    <simpara>
-    Raising a number to the power of a negative number is equivalent to taking
-    the reciprocal of the number raised to the positive opposite of the power.
-    Therefore raising <literal>0</literal> to the power of a negative number
-    corresponds to dividing by <literal>0</literal>.
-    Thus, this behaviour has been deprecated.
+    ある数の負のべき乗は、
+    その数の正のべき乗の逆数と同等です。
+    例えば、<literal>10<superscript>-2</superscript></literal> は
+    <literal>1 / 10<superscript>2</superscript></literal> と同等です。
+    つまり、<literal>0</literal>の負のべき乗は
+    <literal>0</literal> で割ることを意味します。例えば、
+    <literal>0<superscript>-2</superscript></literal> は
+    <literal>1 / 0<superscript>2</superscript></literal>、または
+    <literal>1 / 0</literal> となります。以上より、この動作は非推奨とされました。
    </simpara>
 
    <simpara>
-    This affects the exponentiation operator <literal>**</literal>
-    and the <function>pow</function> function.
+    これはべき乗演算子 <literal>**</literal> と
+    <function>pow</function> 関数に影響します。
    </simpara>
 
    <simpara>
-    If the IEEE 754 semantics are desired one should use the new
-    <function>fpow</function> function.
+    IEEE 754 のセマンティクスが必要な場合は、新しい
+    <function>fpow</function> 関数を使用してください。
    </simpara>
   </sect3>
 
   <sect3 xml:id="migration84.deprecated.core.underscore-class-name">
    <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_using_a_single_underscore_as_a_class_name -->
-   <title>Using underscore <literal>_</literal> as class name</title>
+   <title>クラス名をアンダースコア <literal>_</literal> とする</title>
 
    <para>
-    Naming a class <literal>_</literal> is now deprecated:
+    クラス名を <literal>_</literal> とすることは、現在非推奨となっています:
     <informalexample>
      <programlisting role="php">
 <![CDATA[
@@ -118,8 +124,8 @@ class _ {}
 
    <note>
     <para>
-     Classes whose names start with an underscore are <emphasis>not</emphasis>
-     deprecated:
+     クラス名がアンダースコアで始まるのは、
+     非推奨では<emphasis>ありません</emphasis>:
      <informalexample>
       <programlisting role="php">
 <![CDATA[
@@ -135,31 +141,31 @@ class _MyClass {}
   <sect3>
    <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_passing_e_user_error_to_trigger_error -->
    <title>
-    Using <function>trigger_error</function> with
-    <constant>E_USER_ERROR</constant>
+    <function>trigger_error</function> で
+    <constant>E_USER_ERROR</constant> を使用
    </title>
 
    <simpara>
-    Calling <function>trigger_error</function> with
-    <parameter>error_level</parameter> being equal to
-    <constant>E_USER_ERROR</constant> is now deprecated.
+    <function>trigger_error</function> で
+    <parameter>error_level</parameter> として
+    <constant>E_USER_ERROR</constant> を指定するのは非推奨となりました。
    </simpara>
 
    <simpara>
-    Such usages should be replaced by either throwing an exception,
-    or calling <function>exit</function>, whichever is more appropriate.
+    そのような場合、例外をスローするか、
+    <function>exit</function> を呼び出すように修正すべきです。
    </simpara>
   </sect3>
 
   <sect3>
    <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_4#remove_e_strict_error_level_and_deprecate_e_strict_constant -->
    <title>
-    The <constant>E_STRICT</constant> constant
+    <constant>E_STRICT</constant> 定数
    </title>
 
    <simpara>
-    Because the <constant>E_STRICT</constant> error level was removed,
-    this constant is now deprecated.
+    <constant>E_STRICT</constant> エラーレベルが削除されたため、
+    この定数は非推奨となりました。
    </simpara>
   </sect3>
  </sect2>
@@ -168,7 +174,7 @@ class _MyClass {}
   <title>cURL</title>
 
   <simpara>
-   The <constant>CURLOPT_BINARYTRANSFER</constant> constant is now deprecated.
+   <constant>CURLOPT_BINARYTRANSFER</constant> 定数は非推奨となりました。
   </simpara>
  </sect2>
 
@@ -176,18 +182,18 @@ class _MyClass {}
   <title>Date</title>
 
   <simpara>
-   The <code> DatePeriod::__construct(string $isostr, int $options = 0)</code>
-   signature has been deprecated.
-   Use <methodname>DatePeriod::createFromISO8601String</methodname> instead.
+   <code> DatePeriod::__construct(string $isostr, int $options = 0)</code> の
+   シグネチャは非推奨となりました。
+   代わりに <methodname>DatePeriod::createFromISO8601String</methodname> を使用してください。
   </simpara>
 
   <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_4#constants_sunfuncs_ret_string_sunfuncs_ret_double_sunfuncs_ret_timestamp -->
   <simpara>
-   The <constant>SUNFUNCS_RET_TIMESTAMP</constant>,
-   <constant>SUNFUNCS_RET_STRING</constant>,
-   and <constant>SUNFUNCS_RET_DOUBLE</constant> constants are now deprecated.
-   This follows from the deprecation of the <function>date_sunset</function> and
-   <function>date_sunrise</function> functions in PHP 8.1.0.
+   <constant>SUNFUNCS_RET_TIMESTAMP</constant>、
+   <constant>SUNFUNCS_RET_STRING</constant>、
+   および <constant>SUNFUNCS_RET_DOUBLE</constant> 定数は非推奨となりました。
+   これは PHP 8.1.0 で <function>date_sunset</function> と
+   <function>date_sunrise</function> 関数が非推奨となったことに伴うものです。
   </simpara>
  </sect2>
 
@@ -196,9 +202,9 @@ class _MyClass {}
 
   <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_passing_null_and_false_to_dba_key_split -->
   <simpara>
-   Passing &null; or &false; to <function>dba_key_split</function> is now
-   deprecated.
-   It would always return &false; in those cases.
+   <function>dba_key_split</function> に &null; または &false; を渡すことは
+   非推奨となりました。
+   これらの場合、常に &false; を返していました。
   </simpara>
  </sect2>
 
@@ -207,12 +213,12 @@ class _MyClass {}
 
   <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_dom_php_err_constant -->
   <simpara>
-   The <constant>DOM_PHP_ERR</constant> constant is now deprecated.
+   <constant>DOM_PHP_ERR</constant> 定数は非推奨となりました。
   </simpara>
 
   <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_4#formally_deprecate_soft-deprecated_domdocument_and_domentity_properties -->
   <para>
-   The following properties have been formally deprecated:
+   以下のプロパティは正式に非推奨となりました:
    <simplelist>
     <member><property>DOMDocument::$actualEncoding</property></member>
     <member><property>DOMDocument::$config</property></member>
@@ -228,7 +234,7 @@ class _MyClass {}
 
   <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_passing_incorrect_data_types_for_options_to_exthash_functions -->
   <simpara>
-   Passing invalid options to hash functions is now deprecated.
+   ハッシュ関数に無効なオプションを渡すことは非推奨となりました。
   </simpara>
  </sect2>
 
@@ -236,19 +242,19 @@ class _MyClass {}
   <title>Intl</title>
 
   <simpara>
-   Calling <function>intlcal_set</function> or
+   <function>intlcal_set</function> または
    <methodname>IntlCalendar::set</methodname>
-   with more than two arguments is deprecated.
-   Use either <methodname>IntlCalendar::setDate</methodname> or
-   <methodname>IntlCalendar::setDateTime</methodname> instead.
+   を 2 つを超える引数で呼び出すことは非推奨となりました。
+   代わりに <methodname>IntlCalendar::setDate</methodname> または
+   <methodname>IntlCalendar::setDateTime</methodname> を使用してください。
   </simpara>
 
   <simpara>
-   Calling <function>intlgregcal_create_instance</function> or
+   <function>intlgregcal_create_instance</function> または
    <methodname>IntlGregorianCalendar::__construct</methodname>
-   with more than two arguments is deprecated.
-   Use either <methodname>IntlGregorianCalendar::createFromDate</methodname> or
-   <methodname>IntlGregorianCalendar::createFromDateTime</methodname> instead.
+   を 2 つを超える引数で呼び出すことは非推奨となりました。
+   代わりに <methodname>IntlGregorianCalendar::createFromDate</methodname> または
+   <methodname>IntlGregorianCalendar::createFromDateTime</methodname> を使用してください。
   </simpara>
  </sect2>
 
@@ -256,15 +262,15 @@ class _MyClass {}
   <title>LDAP</title>
 
   <simpara>
-   Calling <function>ldap_connect</function>
-   with more than two arguments is deprecated.
-   Use <function>ldap_connect_wallet</function> instead.
+   <function>ldap_connect</function> を
+   2 つを超える引数で呼び出すことは非推奨となりました。
+   代わりに <function>ldap_connect_wallet</function> を使用してください。
   </simpara>
 
   <simpara>
-   Calling <function>ldap_exop</function>
-   with more than four arguments is deprecated.
-   Use <function>ldap_exop_sync</function> instead.
+   <function>ldap_exop</function>
+   を 4 つを超える引数で呼び出すことは非推奨となりました。
+   代わりに <function>ldap_exop_sync</function> を使用してください。
   </simpara>
  </sect2>
 
@@ -273,37 +279,37 @@ class _MyClass {}
 
   <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_4#mysqli_ping_and_mysqliping -->
   <simpara>
-   The <function>mysqli_ping</function> function and
-   <methodname>mysqli::ping</methodname> method
-   are now deprecated as the reconnect feature was removed in PHP 8.2.0.
+   <function>mysqli_ping</function> 関数および
+   <methodname>mysqli::ping</methodname> メソッドは、
+   PHP 8.2.0 で再接続機能が削除されたため、非推奨となりました。
   </simpara>
 
   <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_mysqli_kill -->
   <simpara>
-   The <function>mysqli_kill</function> function and
-   <methodname>mysqli::kill</methodname> method
-   are now deprecated.
-   If this functionality is needed a SQL <literal>KILL</literal> command
-   can be used instead.
+   <function>mysqli_kill</function> 関数および
+   <methodname>mysqli::kill</methodname> メソッド
+   は非推奨となりました。
+   この機能が必要な場合は、代わりに SQL の <literal>KILL</literal>
+   コマンドを使用できます。
   </simpara>
 
   <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_mysqli_refresh -->
   <simpara>
-   The <function>mysqli_refresh</function> function and
-   <methodname>mysqli::refresh</methodname> method
-   are now deprecated.
-   If this functionality is needed a SQL <literal>FLUSH</literal> command
-   can be used instead.
-   All <constant>MYSQLI_REFRESH_<replaceable>*</replaceable></constant>
-   constants have been deprecated as well.
+   <function>mysqli_refresh</function> 関数および
+   <methodname>mysqli::refresh</methodname> メソッドは
+   非推奨となりました。
+   この機能が必要な場合は、代わりに SQL の <literal>FLUSH</literal> コマンド
+   を使用できます。
+   すべての <constant>MYSQLI_REFRESH_<replaceable>*</replaceable></constant>
+   定数も非推奨となりました。
   </simpara>
 
   <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_the_second_parameter_to_mysqli_store_result -->
   <simpara>
-   Passing the <parameter>mode</parameter> parameter to
-   <function>mysqli_store_result</function> explicitly has been deprecated.
-   As the <constant>MYSQLI_STORE_RESULT_COPY_DATA</constant> constant was
-   only used in conjunction with this function it has also been deprecated.
+   <function>mysqli_store_result</function> に
+   <parameter>mode</parameter> パラメータを明示的に渡すことは非推奨となりました。
+   この関数のために用意されていた<constant>MYSQLI_STORE_RESULT_COPY_DATA</constant> 定数も
+   非推奨となりました。
   </simpara>
  </sect2>
 
@@ -311,10 +317,10 @@ class _MyClass {}
   <title>PDO_PGSQL</title>
 
   <simpara>
-   Using escaped question marks (<literal>??</literal>) inside
-   dollar-quoted strings is deprecated.
-   Because PDO_PGSQL now has its own SQL parser with dollar-quoted strings
-   support, it is no longer necessary to escape question marks inside them.
+   ドル記号で囲まれた文字列の中で
+   エスケープされた疑問符（<literal>??</literal>）を使用することは非推奨となりました。
+   PDO_PGSQL はドル記号で囲まれた文字列をサポートする独自の SQL パーサーを持つようになったため、
+   それらの中で疑問符をエスケープする必要はなくなりました。
   </simpara>
  </sect2>
 
@@ -322,11 +328,11 @@ class _MyClass {}
   <title>PGSQL</title>
 
   <simpara>
-   The 2 arguments signature of <function>pg_fetch_result</function>,
-   <function>pg_field_prtlen</function>, and
-   <function>pg_field_is_null</function> is now deprecated.
-   Use the 3 arguments signature with <parameter>row</parameter> set to
-   &null; instead.
+   <function>pg_fetch_result</function>、
+   <function>pg_field_prtlen</function>、
+   および <function>pg_field_is_null</function> の 2 引数のシグネチャは非推奨となりました。
+   代わりに <parameter>row</parameter> を &null; に設定した 3 引数のシグネチャを
+   使用してください。
   </simpara>
  </sect2>
 
@@ -335,9 +341,9 @@ class _MyClass {}
 
   <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_lcg_value -->
   <simpara>
-   <function>lcg_value</function> is now deprecated,
-   as the function is broken in multiple ways.
-   Use <methodname>Random\Randomizer::getFloat</methodname> instead.
+   <function>lcg_value</function> は非推奨となりました。
+   この関数は複数の点で問題があるためです。
+   代わりに <methodname>Random\Randomizer::getFloat</methodname> を使用してください。
   </simpara>
  </sect2>
 
@@ -345,9 +351,9 @@ class _MyClass {}
   <title>Reflection</title>
 
   <simpara>
-   Calling <methodname>ReflectionMethod::__construct</methodname>
-   with one arguments is deprecated.
-   Use <methodname>ReflectionMethod::createFromMethodName</methodname> instead.
+   <methodname>ReflectionMethod::__construct</methodname> を
+   1 つの引数で呼び出すことは非推奨となりました。
+   代わりに <methodname>ReflectionMethod::createFromMethodName</methodname> を使用してください。
   </simpara>
  </sect2>
 
@@ -355,31 +361,29 @@ class _MyClass {}
   <title>Session</title>
 
   <simpara>
-   Calling <function>session_set_save_handler</function>
-   with more than two arguments is deprecated.
-   Use the two arguments signature instead.
+   <function>session_set_save_handler</function> を
+   2 つを超える引数で呼び出すことは非推奨となりました。
+   2 引数のシグネチャを使用してください。
   </simpara>
 
   <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_4#sessionsid_length_and_sessionsid_bits_per_character -->
   <simpara>
-   Changing the value of the
-   <link linkend="ini.session.sid-length"><literal>session.sid_length</literal></link> and
+   <link linkend="ini.session.sid-length"><literal>session.sid_length</literal></link> および
    <link linkend="ini.session.sid-bits-per-character"><literal>session.sid_bits_per_character</literal></link>
-   INI settings is deprecated.
-   Update the session storage backend to accept 32 character hexadecimal
-   session IDs and stop changing these two INI settings instead.
+   の INI 設定値を変更することは非推奨となりました。
+   セッションストレージバックエンドを修正し、 16 進数 32 文字による
+   セッション ID を受け入れるようにし、これら 2 つの INI 設定を変更するのをやめてください。
   </simpara>
 
   <!-- RFC: https://wiki.php.net/rfc/deprecate-get-post-sessions -->
   <simpara>
-   Changing the value of the
-   <link linkend="ini.session.use-only-cookies"><literal>session.use_only_cookies</literal></link>,
-   <link linkend="ini.session.use-trans-sid"><literal>session.use_trans_sid</literal></link>,
-   <link linkend="ini.session.trans-sid-tags"><literal>session.trans_sid_tags</literal></link>,
-   <link linkend="ini.session.trans-sid-hosts"><literal>session.trans_sid_hosts</literal></link>, and
+   <link linkend="ini.session.use-only-cookies"><literal>session.use_only_cookies</literal></link>、
+   <link linkend="ini.session.use-trans-sid"><literal>session.use_trans_sid</literal></link>、
+   <link linkend="ini.session.trans-sid-tags"><literal>session.trans_sid_tags</literal></link>、
+   <link linkend="ini.session.trans-sid-hosts"><literal>session.trans_sid_hosts</literal></link>、および
    <link linkend="ini.session.referer-check"><literal>session.referer_check</literal></link>
-   INI settings is deprecated.
-   The <constant>SID</constant> constant is also deprecated.
+   の INI 設定値を変更することは非推奨となりました。
+   <constant>SID</constant> 定数も非推奨となりました。
   </simpara>
  </sect2>
 
@@ -388,15 +392,15 @@ class _MyClass {}
 
   <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_soap_functions_all_constant_and_passing_it_to_soapserveraddfunction -->
   <simpara>
-   Passing an <type>int</type> to
-   <methodname>SoapServer::addFunction</methodname> is now deprecated.
-   If all PHP functions need to be provided flatten the array returned by
-   <function>get_defined_functions</function>.
+   <methodname>SoapServer::addFunction</methodname> に
+   <type>int</type> を渡すことは非推奨となりました。
+   すべての PHP 関数を提供する必要がある場合は、
+   <function>get_defined_functions</function> が返す配列をフラット化してください。
   </simpara>
 
   <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_soap_functions_all_constant_and_passing_it_to_soapserveraddfunction -->
   <simpara>
-   The <constant>SOAP_FUNCTIONS_ALL</constant> constant is now deprecated.
+   <constant>SOAP_FUNCTIONS_ALL</constant> 定数は非推奨となりました。
   </simpara>
  </sect2>
 
@@ -404,25 +408,24 @@ class _MyClass {}
   <title>SPL</title>
 
   <simpara>
-   The <methodname>SplFixedArray::__wakeup</methodname> method is now
-   deprecated, as it implements
-   <methodname>SplFixedArray::__serialize</methodname> and
+   <methodname>SplFixedArray::__wakeup</methodname> メソッドは
+   非推奨となりました。代わりに
+   <methodname>SplFixedArray::__serialize</methodname> と
    <methodname>SplFixedArray::__unserialize</methodname>
-   which need to be overwritten instead.
+   をオーバーライドしてください。
   </simpara>
 
   <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_proprietary_csv_escaping_mechanism -->
   <simpara>
-   Using the default value for the <parameter>escape</parameter> parameter for the
-   <methodname>SplFileObject::setCsvControl</methodname>,
-   <methodname>SplFileObject::fputcsv</methodname>, and
-   <methodname>SplFileObject::fgetcsv</methodname> is now deprecated.
+   <methodname>SplFileObject::setCsvControl</methodname>、
+   <methodname>SplFileObject::fputcsv</methodname>、および
+   <methodname>SplFileObject::fgetcsv</methodname> で
+   <parameter>escape</parameter> パラメータのデフォルト値を利用することは非推奨となりました。
    <!-- TODO: Link to named arguments feature -->
-   It must be passed explicitly either positionally or via named arguments.
-   This does not apply to <methodname>SplFileObject::fputcsv</methodname>
-   and <methodname>SplFileObject::fgetcsv</methodname> if
-   <methodname>SplFileObject::setCsvControl</methodname> was used to set a
-   new default value.
+   引数または名前付き引数で明示的に指定する必要があります。
+   これは、<methodname>SplFileObject::setCsvControl</methodname> で
+   新しいデフォルト値を設定した場合、<methodname>SplFileObject::fputcsv</methodname> および
+   <methodname>SplFileObject::fgetcsv</methodname> には適用されません。
   </simpara>
  </sect2>
 
@@ -430,25 +433,25 @@ class _MyClass {}
   <title>Standard</title>
 
   <simpara>
-   Calling <function>stream_context_set_option</function>
-   with two arguments is deprecated.
-   Use <function>stream_context_set_options</function> instead.
+   <function>stream_context_set_option</function> を
+   2 つの引数で呼び出すことは非推奨となりました。
+   代わりに <function>stream_context_set_options</function> を使用してください。
   </simpara>
 
   <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_4#unserialize_s_s_tag -->
   <simpara>
-   Unserializing strings using the uppercase <literal>S</literal> tag
-   with <function>unserialize</function> is deprecated.
+   <function>unserialize</function> で大文字の <literal>S</literal> タグを使用して文字列を
+   アンシリアライズすることは非推奨となりました。
   </simpara>
 
   <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_proprietary_csv_escaping_mechanism -->
   <simpara>
-   Using the default value for the <parameter>escape</parameter> parameter for the
-   <function>fputcsv</function>,
-   <function>fgetcsv</function>, and
-   <function>str_getcsv</function>  is now deprecated.
+   <function>fputcsv</function>、
+   <function>fgetcsv</function>、および
+   <function>str_getcsv</function> の
+   <parameter>escape</parameter> パラメータのデフォルト値を利用することは非推奨となりました。
    <!-- TODO: Link to named arguments feature -->
-   It must be passed explicitly either positionally or via named arguments.
+   引数または名前付き引数で明示的に指定する必要があります。
   </simpara>
  </sect2>
 
@@ -457,14 +460,14 @@ class _MyClass {}
 
   <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_4#xml_set_object_and_xml_set_handler_with_string_method_names -->
   <simpara>
-   The <function>xml_set_object</function> function has been deprecated.
+   <function>xml_set_object</function> 関数は非推奨となりました。
   </simpara>
 
   <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_4#xml_set_object_and_xml_set_handler_with_string_method_names -->
   <simpara>
-   Passing non-<type>callable</type> strings to the
+   <type>callable</type> でない文字列を
    <function>xml_set_<replaceable>*</replaceable></function>
-   functions is now deprecated.
+   関数に渡すことは非推奨となりました。
   </simpara>
  </sect2>
 

--- a/appendices/migration84/incompatible.xml
+++ b/appendices/migration84/incompatible.xml
@@ -1,0 +1,843 @@
+<?xml version="1.0" encoding="utf-8"?>
+<sect1 xml:id="migration84.incompatible" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>Backward Incompatible Changes</title>
+
+ <simpara>
+  Although not explicitly stated in this section,
+  every new <link linkend="migration84.new-functions">function</link>,
+  <link linkend="migration84.new-classes">class, interface, enum</link>,
+  or <link linkend="migration84.constants">constant</link>
+  may cause a redeclaration <exceptionname>Error</exceptionname> to be thrown.
+ </simpara>
+
+ <sect2 xml:id="migration84.incompatible.core">
+  <title>PHP Core</title>
+
+  <!-- RFC: https://wiki.php.net/rfc/exit-as-function -->
+  <sect3 xml:id="migration84.incompatible.core.exit">
+   <title><function>exit</function> behavioral change</title>
+
+   <simpara>
+    The <function>exit</function> (and <function>die</function>) language
+    constructs now behave more like a function.
+    This means that they can now be passed like <type>callable</type>s,
+    <!-- TODO: Link to declare documentation/type juggling documentation -->
+    are affected by the <literal>strict_types</literal> declare statement,
+    and now perform the usual type coercions instead of casting any non-integer
+    value to a string.
+   </simpara>
+
+   <simpara>
+    As such, passing invalid types to <function>exit</function> and
+    <function>die</function> now consistently result in a
+    <exceptionname>TypeError</exceptionname> being thrown.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.incompatible.core.recursion-comparison">
+   <title>Recursion during comparison</title>
+
+   <simpara>
+    Encountering recursion during comparison now results in an
+    <exceptionname>Error</exceptionname> exception instead of a
+    <constant>E_ERROR</constant> fatal error.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.incompatible.core.readonly-indirect-modification">
+   <title>Indirect Modification of readonly Properties</title>
+
+   <!-- TODO Link to clone magic method, and explain this better as UPGRADING is... -->
+   <simpara>
+    Indirect modification of readonly properties within <code>__clone()</code>
+    is no longer allowed, e.g. <code>$ref = &amp;$this->readonly</code>.
+    This was already forbidden for readonly initialization, and was an
+    oversight in the "readonly reinitialization during cloning" implementation.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.incompatible.core.constant-type-change">
+   <title>Type Change of Constants</title>
+
+   <simpara>
+    The <constant>PHP_DEBUG</constant> and <constant>PHP_ZTS</constant>
+    constants are now of type <type>bool</type>.
+    Previously they were of type <type>int</type>.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.incompatible.core.tempnam-length">
+   <title>Temporary Filename Length</title>
+
+   <simpara>
+    The name of uploaded files and files created by the
+    <function>tempnam</function> function are now 13 bytes longer.
+    The total length is still platform-dependent.
+   </simpara>
+  </sect3>
+
+  <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_4#remove_e_strict_error_level_and_deprecate_e_strict_constant -->
+  <sect3 xml:id="migration84.incompatible.core.e-strict">
+   <title>Removal of <constant>E_STRICT</constant> error level</title>
+
+   <simpara>
+    The <constant>E_STRICT</constant> error level has been removed,
+    as it was no longer in use within the PHP engine.
+    The <constant>E_STRICT</constant> constant has been deprecated.
+   </simpara>
+  </sect3>
+ </sect2>
+
+ <sect2 xml:id="migration84.incompatible.typed-constants">
+  <title>Extension Class Constants which are now Typed</title>
+
+  <para>
+   The following extension class constants now declare a type on their
+   constants:
+   <simplelist>
+    <member><link linkend="book.datetime">Date</link></member>
+    <member><link linkend="book.intl">Intl</link></member>
+    <member><link linkend="book.pdo">PDO</link></member>
+    <member><link linkend="book.reflection">Reflection</link></member>
+    <member><link linkend="book.spl">SPL</link></member>
+    <member><link linkend="book.sqlite3">Sqlite</link></member>
+    <member><link linkend="book.xmlreader">XMLReader</link></member>
+   </simplelist>
+  </para>
+ </sect2>
+
+ <!-- TODO: Check resource names -->
+ <sect2 xml:id="migration84.incompatible.resource2object">
+  <title>Resource to Object Migration</title>
+
+  <simpara>
+   Several &resource;s have been migrated to &object;s.
+   Return value checks using <function>is_resource</function> should be
+   replaced with checks for &false;, unless specified otherwise.
+  </simpara>
+
+  <sect3 xml:id="migration84.incompatible.resource2object.dba">
+   <title>DBA</title>
+
+   <simpara>
+    The <link linkend="book.dba">DBA</link> functions now accept and return
+    <classname>Dba\Connection</classname> objects instead of
+    <literal>dba_connection</literal> &resource;s.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.incompatible.resource2object.odbc">
+   <title>ODBC</title>
+
+   <simpara>
+    The <link linkend="book.uodbc">ODBC</link> functions now accept and return
+    <classname>Odbc\Result</classname> objects instead of
+    <literal>odbc_result</literal> &resource;s.
+   </simpara>
+
+   <simpara>
+    The <link linkend="book.uodbc">ODBC</link> functions now accept and return
+    <classname>Odbc\Connection</classname> objects instead of
+    <literal>odbc_connection</literal> &resource;s.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.incompatible.resource2object.soap">
+   <title>SOAP</title>
+
+   <simpara>
+    The <property>SoapClient::$httpurl</property> property is now a
+    <classname>Soap\Url</classname> object rather than a
+    <literal>soap_url</literal> &resource;.
+    Checks using <function>is_resource</function> (i.e.
+    <code>is_resource($client->httpurl)</code>) should be  replaced with checks
+    for &null; (i.e. <code>$client->httpurl !== null</code>).
+   </simpara>
+   <simpara>
+    The <property>SoapClient::$sdl</property> property is now a
+    <classname>Soap\Sdl</classname> object rather than a
+    <literal>soap_sdl</literal> &resource;.
+    Checks using <function>is_resource</function> (i.e.
+    <code>is_resource($client->sdl)</code>) should be  replaced with checks
+    for &null; (i.e. <code>$client->sdl !== null</code>).
+   </simpara>
+  </sect3>
+ </sect2>
+
+ <sect2 xml:id="migration84.incompatible.new-warnings-exceptions">
+  <title>New warnings and exceptions</title>
+
+  <simpara>
+   New warnings and exceptions have been added which are triggered on
+   programming errors, i.e. invalid values provided as arguments.
+  </simpara>
+
+  <sect3 xml:id="migration84.incompatible.new-warnings-exceptions.curl">
+   <title>Curl</title>
+
+   <simpara>
+    <function>curl_multi_select</function> now throws a
+    <exceptionname>ValueError</exceptionname> if the
+    <parameter>timeout</parameter> parameter is less than
+    <literal>0</literal> or greater than <constant>PHP_INT_MAX</constant>.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.incompatible.new-warnings-exceptions.gd">
+   <title>Gd</title>
+
+   <para>
+    <simplelist type="inline">
+     <member><function>imagejpeg</function></member>
+     <member><function>imagewebp</function></member>
+     <member><function>imagepng</function></member>
+     <member><function>imageavif</function></member>
+    </simplelist>
+    now throw a <exceptionname>ValueError</exceptionname> when an invalid
+    <parameter>quality</parameter> is passed.
+   </para>
+
+   <simpara>
+    <function>imageavif</function> will now throw a
+    <exceptionname>ValueError</exceptionname> if an invalid
+    <parameter>speed</parameter> parameter value is passed.
+   </simpara>
+
+   <simpara>
+    <function>imagescale</function> will now throw a
+    <exceptionname>ValueError</exceptionname> if the
+    <parameter>width</parameter> or <parameter>height</parameter>
+    parameters underflows/overflows.
+   </simpara>
+
+   <simpara>
+    <function>imagescale</function> will now throw a
+    <exceptionname>ValueError</exceptionname> if an invalid
+    <parameter>mode</parameter> parameter value is passed.
+   </simpara>
+
+   <simpara>
+    <function>imagefilter</function> will now throw a
+    <exceptionname>ValueError</exceptionname> with the
+    <constant>IMG_FILTER_SCATTER</constant> filter
+    if the <parameter>sub</parameter> or <parameter>plus</parameter>
+    parameters underflows/overflows.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.incompatible.new-warnings-exceptions.gettext">
+   <title>Gettext</title>
+
+   <para>
+    <simplelist type="inline">
+     <member><function>bind_textdomain_codeset</function></member>
+     <member><function>textdomain</function></member>
+     <member><function>d<replaceable>*</replaceable>gettext</function></member>
+    </simplelist>
+    now throw a <exceptionname>ValueError</exceptionname> if
+    <parameter>domain</parameter> is the empty string.
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration84.incompatible.new-warnings-exceptions.intl">
+   <title>Intl</title>
+
+   <para>
+    <function>resourcebundle_get</function>,
+    <methodname>ResourceBundle::get</methodname>, and accessing offsets on
+    a <classname>ResourceBundle</classname> object now throw:
+    <simplelist>
+     <member>
+      <exceptionname>TypeError</exceptionname> for invalid offset types
+     </member>
+     <member>
+      <exceptionname>ValueError</exceptionname> for an empty &string;
+     </member>
+     <member>
+      <exceptionname>ValueError</exceptionname> if the integer index does
+      not fit in a signed 32 bit integer
+     </member>
+    </simplelist>
+   </para>
+
+   <simpara>
+    <methodname>IntlDateFormatter::__construct</methodname> throws a
+    <exceptionname>ValueError</exceptionname> if the
+    <parameter>locale</parameter> is invalid.
+   </simpara>
+
+   <simpara>
+    <methodname>NumberFormatter::__construct</methodname> throws a
+    <exceptionname>ValueError</exceptionname> if the
+    <parameter>locale</parameter> is invalid.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.incompatible.new-warnings-exceptions.mbstring">
+   <title>MBString</title>
+
+   <simpara>
+    <function>mb_encode_numericentity</function> and
+    <function>mb_decode_numericentity</function> now check that the
+    <parameter>map</parameter> is only composed of &integer;s,
+    if not a <exceptionname>ValueError</exceptionname> is now thrown.
+   </simpara>
+
+   <simpara>
+    <function>mb_http_input</function> now always throw a
+    <exceptionname>ValueError</exceptionname> if <parameter>type</parameter>
+    is invalid.
+   </simpara>
+
+   <simpara>
+    <function>mb_http_output</function> now check that the
+    <parameter>encoding</parameter> does not contain any null bytes,
+    if it does a <exceptionname>ValueError</exceptionname> is now thrown.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.incompatible.new-warnings-exceptions.odbc">
+   <title>ODBC</title>
+
+   <simpara>
+    <function>odbc_fetch_row</function> returns &false; when
+    <parameter>row</parameter> is less than or equal to <literal>0</literal>.
+    A warning is now emitted in this case.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.incompatible.new-warnings-exceptions.pcntl">
+   <title>PCNTL</title>
+
+   <para>
+    The <function>pcntl_sigprocmask</function>,
+    <function>pcntl_sigwaitinfo</function>, and
+    <function>pcntl_sigtimedwait</function> functions now throw:
+    <simplelist>
+     <member>
+      A <exceptionname>ValueError</exceptionname> if the
+      <parameter>signals</parameter> array is empty
+      (except for <function>pcntl_sigprocmask</function> if the
+      <parameter>mode</parameter> <constant>SIG_SETMASK</constant>)
+     </member>
+     <member>
+      A <exceptionname>TypeError</exceptionname> if a value of the
+      <parameter>signals</parameter> array is not an &integer;
+     </member>
+     <member>
+      A <exceptionname>ValueError</exceptionname> if a value of the
+      <parameter>signals</parameter> array is not a valid signal number
+     </member>
+    </simplelist>
+   </para>
+
+   <simpara>
+    The <function>pcntl_sigprocmask</function> function now throws a
+    <exceptionname>ValueError</exceptionname> if the
+    <parameter>mode</parameter> is not one of <constant>SIG_BLOCK</constant>,
+    <constant>SIG_UNBLOCK</constant>, or <constant>SIG_SETMASK</constant>.
+   </simpara>
+
+   <para>
+    The <function>pcntl_sigtimedwait</function> function now throw:
+    <simplelist>
+     <member>
+      A <exceptionname>ValueError</exceptionname> if
+      <parameter>seconds</parameter> is less than <literal>0</literal>
+     </member>
+     <member>
+      A <exceptionname>ValueError</exceptionname> if
+      <parameter>nanoseconds</parameter> is less than <literal>0</literal>
+      or greater than <literal>1e9</literal>
+     </member>
+     <member>
+      A <exceptionname>ValueError</exceptionname> if both
+      <parameter>seconds</parameter> and <parameter>nanoseconds</parameter>
+      are <literal>0</literal>
+     </member>
+    </simplelist>
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration84.incompatible.new-warnings-exceptions.simplexml">
+   <title>SimpleXML</title>
+
+   <simpara>
+    Calling <function>simplexml_import_dom</function> with a non-XML object
+    now throws a <exceptionname>TypeError</exceptionname> instead of a
+    <exceptionname>ValueError</exceptionname>.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.incompatible.new-warnings-exceptions.standard">
+   <title>Standard</title>
+
+   <simpara>
+    The <function>round</function> function now validates the value of the
+    <parameter>mode</parameter> and throw a
+    <exceptionname>ValueError</exceptionname> for invalid modes.
+    Previously, invalid modes would have been interpreted as
+    <constant>PHP_ROUND_HALF_UP</constant>.
+   </simpara>
+
+   <simpara>
+    The <function>str_getcsv</function> now throws
+    <exceptionname>ValueError</exceptionname>s when the
+    <parameter>separator</parameter> and <parameter>enclosure</parameter>
+    arguments are not one byte long, or if the <parameter>escape</parameter>
+    argument is not one byte long nor the empty string.
+    This aligns the behaviour to be identical to the one of
+    <function>fputcsv</function> and <function>fgetcsv</function>.
+   </simpara>
+
+   <simpara>
+    The <function>php_uname</function> function now throws a
+    <exceptionname>ValueError</exceptionname> if the
+    <parameter>mode</parameter> is invalid.
+   </simpara>
+
+   <simpara>
+    The <literal>"allowed_classes"</literal> option for
+    <function>unserialize</function> now throws
+    <exceptionname>TypeError</exceptionname>s and
+    <exceptionname>ValueError</exceptionname>s if it is not an
+    <type>array</type> of class names.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.incompatible.new-warnings-exceptions.xmlreader">
+   <title>XMLReader</title>
+
+   <simpara>
+    Passing an invalid character encoding to
+    <methodname>XMLReader::open</methodname> or
+    <methodname>XMLReader::XML</methodname> now throws a
+    <exceptionname>ValueError</exceptionname>.
+   </simpara>
+
+   <simpara>
+    Passing a &string; containing null bytes previously emitted a
+    warning and now throws a <exceptionname>ValueError</exceptionname>.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.incompatible.new-warnings-exceptions.xmlwriter">
+   <title>XMLWriter</title>
+
+   <simpara>
+    Passing a &string; containing null bytes previously emitted a
+    warning and now throws a <exceptionname>ValueError</exceptionname>.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.incompatible.new-warnings-exceptions.xsl">
+   <title>XSL</title>
+
+   <simpara>
+    <methodname>XSLTProcessor::setParameter</methodname> will now throw a
+    <exceptionname>ValueError</exceptionname> when its arguments contain null
+    bytes. This never actually worked correctly in the first place,
+    which is why it throws an exception now.
+   </simpara>
+
+   <simpara>
+    Calling <methodname>XSLTProcessor::importStyleSheet</methodname> with a
+    non-XML object now throws a <exceptionname>TypeError</exceptionname>
+    instead of a <exceptionname>ValueError</exceptionname>.
+   </simpara>
+
+   <!-- RFC: https://wiki.php.net/rfc/improve_callbacks_dom_and_xsl -->
+   <simpara>
+    Failure to call a PHP function callback during evaluation now throws
+    instead of emitting a warning.
+   </simpara>
+  </sect3>
+ </sect2>
+
+ <sect2 xml:id="migration84.incompatible.dom">
+  <title>DOM</title>
+
+  <simpara>
+   Some DOM methods previously returned &false; or a
+   <exceptionname>DOMException</exceptionname> with code
+   <constant>DOM_PHP_ERR</constant> if a new node could not be allocated.
+   They now consistently throw a <exceptionname>DOMException</exceptionname>
+   with code <constant>DOM_INVALID_STATE_ERR</constant>.
+   This situation is extremely unlikely and the probability of being affected
+   is low.
+   As a result <methodname>DOMImplementation::createDocument</methodname>
+   now has a tentative return type of <classname>DOMDocument</classname>
+   <!-- TODO: Use a proper union type for linkage -->
+   instead of <code>DOMDocument|false</code>.
+  </simpara>
+
+  <simpara>
+   Previously, <classname>DOMXPath</classname> objects could be cloned,
+   but resulted in an unusable object.
+   This is no longer possible, and cloning a <classname>DOMXPath</classname>
+   object now throws an <exceptionname>Error</exceptionname>.
+  </simpara>
+
+  <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_4#remove_domimplementationgetfeature_feature_version -->
+  <simpara>
+   The <methodname>DOMImplementation::getFeature</methodname> method has been removed.
+  </simpara>
+ </sect2>
+
+ <sect2 xml:id="migration84.incompatible.gmp">
+  <title>GMP</title>
+
+  <!-- RFC: https://wiki.php.net/rfc/gmp-final -->
+  <simpara>
+   The <classname>GMP</classname> class is now final and cannot be extended
+   anymore.
+  </simpara>
+ </sect2>
+
+ <sect2 xml:id="migration84.incompatible.mbstring">
+  <title>MBString</title>
+
+  <simpara>
+   On invalid strings (those with encoding errors),
+   <function>mb_substr</function> now interprets character indices in the same
+   manner as most other mbstring functions.
+   This means that character indices returned by <function>mb_strpos</function>
+   can be passed to <function>mb_substr</function>.
+  </simpara>
+
+  <simpara>
+   For SJIS-Mac (MacJapanese) strings, character indices passed to
+   <function>mb_substr</function> now refer to the indices of the Unicode
+   codepoints which are produced when the string is converted to Unicode.
+   This is significant because around 40 SJIS-Mac characters convert to a
+   sequence of multiple Unicode codepoints.
+  </simpara>
+ </sect2>
+
+ <sect2 xml:id="migration84.incompatible.mysqli">
+  <title>MySQLi</title>
+
+  <simpara>
+   The unused and undocumented constant
+   <constant>MYSQLI_SET_CHARSET_DIR</constant> has been removed.
+  </simpara>
+
+  <simpara>
+   The <constant>MYSQLI_STMT_ATTR_PREFETCH_ROWS</constant> constant has been
+   removed. The feature is unavailable with mysqlnd.
+  </simpara>
+
+  <simpara>
+   The <constant>MYSQLI_CURSOR_TYPE_FOR_UPDATE</constant> and
+   <constant>MYSQLI_CURSOR_TYPE_SCROLLABLE</constant> constants have been
+   removed. This functionality was never implemented,
+   neither with mysqlnd nor with libmysql.
+  </simpara>
+
+  <simpara>
+   The unused <constant>MYSQLI_TYPE_INTERVAL</constant> constant, which is
+   currently a stub and an alias for <constant>MYSQLI_TYPE_ENUM</constant>,
+   has been removed.
+   <!-- There are no
+  plans to add such data type to MySQL yet, so it's unclear what its value
+  would finally be. -->
+  </simpara>
+ </sect2>
+
+ <sect2 xml:id="migration84.incompatible.mysqlnd">
+  <title>MySQLnd</title>
+
+  <simpara>
+   The error code reported for MySQL server wait timeouts has been changed from
+   <literal>2006</literal> to <literal>4031</literal> for MySQL server
+   versions 8.0.24 and above.
+  </simpara>
+ </sect2>
+
+ <sect2 xml:id="migration84.incompatible.opcache">
+  <title>Opcache</title>
+
+  <simpara>
+   The maximum value of the
+   <link linkend="ini.opcache.interned-strings-buffer">opcache.interned_strings_buffer</link>
+   setting on 64bit architectures is now <literal>32767</literal>.
+   Previously it was <literal>4095</literal>.
+  </simpara>
+
+  <sect3>
+   <title>JIT</title>
+
+   <simpara>
+    The default configuration values for the JIT changed from
+    <link linkend="ini.opcache.jit"><literal>opcache.jit=tracing</literal></link>
+    and <link linkend="ini.opcache.jit-buffer-size"><literal>opcache.jit_buffer_size=0</literal></link>
+    to <link linkend="ini.opcache.jit"><literal>opcache.jit=disable</literal></link>
+    and <link linkend="ini.opcache.jit-buffer-size"><literal>opcache.jit_buffer_size=64M</literal></link>, respectively.
+   </simpara>
+
+   <simpara>
+    This does not affect the default observable behavior,
+    as the JIT is still disabled by default.
+    However, it is now disabled through the
+    <link linkend="ini.opcache.jit">opcache.jit</link> setting,
+    rather than
+    <link linkend="ini.opcache.jit-buffer-size">opcache.jit_buffer_size</link>.
+    This may affect users who previously enabled JIT through
+    <link linkend="ini.opcache.jit-buffer-size">opcache.jit_buffer_size</link>
+    exclusively, without also specifying a JIT mode using
+    <link linkend="ini.opcache.jit">opcache.jit</link>.
+    To enable JIT compilation, set the
+    <link linkend="ini.opcache.jit">opcache.jit</link> config value accordingly.
+   </simpara>
+
+   <simpara>
+    If <acronym>JIT</acronym> compilation is enabled, <acronym>PHP</acronym> will now exit with a fatal error on
+    startup if the initialization of the <acronym>JIT</acronym> compiler failed for any reason.
+   </simpara>
+  </sect3>
+ </sect2>
+
+ <sect2 xml:id="migration84.incompatible.pcntl">
+  <title>PCNTL</title>
+
+  <simpara>
+   The <function>pcntl_sigprocmask</function>,
+   <function>pcntl_sigwaitinfo</function>, and
+   <function>pcntl_sigtimedwait</function> functions now always
+   return &false; on failure.
+   In some case previously it could return the value <literal>-1</literal>.
+  </simpara>
+ </sect2>
+
+ <sect2 xml:id="migration84.incompatible.pcre">
+  <title>PCRE</title>
+
+  <simpara>
+   The bundled pcre2lib has been updated to version 10.44.
+   As a consequence, this means <literal>{,3}</literal> is now recognized
+   as a quantifier instead of as text.
+   Furthermore, the meaning of some character classes in UCP mode has changed.
+   Consult the <link xlink:href="https://github.com/PCRE2Project/pcre2/blob/master/NEWS">PCRE2 Changelog</link>
+   for a full changelog.
+  </simpara>
+ </sect2>
+
+ <sect2 xml:id="migration84.incompatible.pdo-dblib">
+  <title>PDO_DBLIB</title>
+
+  <simpara>
+   The <constant>Pdo\Dblib::ATTR_STRINGIFY_UNIQUEIDENTIFIER</constant> and
+   <constant>Pdo\Dblib::ATTR_DATETIME_CONVERT</constant> attributes now act as
+   boolean attributes instead of integer attributes.
+   Thus setting the attribute via <methodname>PDO::setAttribute</methodname>
+   and retrieving it via <methodname>PDO::getAttribute</methodname> expects
+   and or return a <type>bool</type>.
+  </simpara>
+ </sect2>
+
+ <sect2 xml:id="migration84.incompatible.pdo-firebird">
+  <title>PDO_FIREBIRD</title>
+
+  <simpara>
+   The <constant>PDO::ATTR_AUTOCOMMIT</constant> attribute now act as
+   boolean attributes instead of integer attributes.
+   Thus setting the attribute via <methodname>PDO::setAttribute</methodname>
+   and retrieving it via <methodname>PDO::getAttribute</methodname> expects
+   and or return a <type>bool</type>.
+  </simpara>
+
+  <simpara>
+   The extension now exposes some Firebird C++ APIs,
+   therefore building this extension now requires a C++ compiler.
+   Moreover, the extension must now be compiled against fbclient 3.0 or higher.
+  </simpara>
+ </sect2>
+
+ <sect2 xml:id="migration84.incompatible.pdo-mysql">
+  <title>PDO_MYSQL</title>
+
+  <simpara>
+   The <constant>PDO::ATTR_AUTOCOMMIT</constant>,
+   <constant>PDO::ATTR_EMULATE_PREPARES</constant>, and
+   <constant>PDO::MYSQL_ATTR_DIRECT_QUERY</constant> attributes now act as
+   boolean attributes instead of integer attributes.
+   Thus setting the attribute via <methodname>PDO::setAttribute</methodname>
+   and retrieving it via <methodname>PDO::getAttribute</methodname> expects
+   and or return a <type>bool</type>.
+  </simpara>
+ </sect2>
+
+ <sect2 xml:id="migration84.incompatible.pdo-pgsql">
+  <title>PDO_PGSQL</title>
+
+  <simpara>
+   The DSN's credentials, when set, are given priority over their PDO
+   constructor counterparts, being closer to the documentation states.
+  </simpara>
+ </sect2>
+
+ <sect2 xml:id="migration84.incompatible.simplexml">
+  <title>SimpleXML</title>
+
+  <simpara>
+   <classname>SimpleXMLElement</classname> is not only a representation of an
+   XML element, but it is also a <classname>RecursiveIterator</classname>.
+   Prior to PHP 8.4.0, some of its methods (e.g.
+   <methodname>SimpleXMLElement::asXML</methodname> or
+   <methodname>SimpleXMLElement::getName</methodname>) and casting such
+   instances to &string; would implicitly reset the iterator.
+  </simpara>
+  <para>
+   This could cause unexpected infinite loops as the iterator was rewound.
+   For example:
+   <informalexample>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+$xmlString = "<root><a><b>1</b><b>2</b><b>3</b></a></root>";
+$xml = simplexml_load_string($xmlString);
+
+$nodes = $xml->a->b;
+foreach ($nodes as $nodeData) {
+    echo "nodeData: " . $nodeData . "\n";
+
+    $xml = $nodes->asXml();
+}
+
+]]>
+    </programlisting>
+    <simpara>
+     would result in an infinite loop.
+    </simpara>
+    <screen>
+<![CDATA[
+nodeData: 1
+nodeData: 2
+nodeData: 2
+nodeData: 2
+nodeData: 2
+nodeData: 2
+nodeData: 2
+// ...
+]]>
+    </screen>
+    <simpara>
+     However, this behavior has now been corrected, and a
+     <classname>SimpleXMLElement</classname> will no longer implicitly reset
+     the iterator data, unless explicitly rewound.
+     Meaning the previous example would now result in:
+    </simpara>
+    <screen>
+<![CDATA[
+nodeData: 1
+nodeData: 2
+nodeData: 3
+]]>
+    </screen>
+   </informalexample>
+  </para>
+  <!-- This is no longer the case as a consequence of the bugfixes for GH-12192,GH-12208, #55098. -->
+ </sect2>
+
+ <sect2 xml:id="migration84.incompatible.soap">
+  <title>SOAP</title>
+
+  <simpara>
+   <property>SoapClient::$typemap</property> is now an <type>array</type>
+   rather than a <type>resource</type>.
+   Checks using <function>is_resource</function> (i.e.
+   <code>is_resource($client->typemap)</code>) should be
+   replaced with checks for &null; (i.e. <code>$client->typemap !== null</code>).
+  </simpara>
+
+  <simpara>
+   The SOAP extension gained an optional dependency on the
+   <link linkend="book.session">session</link> extension.
+   If PHP is built without the session extension and with the
+   <option>--enable-rtld-now</option> configure flag enabled,
+   startup errors will now occur if the <link linkend="book.soap">SOAP</link>
+   extension is also used.
+   To solve this either don't use rtld-now or load the session extension.
+  </simpara>
+ </sect2>
+
+ <sect2 xml:id="migration84.incompatible.standard">
+  <title>Standard</title>
+
+  <simpara>
+   When using <function>strcspn</function> with
+   <parameter>characters</parameter> being the empty string,
+   the length of the string is now returned instead of incorrectly stopping
+   at the first null byte.
+   <!-- See GH-12592 -->
+  </simpara>
+
+  <simpara>
+   <function>http_build_query</function> now correctly handles backed enums.
+  </simpara>
+
+  <!-- RFC: https://wiki.php.net/rfc/dedicated_stream_bucket -->
+  <simpara>
+   <function>stream_bucket_make_writeable</function> and
+   <function>stream_bucket_new</function> will now return a
+   <classname>StreamBucket</classname> instance instead of an instance of
+   <classname>stdClass</classname>.
+  </simpara>
+ </sect2>
+
+ <sect2 xml:id="migration84.incompatible.tidy">
+  <title>Tidy</title>
+
+  <simpara>
+   Failures in the constructor now throw exceptions rather than emitting
+   warnings and having a broken object.
+  </simpara>
+ </sect2>
+
+ <sect2 xml:id="migration84.incompatible.xml">
+  <title>XML</title>
+
+  <simpara>
+   The <function>xml_set_<replaceable>*</replaceable>_handler</function>
+   functions now declare and check for an effective
+   signature of <type class="union"><type>callable</type><type>string</type><type>null</type></type> for the
+   <parameter>handler</parameter> parameters.
+   Moreover, values of type <type>string</type> that correspond to method names,
+   of object set with <function>xml_set_object</function> are now checked to
+   see if the method exists on the class of the previously passed object.
+   This means that <function>xml_set_object</function> must now always be
+   called prior to setting method names as <type>callable</type>s.
+   Passing an empty string to disable the handler is still allowed,
+   but deprecated.
+  </simpara>
+
+  <simpara>
+   However, as <function>xml_set_object</function> and passing
+   non-<type>callable</type> strings is deprecated.
+   It is recommended to change such instances with a <type>callable</type>
+   referring to the method directly.
+  </simpara>
+ </sect2>
+
+</sect1>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/appendices/migration84/incompatible.xml
+++ b/appendices/migration84/incompatible.xml
@@ -1,99 +1,99 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: b1b039696eedcc82e9c1144eeecbfc0a8a1b3859 Maintainer: KentarouTakeda Status: ready -->
+<!-- Credits: KentarouTakeda -->
 <sect1 xml:id="migration84.incompatible" xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>Backward Incompatible Changes</title>
+ <title>下位互換性のない変更点</title>
 
  <simpara>
-  Although not explicitly stated in this section,
-  every new <link linkend="migration84.new-functions">function</link>,
-  <link linkend="migration84.new-classes">class, interface, enum</link>,
-  or <link linkend="migration84.constants">constant</link>
-  may cause a redeclaration <exceptionname>Error</exceptionname> to be thrown.
+  このセクションで明示的に述べられていなくても、
+  新しい<link linkend="migration84.new-functions">関数</link>、
+  <link linkend="migration84.new-classes">クラス、インターフェイス、列挙型</link>、
+  または<link linkend="migration84.constants">定数</link>は、
+  再宣言による<exceptionname>Error</exceptionname>がスローされる可能性があります。
  </simpara>
 
  <sect2 xml:id="migration84.incompatible.core">
-  <title>PHP Core</title>
+  <title>PHP コア</title>
 
   <!-- RFC: https://wiki.php.net/rfc/exit-as-function -->
   <sect3 xml:id="migration84.incompatible.core.exit">
-   <title><function>exit</function> behavioral change</title>
+   <title><function>exit</function> の動作の変更</title>
 
    <simpara>
-    The <function>exit</function> (and <function>die</function>) language
-    constructs now behave more like a function.
-    This means that they can now be passed like <type>callable</type>s,
+    <function>exit</function> (および<function>die</function>)
+    言語構造は、関数のように振る舞います。
+    これにより、<type>callable</type>として渡すことができ、
     <!-- TODO: Link to declare documentation/type juggling documentation -->
-    are affected by the <literal>strict_types</literal> declare statement,
-    and now perform the usual type coercions instead of casting any non-integer
-    value to a string.
+    <literal>strict_types</literal> 宣言の影響を受け、
+    任意の非整数値を文字列にキャストする代わりに、通常の型強制を行います。
    </simpara>
 
    <simpara>
-    As such, passing invalid types to <function>exit</function> and
-    <function>die</function> now consistently result in a
-    <exceptionname>TypeError</exceptionname> being thrown.
+    そのため、<function>exit</function> および <function>die</function> に
+    無効な型を渡すと、一貫して<exceptionname>TypeError</exceptionname> が
+    スローされるようになりました。
    </simpara>
   </sect3>
 
   <sect3 xml:id="migration84.incompatible.core.recursion-comparison">
-   <title>Recursion during comparison</title>
+   <title>比較中の再帰</title>
 
    <simpara>
-    Encountering recursion during comparison now results in an
-    <exceptionname>Error</exceptionname> exception instead of a
-    <constant>E_ERROR</constant> fatal error.
+    比較中に再帰が発生すると、
+    <constant>E_ERROR</constant> の致命的なエラーの代わりに、
+    <exceptionname>Error</exceptionname> 例外がスローされるようになりました。
    </simpara>
   </sect3>
 
   <sect3 xml:id="migration84.incompatible.core.readonly-indirect-modification">
-   <title>Indirect Modification of readonly Properties</title>
+   <title>readonly プロパティの間接的な変更</title>
 
    <!-- TODO Link to clone magic method, and explain this better as UPGRADING is... -->
    <simpara>
-    Indirect modification of readonly properties within <code>__clone()</code>
-    is no longer allowed, e.g. <code>$ref = &amp;$this->readonly</code>.
-    This was already forbidden for readonly initialization, and was an
-    oversight in the "readonly reinitialization during cloning" implementation.
+    <code>__clone()</code> 内で readonly プロパティを間接的に変更することは、
+    もはや許可されなくなりました。例えば、<code>$ref = &amp;$this->readonly</code> のようなコードです。
+    これは readonly の初期化時にはすでに禁止されており、
+    「クローン時の readonly の再初期化」の実装における見落としでした。
    </simpara>
   </sect3>
 
   <sect3 xml:id="migration84.incompatible.core.constant-type-change">
-   <title>Type Change of Constants</title>
+   <title>定数の型の変更</title>
 
    <simpara>
-    The <constant>PHP_DEBUG</constant> and <constant>PHP_ZTS</constant>
-    constants are now of type <type>bool</type>.
-    Previously they were of type <type>int</type>.
+    <constant>PHP_DEBUG</constant> および <constant>PHP_ZTS</constant> 定数の型が、
+    <type>int</type> から <type>bool</type> に変更されました。
    </simpara>
   </sect3>
 
   <sect3 xml:id="migration84.incompatible.core.tempnam-length">
-   <title>Temporary Filename Length</title>
+   <title>一時ファイル名の長さ</title>
 
    <simpara>
-    The name of uploaded files and files created by the
-    <function>tempnam</function> function are now 13 bytes longer.
-    The total length is still platform-dependent.
+    アップロードされたファイルや <function>tempnam</function> 関数で作成されるファイルの名前は、
+    以前より13バイト長くなりました。
+    総合的な長さは引き続きプラットフォーム依存です。
    </simpara>
   </sect3>
 
   <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_4#remove_e_strict_error_level_and_deprecate_e_strict_constant -->
   <sect3 xml:id="migration84.incompatible.core.e-strict">
-   <title>Removal of <constant>E_STRICT</constant> error level</title>
+   <title><constant>E_STRICT</constant> エラーレベルの削除</title>
 
    <simpara>
-    The <constant>E_STRICT</constant> error level has been removed,
-    as it was no longer in use within the PHP engine.
-    The <constant>E_STRICT</constant> constant has been deprecated.
+    <constant>E_STRICT</constant> エラーレベルは、
+    PHPエンジン内で使用されなくなったため削除されました。
+    <constant>E_STRICT</constant> 定数は非推奨となりました。
    </simpara>
   </sect3>
  </sect2>
 
  <sect2 xml:id="migration84.incompatible.typed-constants">
-  <title>Extension Class Constants which are now Typed</title>
+  <title>型が追加された拡張クラスの定数</title>
 
   <para>
-   The following extension class constants now declare a type on their
-   constants:
+   以下の拡張クラスは、定数に型が宣言されました:
    <simplelist>
     <member><link linkend="book.datetime">Date</link></member>
     <member><link linkend="book.intl">Intl</link></member>
@@ -108,21 +108,21 @@
 
  <!-- TODO: Check resource names -->
  <sect2 xml:id="migration84.incompatible.resource2object">
-  <title>Resource to Object Migration</title>
+  <title>リソースからオブジェクトへの移行</title>
 
   <simpara>
-   Several &resource;s have been migrated to &object;s.
-   Return value checks using <function>is_resource</function> should be
-   replaced with checks for &false;, unless specified otherwise.
+   いくつかの &resource; が &object; に移行されました。
+   <function>is_resource</function> を使用した戻り値のチェックは、
+   特に指定がない限り、&false; かどうかを確認するように置き換える必要があります。
   </simpara>
 
   <sect3 xml:id="migration84.incompatible.resource2object.dba">
    <title>DBA</title>
 
    <simpara>
-    The <link linkend="book.dba">DBA</link> functions now accept and return
-    <classname>Dba\Connection</classname> objects instead of
-    <literal>dba_connection</literal> &resource;s.
+    <link linkend="book.dba">DBA</link> 関数は、
+    <literal>dba_connection</literal> &resource; の代わりに
+    <classname>Dba\Connection</classname> オブジェクトを受け取り、返すようになりました。
    </simpara>
   </sect3>
 
@@ -130,15 +130,15 @@
    <title>ODBC</title>
 
    <simpara>
-    The <link linkend="book.uodbc">ODBC</link> functions now accept and return
-    <classname>Odbc\Result</classname> objects instead of
-    <literal>odbc_result</literal> &resource;s.
+    <link linkend="book.uodbc">ODBC</link> 関数は、
+    <literal>odbc_result</literal> &resource; の代わりに
+    <classname>Odbc\Result</classname> オブジェクトを受け取り、返すようになりました。
    </simpara>
 
    <simpara>
-    The <link linkend="book.uodbc">ODBC</link> functions now accept and return
-    <classname>Odbc\Connection</classname> objects instead of
-    <literal>odbc_connection</literal> &resource;s.
+    <link linkend="book.uodbc">ODBC</link> 関数は、
+    <literal>odbc_connection</literal> &resource; の代わりに
+    <classname>Odbc\Connection</classname> オブジェクトを受け取り、返すようになりました。
    </simpara>
   </sect3>
 
@@ -146,45 +146,45 @@
    <title>SOAP</title>
 
    <simpara>
-    The <property>SoapClient::$httpurl</property> property is now a
-    <classname>Soap\Url</classname> object rather than a
-    <literal>soap_url</literal> &resource;.
-    Checks using <function>is_resource</function> (i.e.
-    <code>is_resource($client->httpurl)</code>) should be  replaced with checks
-    for &null; (i.e. <code>$client->httpurl !== null</code>).
+    <property>SoapClient::$httpurl</property> プロパティは、
+    <literal>soap_url</literal> &resource; の代わりに
+    <classname>Soap\Url</classname> オブジェクトになりました。
+    <function>is_resource</function> を使用したチェック
+    (例: <code>is_resource($client->httpurl)</code>)は、
+    &null; かどうかのチェック(例: <code>$client->httpurl !== null</code>)に置き換える必要があります。
    </simpara>
    <simpara>
-    The <property>SoapClient::$sdl</property> property is now a
-    <classname>Soap\Sdl</classname> object rather than a
-    <literal>soap_sdl</literal> &resource;.
-    Checks using <function>is_resource</function> (i.e.
-    <code>is_resource($client->sdl)</code>) should be  replaced with checks
-    for &null; (i.e. <code>$client->sdl !== null</code>).
+    <property>SoapClient::$sdl</property> プロパティは、
+    <literal>soap_sdl</literal> &resource; の代わりに
+    <classname>Soap\Sdl</classname> オブジェクトになりました。
+    <function>is_resource</function> を使用したチェック
+    (例: <code>is_resource($client->sdl)</code>)は、
+    &null; かどうかのチェック(例: <code>$client->sdl !== null</code>)に置き換える必要があります。
    </simpara>
   </sect3>
  </sect2>
 
  <sect2 xml:id="migration84.incompatible.new-warnings-exceptions">
-  <title>New warnings and exceptions</title>
+  <title>新しい警告と例外</title>
 
   <simpara>
-   New warnings and exceptions have been added which are triggered on
-   programming errors, i.e. invalid values provided as arguments.
+   プログラミングエラー、つまり無効な値が引数として提供された場合にトリガーされる
+   新しい警告と例外が追加されました。
   </simpara>
 
   <sect3 xml:id="migration84.incompatible.new-warnings-exceptions.curl">
-   <title>Curl</title>
+   <title>cURL</title>
 
    <simpara>
-    <function>curl_multi_select</function> now throws a
-    <exceptionname>ValueError</exceptionname> if the
-    <parameter>timeout</parameter> parameter is less than
-    <literal>0</literal> or greater than <constant>PHP_INT_MAX</constant>.
+    <function>curl_multi_select</function> は、
+    <parameter>timeout</parameter> パラメータが <literal>0</literal> 未満または
+    <constant>PHP_INT_MAX</constant> を超える場合、
+    <exceptionname>ValueError</exceptionname> をスローするようになりました。
    </simpara>
   </sect3>
 
   <sect3 xml:id="migration84.incompatible.new-warnings-exceptions.gd">
-   <title>Gd</title>
+   <title>GD</title>
 
    <para>
     <simplelist type="inline">
@@ -193,35 +193,35 @@
      <member><function>imagepng</function></member>
      <member><function>imageavif</function></member>
     </simplelist>
-    now throw a <exceptionname>ValueError</exceptionname> when an invalid
-    <parameter>quality</parameter> is passed.
+    は、無効な <parameter>quality</parameter> が渡された場合、
+    <exceptionname>ValueError</exceptionname> をスローするようになりました。
    </para>
 
    <simpara>
-    <function>imageavif</function> will now throw a
-    <exceptionname>ValueError</exceptionname> if an invalid
-    <parameter>speed</parameter> parameter value is passed.
+    <function>imageavif</function> は、
+    無効な <parameter>speed</parameter> パラメータ値が渡された場合、
+    <exceptionname>ValueError</exceptionname> をスローするようになりました。
    </simpara>
 
    <simpara>
-    <function>imagescale</function> will now throw a
-    <exceptionname>ValueError</exceptionname> if the
-    <parameter>width</parameter> or <parameter>height</parameter>
-    parameters underflows/overflows.
+    <function>imagescale</function> は、
+    <parameter>width</parameter> または <parameter>height</parameter> パラメータが
+    アンダーフロー/オーバーフローした場合、
+    <exceptionname>ValueError</exceptionname> をスローするようになりました。
    </simpara>
 
    <simpara>
-    <function>imagescale</function> will now throw a
-    <exceptionname>ValueError</exceptionname> if an invalid
-    <parameter>mode</parameter> parameter value is passed.
+    <function>imagescale</function> は、
+    無効な <parameter>mode</parameter> パラメータ値が渡された場合、
+    <exceptionname>ValueError</exceptionname> をスローするようになりました。
    </simpara>
 
    <simpara>
-    <function>imagefilter</function> will now throw a
-    <exceptionname>ValueError</exceptionname> with the
-    <constant>IMG_FILTER_SCATTER</constant> filter
-    if the <parameter>sub</parameter> or <parameter>plus</parameter>
-    parameters underflows/overflows.
+    <function>imagefilter</function> は、
+    <constant>IMG_FILTER_SCATTER</constant> フィルタで、
+    <parameter>sub</parameter> または <parameter>plus</parameter> パラメータが
+    アンダーフロー/オーバーフローした場合、
+    <exceptionname>ValueError</exceptionname> をスローするようになりました。
    </simpara>
   </sect3>
 
@@ -234,8 +234,8 @@
      <member><function>textdomain</function></member>
      <member><function>d<replaceable>*</replaceable>gettext</function></member>
     </simplelist>
-    now throw a <exceptionname>ValueError</exceptionname> if
-    <parameter>domain</parameter> is the empty string.
+    は、<parameter>domain</parameter> が空文字列の場合、
+    <exceptionname>ValueError</exceptionname> をスローするようになりました。
    </para>
   </sect3>
 
@@ -243,33 +243,34 @@
    <title>Intl</title>
 
    <para>
-    <function>resourcebundle_get</function>,
-    <methodname>ResourceBundle::get</methodname>, and accessing offsets on
-    a <classname>ResourceBundle</classname> object now throw:
+    <function>resourcebundle_get</function>、
+    <methodname>ResourceBundle::get</methodname>、および
+    <classname>ResourceBundle</classname> オブジェクトでのオフセットアクセスは、
+    以下の場合に例外をスローするようになりました:
     <simplelist>
      <member>
-      <exceptionname>TypeError</exceptionname> for invalid offset types
+      無効なオフセット型の場合、<exceptionname>TypeError</exceptionname>
      </member>
      <member>
-      <exceptionname>ValueError</exceptionname> for an empty &string;
+      空の &string; の場合、<exceptionname>ValueError</exceptionname>
      </member>
      <member>
-      <exceptionname>ValueError</exceptionname> if the integer index does
-      not fit in a signed 32 bit integer
+      整数インデックスが符号付き32ビット整数に収まらない場合、
+      <exceptionname>ValueError</exceptionname>
      </member>
     </simplelist>
    </para>
 
    <simpara>
-    <methodname>IntlDateFormatter::__construct</methodname> throws a
-    <exceptionname>ValueError</exceptionname> if the
-    <parameter>locale</parameter> is invalid.
+    <methodname>IntlDateFormatter::__construct</methodname> は、
+    <parameter>locale</parameter> が無効な場合、
+    <exceptionname>ValueError</exceptionname> をスローするようになりました。
    </simpara>
 
    <simpara>
-    <methodname>NumberFormatter::__construct</methodname> throws a
-    <exceptionname>ValueError</exceptionname> if the
-    <parameter>locale</parameter> is invalid.
+    <methodname>NumberFormatter::__construct</methodname> は、
+    <parameter>locale</parameter> が無効な場合、
+    <exceptionname>ValueError</exceptionname> をスローするようになりました。
    </simpara>
   </sect3>
 
@@ -277,22 +278,22 @@
    <title>MBString</title>
 
    <simpara>
-    <function>mb_encode_numericentity</function> and
-    <function>mb_decode_numericentity</function> now check that the
-    <parameter>map</parameter> is only composed of &integer;s,
-    if not a <exceptionname>ValueError</exceptionname> is now thrown.
+    <function>mb_encode_numericentity</function> および
+    <function>mb_decode_numericentity</function> は、
+    <parameter>map</parameter> が &integer; のみで構成されているかをチェックし、
+    そうでない場合 <exceptionname>ValueError</exceptionname> をスローするようになりました。
    </simpara>
 
    <simpara>
-    <function>mb_http_input</function> now always throw a
-    <exceptionname>ValueError</exceptionname> if <parameter>type</parameter>
-    is invalid.
+    <function>mb_http_input</function> は、
+    <parameter>type</parameter> が無効な場合、常に
+    <exceptionname>ValueError</exceptionname> をスローするようになりました。
    </simpara>
 
    <simpara>
-    <function>mb_http_output</function> now check that the
-    <parameter>encoding</parameter> does not contain any null bytes,
-    if it does a <exceptionname>ValueError</exceptionname> is now thrown.
+    <function>mb_http_output</function> は、
+    <parameter>encoding</parameter> にヌルバイトが含まれていないかをチェックし、
+    含まれている場合 <exceptionname>ValueError</exceptionname> をスローするようになりました。
    </simpara>
   </sect3>
 
@@ -300,9 +301,9 @@
    <title>ODBC</title>
 
    <simpara>
-    <function>odbc_fetch_row</function> returns &false; when
-    <parameter>row</parameter> is less than or equal to <literal>0</literal>.
-    A warning is now emitted in this case.
+    <function>odbc_fetch_row</function> は、
+    <parameter>row</parameter> が <literal>0</literal> 以下の場合、
+    &false; を返すようになりました。この場合、警告が発せられます。
    </simpara>
   </sect3>
 
@@ -310,50 +311,49 @@
    <title>PCNTL</title>
 
    <para>
-    The <function>pcntl_sigprocmask</function>,
-    <function>pcntl_sigwaitinfo</function>, and
-    <function>pcntl_sigtimedwait</function> functions now throw:
+    <function>pcntl_sigprocmask</function>、
+    <function>pcntl_sigwaitinfo</function>、および
+    <function>pcntl_sigtimedwait</function> 関数は、次の場合エラーをスローするようになりました:
     <simplelist>
      <member>
-      A <exceptionname>ValueError</exceptionname> if the
-      <parameter>signals</parameter> array is empty
-      (except for <function>pcntl_sigprocmask</function> if the
-      <parameter>mode</parameter> <constant>SIG_SETMASK</constant>)
+      <parameter>signals</parameter> 配列が空の場合、
+      <exceptionname>ValueError</exceptionname>
+      (<function>pcntl_sigprocmask</function> で
+      <parameter>mode</parameter> が <constant>SIG_SETMASK</constant> のときを除く)
      </member>
      <member>
-      A <exceptionname>TypeError</exceptionname> if a value of the
-      <parameter>signals</parameter> array is not an &integer;
+      <parameter>signals</parameter> 配列の値が &integer; でない場合、
+      <exceptionname>TypeError</exceptionname>
      </member>
      <member>
-      A <exceptionname>ValueError</exceptionname> if a value of the
-      <parameter>signals</parameter> array is not a valid signal number
+      <parameter>signals</parameter> 配列の値が有効なシグナル番号でない場合、
+      <exceptionname>ValueError</exceptionname>
      </member>
     </simplelist>
    </para>
 
    <simpara>
-    The <function>pcntl_sigprocmask</function> function now throws a
-    <exceptionname>ValueError</exceptionname> if the
-    <parameter>mode</parameter> is not one of <constant>SIG_BLOCK</constant>,
-    <constant>SIG_UNBLOCK</constant>, or <constant>SIG_SETMASK</constant>.
+    <function>pcntl_sigprocmask</function> 関数は、
+    <parameter>mode</parameter> が <constant>SIG_BLOCK</constant>、
+    <constant>SIG_UNBLOCK</constant>、<constant>SIG_SETMASK</constant> のいずれでもない場合、
+    <exceptionname>ValueError</exceptionname> をスローするようになりました。
    </simpara>
 
    <para>
-    The <function>pcntl_sigtimedwait</function> function now throw:
+    <function>pcntl_sigtimedwait</function> 関数は、次の場合エラーをスローするようになりました:
     <simplelist>
      <member>
-      A <exceptionname>ValueError</exceptionname> if
-      <parameter>seconds</parameter> is less than <literal>0</literal>
+      <parameter>seconds</parameter> が <literal>0</literal> 未満の場合、
+      <exceptionname>ValueError</exceptionname>
      </member>
      <member>
-      A <exceptionname>ValueError</exceptionname> if
-      <parameter>nanoseconds</parameter> is less than <literal>0</literal>
-      or greater than <literal>1e9</literal>
+      <parameter>nanoseconds</parameter> が <literal>0</literal> 未満
+      または <literal>1e9</literal> を超える場合、
+      <exceptionname>ValueError</exceptionname>
      </member>
      <member>
-      A <exceptionname>ValueError</exceptionname> if both
-      <parameter>seconds</parameter> and <parameter>nanoseconds</parameter>
-      are <literal>0</literal>
+      <parameter>seconds</parameter> および <parameter>nanoseconds</parameter> が両方とも
+      <literal>0</literal> の場合、<exceptionname>ValueError</exceptionname>
      </member>
     </simplelist>
    </para>
@@ -363,9 +363,9 @@
    <title>SimpleXML</title>
 
    <simpara>
-    Calling <function>simplexml_import_dom</function> with a non-XML object
-    now throws a <exceptionname>TypeError</exceptionname> instead of a
-    <exceptionname>ValueError</exceptionname>.
+    <function>simplexml_import_dom</function> に非XMLオブジェクトを渡すと、
+    <exceptionname>ValueError</exceptionname> の代わりに
+    <exceptionname>TypeError</exceptionname> をスローするようになりました。
    </simpara>
   </sect3>
 
@@ -373,35 +373,33 @@
    <title>Standard</title>
 
    <simpara>
-    The <function>round</function> function now validates the value of the
-    <parameter>mode</parameter> and throw a
-    <exceptionname>ValueError</exceptionname> for invalid modes.
-    Previously, invalid modes would have been interpreted as
-    <constant>PHP_ROUND_HALF_UP</constant>.
+    <function>round</function> 関数は、 <parameter>mode</parameter> の値を検証し、
+    無効なモードの場合、<exceptionname>ValueError</exceptionname> をスローするようになりました。
+    以前は、無効なモードは <constant>PHP_ROUND_HALF_UP</constant> と解釈されていました。
    </simpara>
 
    <simpara>
-    The <function>str_getcsv</function> now throws
-    <exceptionname>ValueError</exceptionname>s when the
-    <parameter>separator</parameter> and <parameter>enclosure</parameter>
-    arguments are not one byte long, or if the <parameter>escape</parameter>
-    argument is not one byte long nor the empty string.
-    This aligns the behaviour to be identical to the one of
-    <function>fputcsv</function> and <function>fgetcsv</function>.
+    <function>str_getcsv</function> は、
+    <parameter>separator</parameter> および <parameter>enclosure</parameter> 引数が
+    1バイトの長さでない場合、または <parameter>escape</parameter> 引数が
+    1バイトの長さでないか空文字列でない場合、
+    <exceptionname>ValueError</exceptionname> をスローするようになりました。
+    これは、<function>fputcsv</function> および <function>fgetcsv</function> の動作と
+    同じになるように合わせたものです。
    </simpara>
 
    <simpara>
-    The <function>php_uname</function> function now throws a
-    <exceptionname>ValueError</exceptionname> if the
-    <parameter>mode</parameter> is invalid.
+    <function>php_uname</function> 関数は、
+    <parameter>mode</parameter> が無効な場合、
+    <exceptionname>ValueError</exceptionname> をスローするようになりました。
    </simpara>
 
    <simpara>
-    The <literal>"allowed_classes"</literal> option for
-    <function>unserialize</function> now throws
-    <exceptionname>TypeError</exceptionname>s and
-    <exceptionname>ValueError</exceptionname>s if it is not an
-    <type>array</type> of class names.
+    <function>unserialize</function> の
+    <literal>"allowed_classes"</literal> オプションは、
+    クラス名の <type>array</type> でない場合、
+    <exceptionname>TypeError</exceptionname> および
+    <exceptionname>ValueError</exceptionname> をスローするようになりました。
    </simpara>
   </sect3>
 
@@ -409,15 +407,15 @@
    <title>XMLReader</title>
 
    <simpara>
-    Passing an invalid character encoding to
-    <methodname>XMLReader::open</methodname> or
-    <methodname>XMLReader::XML</methodname> now throws a
-    <exceptionname>ValueError</exceptionname>.
+    無効な文字エンコーディングを
+    <methodname>XMLReader::open</methodname> または
+    <methodname>XMLReader::XML</methodname> に渡すと、
+    <exceptionname>ValueError</exceptionname> をスローするようになりました。
    </simpara>
 
    <simpara>
-    Passing a &string; containing null bytes previously emitted a
-    warning and now throws a <exceptionname>ValueError</exceptionname>.
+    ヌルバイトを含む &string; を渡すと、以前は警告が発せられていましたが、
+    現在は <exceptionname>ValueError</exceptionname> をスローするようになりました。
    </simpara>
   </sect3>
 
@@ -425,8 +423,8 @@
    <title>XMLWriter</title>
 
    <simpara>
-    Passing a &string; containing null bytes previously emitted a
-    warning and now throws a <exceptionname>ValueError</exceptionname>.
+    ヌルバイトを含む &string; を渡すと、以前は警告が発せられていましたが、
+    現在は <exceptionname>ValueError</exceptionname> をスローするようになりました。
    </simpara>
   </sect3>
 
@@ -434,22 +432,21 @@
    <title>XSL</title>
 
    <simpara>
-    <methodname>XSLTProcessor::setParameter</methodname> will now throw a
-    <exceptionname>ValueError</exceptionname> when its arguments contain null
-    bytes. This never actually worked correctly in the first place,
-    which is why it throws an exception now.
+    <methodname>XSLTProcessor::setParameter</methodname> は、
+    引数にヌルバイトが含まれる場合、<exceptionname>ValueError</exceptionname> をスローするようになりました。
+    これは、そもそも正しく動作していませんでした。
    </simpara>
 
    <simpara>
-    Calling <methodname>XSLTProcessor::importStyleSheet</methodname> with a
-    non-XML object now throws a <exceptionname>TypeError</exceptionname>
-    instead of a <exceptionname>ValueError</exceptionname>.
+    <methodname>XSLTProcessor::importStyleSheet</methodname> に
+    非XMLオブジェクトを渡すと、<exceptionname>ValueError</exceptionname> の代わりに
+    <exceptionname>TypeError</exceptionname> がスローされるようになりました。
    </simpara>
 
    <!-- RFC: https://wiki.php.net/rfc/improve_callbacks_dom_and_xsl -->
    <simpara>
-    Failure to call a PHP function callback during evaluation now throws
-    instead of emitting a warning.
+    評価中にPHP関数コールバックの呼び出しに失敗した場合、
+    警告の発生ではなく、例外がスローされるようになりました。
    </simpara>
   </sect3>
  </sect2>
@@ -458,29 +455,28 @@
   <title>DOM</title>
 
   <simpara>
-   Some DOM methods previously returned &false; or a
-   <exceptionname>DOMException</exceptionname> with code
-   <constant>DOM_PHP_ERR</constant> if a new node could not be allocated.
-   They now consistently throw a <exceptionname>DOMException</exceptionname>
-   with code <constant>DOM_INVALID_STATE_ERR</constant>.
-   This situation is extremely unlikely and the probability of being affected
-   is low.
-   As a result <methodname>DOMImplementation::createDocument</methodname>
-   now has a tentative return type of <classname>DOMDocument</classname>
+   一部のDOMメソッドは、新しいノードを割り当てられない場合、以前は
+   &false; を返すか、<constant>DOM_PHP_ERR</constant> コードの
+   <exceptionname>DOMException</exceptionname> をスローしていました。
+   これらは現在、一貫して <constant>DOM_INVALID_STATE_ERR</constant> コードの
+   <exceptionname>DOMException</exceptionname> をスローするようになりました。
+   この状況は極めてまれであり、影響を受ける可能性は低いです。
+   その結果、<methodname>DOMImplementation::createDocument</methodname> は、
    <!-- TODO: Use a proper union type for linkage -->
-   instead of <code>DOMDocument|false</code>.
+   戻り値の型が、以前の <code>DOMDocument|false</code> から
+   <classname>DOMDocument</classname> になりました。
   </simpara>
 
   <simpara>
-   Previously, <classname>DOMXPath</classname> objects could be cloned,
-   but resulted in an unusable object.
-   This is no longer possible, and cloning a <classname>DOMXPath</classname>
-   object now throws an <exceptionname>Error</exceptionname>.
+   以前は、<classname>DOMXPath</classname> オブジェクトをクローンできましたが、
+   返されるオブジェクトは使用できませんでした。
+   これはもはや可能ではなく、<classname>DOMXPath</classname> オブジェクトをクローンすると、
+   <exceptionname>Error</exceptionname> がスローされるようになりました。
   </simpara>
 
   <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_4#remove_domimplementationgetfeature_feature_version -->
   <simpara>
-   The <methodname>DOMImplementation::getFeature</methodname> method has been removed.
+   <methodname>DOMImplementation::getFeature</methodname> メソッドは削除されました。
   </simpara>
  </sect2>
 
@@ -489,8 +485,7 @@
 
   <!-- RFC: https://wiki.php.net/rfc/gmp-final -->
   <simpara>
-   The <classname>GMP</classname> class is now final and cannot be extended
-   anymore.
+   <classname>GMP</classname> クラスは final になり、継承できなくなりました。
   </simpara>
  </sect2>
 
@@ -498,19 +493,19 @@
   <title>MBString</title>
 
   <simpara>
-   On invalid strings (those with encoding errors),
-   <function>mb_substr</function> now interprets character indices in the same
-   manner as most other mbstring functions.
-   This means that character indices returned by <function>mb_strpos</function>
-   can be passed to <function>mb_substr</function>.
+   無効な文字列(エンコーディングエラーを含む)に対して、
+   <function>mb_substr</function> は他の多くの mbstring 関数と同様に、
+   文字インデックスを解釈するようになりました。
+   これにより、<function>mb_strpos</function> が返す文字インデックスを
+   <function>mb_substr</function> に渡すことができます。
   </simpara>
 
   <simpara>
-   For SJIS-Mac (MacJapanese) strings, character indices passed to
-   <function>mb_substr</function> now refer to the indices of the Unicode
-   codepoints which are produced when the string is converted to Unicode.
-   This is significant because around 40 SJIS-Mac characters convert to a
-   sequence of multiple Unicode codepoints.
+   SJIS-Mac(MacJapanese) 文字列の場合、<function>mb_substr</function>
+   に渡される文字インデックスは、文字列が Unicode に変換されたときに生成される
+   Unicode コードポイントのインデックスを参照します。
+   これは、 SJIS-Mac の約40文字が複数の Unicode コードポイントの
+   シーケンスに変換されることによる重要な処理です。
   </simpara>
  </sect2>
 
@@ -518,26 +513,25 @@
   <title>MySQLi</title>
 
   <simpara>
-   The unused and undocumented constant
-   <constant>MYSQLI_SET_CHARSET_DIR</constant> has been removed.
+   未使用でドキュメント化されていない定数
+   <constant>MYSQLI_SET_CHARSET_DIR</constant> は削除されました。
   </simpara>
 
   <simpara>
-   The <constant>MYSQLI_STMT_ATTR_PREFETCH_ROWS</constant> constant has been
-   removed. The feature is unavailable with mysqlnd.
+   <constant>MYSQLI_STMT_ATTR_PREFETCH_ROWS</constant> 定数は削除されました。
+   この機能は mysqlnd では利用できません。
   </simpara>
 
   <simpara>
-   The <constant>MYSQLI_CURSOR_TYPE_FOR_UPDATE</constant> and
-   <constant>MYSQLI_CURSOR_TYPE_SCROLLABLE</constant> constants have been
-   removed. This functionality was never implemented,
-   neither with mysqlnd nor with libmysql.
+   <constant>MYSQLI_CURSOR_TYPE_FOR_UPDATE</constant> および
+   <constant>MYSQLI_CURSOR_TYPE_SCROLLABLE</constant> 定数は
+   削除されました。この機能は mysqlnd および libmysql のどちらでも
+   実装されていませんでした。
   </simpara>
 
   <simpara>
-   The unused <constant>MYSQLI_TYPE_INTERVAL</constant> constant, which is
-   currently a stub and an alias for <constant>MYSQLI_TYPE_ENUM</constant>,
-   has been removed.
+   未使用の <constant>MYSQLI_TYPE_INTERVAL</constant> 定数は、
+   現在は <constant>MYSQLI_TYPE_ENUM</constant> のエイリアスであり、削除されました。
    <!-- There are no
   plans to add such data type to MySQL yet, so it's unclear what its value
   would finally be. -->
@@ -548,9 +542,9 @@
   <title>MySQLnd</title>
 
   <simpara>
-   The error code reported for MySQL server wait timeouts has been changed from
-   <literal>2006</literal> to <literal>4031</literal> for MySQL server
-   versions 8.0.24 and above.
+   MySQL サーバーの待機タイムアウトに対して報告されるエラーコードは、
+   MySQL サーバーバージョン 8.0.24 以降で
+   <literal>2006</literal> から <literal>4031</literal> に変更されました。
   </simpara>
  </sect2>
 
@@ -558,41 +552,42 @@
   <title>Opcache</title>
 
   <simpara>
-   The maximum value of the
+   64ビットアーキテクチャ上での
    <link linkend="ini.opcache.interned-strings-buffer">opcache.interned_strings_buffer</link>
-   setting on 64bit architectures is now <literal>32767</literal>.
-   Previously it was <literal>4095</literal>.
+   設定の最大値は <literal>32767</literal> になりました。
+   以前は <literal>4095</literal> でした。
   </simpara>
 
   <sect3>
    <title>JIT</title>
 
    <simpara>
-    The default configuration values for the JIT changed from
+    JIT のデフォルトの設定値は、
     <link linkend="ini.opcache.jit"><literal>opcache.jit=tracing</literal></link>
-    and <link linkend="ini.opcache.jit-buffer-size"><literal>opcache.jit_buffer_size=0</literal></link>
-    to <link linkend="ini.opcache.jit"><literal>opcache.jit=disable</literal></link>
-    and <link linkend="ini.opcache.jit-buffer-size"><literal>opcache.jit_buffer_size=64M</literal></link>, respectively.
+    および <link linkend="ini.opcache.jit-buffer-size"><literal>opcache.jit_buffer_size=0</literal></link>
+    から、 <link linkend="ini.opcache.jit"><literal>opcache.jit=disable</literal></link> および
+    <link linkend="ini.opcache.jit-buffer-size"><literal>opcache.jit_buffer_size=64M</literal></link> にそれぞれ変更されました。
    </simpara>
 
    <simpara>
-    This does not affect the default observable behavior,
-    as the JIT is still disabled by default.
-    However, it is now disabled through the
-    <link linkend="ini.opcache.jit">opcache.jit</link> setting,
-    rather than
-    <link linkend="ini.opcache.jit-buffer-size">opcache.jit_buffer_size</link>.
-    This may affect users who previously enabled JIT through
+    これはデフォルトの動作には影響しません。
+    JIT は引き続きデフォルトで無効になっています。
+    ただし、
+    <link linkend="ini.opcache.jit-buffer-size">opcache.jit_buffer_size</link> ではなく、
+    <link linkend="ini.opcache.jit">opcache.jit</link> を通じて無効化されています。
+    これは、以前に
     <link linkend="ini.opcache.jit-buffer-size">opcache.jit_buffer_size</link>
-    exclusively, without also specifying a JIT mode using
-    <link linkend="ini.opcache.jit">opcache.jit</link>.
-    To enable JIT compilation, set the
-    <link linkend="ini.opcache.jit">opcache.jit</link> config value accordingly.
+    のみを使用して JIT を有効にし、
+    <link linkend="ini.opcache.jit">opcache.jit</link>
+    を使用してJIT モードを指定していなかったユーザーに影響を与える可能性があります。
+    JIT コンパイルを有効にするには、
+    <link linkend="ini.opcache.jit">opcache.jit</link> の設定値を適切に設定してください。
    </simpara>
 
    <simpara>
-    If <acronym>JIT</acronym> compilation is enabled, <acronym>PHP</acronym> will now exit with a fatal error on
-    startup if the initialization of the <acronym>JIT</acronym> compiler failed for any reason.
+    <acronym>JIT</acronym> コンパイルが有効になっている場合、
+    <acronym>JIT</acronym> コンパイラの初期化に何らかの理由で失敗すると、
+    PHP は起動時に致命的なエラーで終了するようになりました。
    </simpara>
   </sect3>
  </sect2>
@@ -601,11 +596,11 @@
   <title>PCNTL</title>
 
   <simpara>
-   The <function>pcntl_sigprocmask</function>,
-   <function>pcntl_sigwaitinfo</function>, and
-   <function>pcntl_sigtimedwait</function> functions now always
-   return &false; on failure.
-   In some case previously it could return the value <literal>-1</literal>.
+   <function>pcntl_sigprocmask</function>、
+   <function>pcntl_sigwaitinfo</function>、
+   および <function>pcntl_sigtimedwait</function> 関数は、
+   失敗時に常に &false; を返すようになりました。
+   以前は場合によっては <literal>-1</literal> を返すことがありました。
   </simpara>
  </sect2>
 
@@ -613,12 +608,12 @@
   <title>PCRE</title>
 
   <simpara>
-   The bundled pcre2lib has been updated to version 10.44.
-   As a consequence, this means <literal>{,3}</literal> is now recognized
-   as a quantifier instead of as text.
-   Furthermore, the meaning of some character classes in UCP mode has changed.
-   Consult the <link xlink:href="https://github.com/PCRE2Project/pcre2/blob/master/NEWS">PCRE2 Changelog</link>
-   for a full changelog.
+   バンドルされた pcre2lib はバージョン 10.44 に更新されました。
+   その結果、<literal>{,3}</literal> はテキストとしてではなく
+   量指定子として認識されるようになりました。
+   さらに、UCP モードでの一部の文字クラスの意味が変更されました。
+   完全な変更ログは <link xlink:href="https://github.com/PCRE2Project/pcre2/blob/master/NEWS">PCRE2 Changelog</link> を
+   参照してください。
   </simpara>
  </sect2>
 
@@ -626,12 +621,12 @@
   <title>PDO_DBLIB</title>
 
   <simpara>
-   The <constant>Pdo\Dblib::ATTR_STRINGIFY_UNIQUEIDENTIFIER</constant> and
-   <constant>Pdo\Dblib::ATTR_DATETIME_CONVERT</constant> attributes now act as
-   boolean attributes instead of integer attributes.
-   Thus setting the attribute via <methodname>PDO::setAttribute</methodname>
-   and retrieving it via <methodname>PDO::getAttribute</methodname> expects
-   and or return a <type>bool</type>.
+   <constant>Pdo\Dblib::ATTR_STRINGIFY_UNIQUEIDENTIFIER</constant> および
+   <constant>Pdo\Dblib::ATTR_DATETIME_CONVERT</constant> 属性は、
+   整数属性の代わりにブール属性として動作するようになりました。
+   したがって、<methodname>PDO::setAttribute</methodname> を介して属性を設定し、
+   <methodname>PDO::getAttribute</methodname> を介して取得する場合、
+   <type>bool</type> を期待または返却します。
   </simpara>
  </sect2>
 
@@ -639,17 +634,17 @@
   <title>PDO_FIREBIRD</title>
 
   <simpara>
-   The <constant>PDO::ATTR_AUTOCOMMIT</constant> attribute now act as
-   boolean attributes instead of integer attributes.
-   Thus setting the attribute via <methodname>PDO::setAttribute</methodname>
-   and retrieving it via <methodname>PDO::getAttribute</methodname> expects
-   and or return a <type>bool</type>.
+   <constant>PDO::ATTR_AUTOCOMMIT</constant> 属性は、
+   整数属性の代わりにブール属性として動作するようになりました。
+   したがって、<methodname>PDO::setAttribute</methodname> を介して属性を設定し、
+   <methodname>PDO::getAttribute</methodname> を介して取得する場合、
+   <type>bool</type> を期待または返却します。
   </simpara>
 
   <simpara>
-   The extension now exposes some Firebird C++ APIs,
-   therefore building this extension now requires a C++ compiler.
-   Moreover, the extension must now be compiled against fbclient 3.0 or higher.
+   この拡張モジュールはいくつかの Firebird C++ API を公開するようになったため、
+   この拡張モジュールをビルドするには C++ コンパイラが必要になりました。
+   さらに、この拡張モジュールは fbclient 3.0 以上にでコンパイルする必要があります。
   </simpara>
  </sect2>
 
@@ -657,13 +652,13 @@
   <title>PDO_MYSQL</title>
 
   <simpara>
-   The <constant>PDO::ATTR_AUTOCOMMIT</constant>,
-   <constant>PDO::ATTR_EMULATE_PREPARES</constant>, and
-   <constant>PDO::MYSQL_ATTR_DIRECT_QUERY</constant> attributes now act as
-   boolean attributes instead of integer attributes.
-   Thus setting the attribute via <methodname>PDO::setAttribute</methodname>
-   and retrieving it via <methodname>PDO::getAttribute</methodname> expects
-   and or return a <type>bool</type>.
+   <constant>PDO::ATTR_AUTOCOMMIT</constant>、
+   <constant>PDO::ATTR_EMULATE_PREPARES</constant>、
+   <constant>PDO::MYSQL_ATTR_DIRECT_QUERY</constant> 属性は、
+   整数属性の代わりにブール属性として動作するようになりました。
+   したがって、<methodname>PDO::setAttribute</methodname> を介して属性を設定し、
+   <methodname>PDO::getAttribute</methodname> を介して取得する場合、
+   <type>bool</type> を期待または返却します。
   </simpara>
  </sect2>
 
@@ -671,8 +666,8 @@
   <title>PDO_PGSQL</title>
 
   <simpara>
-   The DSN's credentials, when set, are given priority over their PDO
-   constructor counterparts, being closer to the documentation states.
+   DSN に認証情報が設定されている場合、PDO コンストラクタの引数よりも優先されるようになり、
+   ドキュメントの記述に近くなりました。
   </simpara>
  </sect2>
 
@@ -680,16 +675,17 @@
   <title>SimpleXML</title>
 
   <simpara>
-   <classname>SimpleXMLElement</classname> is not only a representation of an
-   XML element, but it is also a <classname>RecursiveIterator</classname>.
-   Prior to PHP 8.4.0, some of its methods (e.g.
-   <methodname>SimpleXMLElement::asXML</methodname> or
-   <methodname>SimpleXMLElement::getName</methodname>) and casting such
-   instances to &string; would implicitly reset the iterator.
+   <classname>SimpleXMLElement</classname> は XML 要素の
+   表現であるだけでなく、<classname>RecursiveIterator</classname> でもあります。
+   PHP 8.4.0 より前では、一部のメソッド(例:
+   <methodname>SimpleXMLElement::asXML</methodname> や
+   <methodname>SimpleXMLElement::getName</methodname>)および
+   それらのインスタンスの &string; へのキャストすると、
+   暗黙的にイテレータをリセットしていました。
   </simpara>
   <para>
-   This could cause unexpected infinite loops as the iterator was rewound.
-   For example:
+   これはイテレータが巻き戻されるため、予期しない無限ループを引き起こす可能性がありました。
+   例えば:
    <informalexample>
     <programlisting role="php">
 <![CDATA[
@@ -708,7 +704,7 @@ foreach ($nodes as $nodeData) {
 ]]>
     </programlisting>
     <simpara>
-     would result in an infinite loop.
+     これは無限ループを引き起こしていました。
     </simpara>
     <screen>
 <![CDATA[
@@ -723,10 +719,10 @@ nodeData: 2
 ]]>
     </screen>
     <simpara>
-     However, this behavior has now been corrected, and a
-     <classname>SimpleXMLElement</classname> will no longer implicitly reset
-     the iterator data, unless explicitly rewound.
-     Meaning the previous example would now result in:
+     しかし、この動作は修正され、
+     <classname>SimpleXMLElement</classname> は明示的に巻き戻されない限り、
+     イテレータをリセットしなくなりました。
+     つまり、前述の例は現在では次のようになります:
     </simpara>
     <screen>
 <![CDATA[
@@ -744,21 +740,21 @@ nodeData: 3
   <title>SOAP</title>
 
   <simpara>
-   <property>SoapClient::$typemap</property> is now an <type>array</type>
-   rather than a <type>resource</type>.
-   Checks using <function>is_resource</function> (i.e.
-   <code>is_resource($client->typemap)</code>) should be
-   replaced with checks for &null; (i.e. <code>$client->typemap !== null</code>).
+   <property>SoapClient::$typemap</property> は、<type>resource</type> ではなく
+   <type>array</type> になりました。
+   <function>is_resource</function> を使用したチェック
+   （例: <code>is_resource($client->typemap)</code>)は、
+   &null; かどうかのチェック（例: <code>$client->typemap !== null</code>）に置き換える必要があります。
   </simpara>
 
   <simpara>
-   The SOAP extension gained an optional dependency on the
-   <link linkend="book.session">session</link> extension.
-   If PHP is built without the session extension and with the
-   <option>--enable-rtld-now</option> configure flag enabled,
-   startup errors will now occur if the <link linkend="book.soap">SOAP</link>
-   extension is also used.
-   To solve this either don't use rtld-now or load the session extension.
+   SOAP 拡張モジュールには、<link linkend="book.session">session</link> 拡張モジュールへの
+   オプションの依存関係が追加されました。
+   PHP が session 拡張モジュールなしでビルドされ、かつ
+   <option>--enable-rtld-now</option> 構成フラグが有効になっている場合、
+   <link linkend="book.soap">SOAP</link> 拡張モジュールも使用していると、
+   起動時にエラーが発生します。
+   これを解決するには、rtld-now を使用しないか、session 拡張モジュールを読み込んでください。
   </simpara>
  </sect2>
 
@@ -766,23 +762,23 @@ nodeData: 3
   <title>Standard</title>
 
   <simpara>
-   When using <function>strcspn</function> with
-   <parameter>characters</parameter> being the empty string,
-   the length of the string is now returned instead of incorrectly stopping
-   at the first null byte.
+   <function>strcspn</function> で
+   <parameter>characters</parameter> に空文字列を指定すると
+   文字列の長さが返されるようになりました。
+   以前は、最初のヌルバイトで誤って停止していました。
    <!-- See GH-12592 -->
   </simpara>
 
   <simpara>
-   <function>http_build_query</function> now correctly handles backed enums.
+   <function>http_build_query</function> は、Backed Enumを正しく処理するようになりました。
   </simpara>
 
   <!-- RFC: https://wiki.php.net/rfc/dedicated_stream_bucket -->
   <simpara>
-   <function>stream_bucket_make_writeable</function> and
-   <function>stream_bucket_new</function> will now return a
-   <classname>StreamBucket</classname> instance instead of an instance of
-   <classname>stdClass</classname>.
+   <function>stream_bucket_make_writeable</function> および
+   <function>stream_bucket_new</function> は、
+   <classname>stdClass</classname> のインスタンスではなく、
+   <classname>StreamBucket</classname> のインスタンスを返すようになりました。
   </simpara>
  </sect2>
 
@@ -790,8 +786,8 @@ nodeData: 3
   <title>Tidy</title>
 
   <simpara>
-   Failures in the constructor now throw exceptions rather than emitting
-   warnings and having a broken object.
+   コンストラクタでの失敗時に、警告を発して壊れたオブジェクトになるのではなく、
+   例外をスローするようになりました。
   </simpara>
  </sect2>
 
@@ -799,24 +795,24 @@ nodeData: 3
   <title>XML</title>
 
   <simpara>
-   The <function>xml_set_<replaceable>*</replaceable>_handler</function>
-   functions now declare and check for an effective
-   signature of <type class="union"><type>callable</type><type>string</type><type>null</type></type> for the
-   <parameter>handler</parameter> parameters.
-   Moreover, values of type <type>string</type> that correspond to method names,
-   of object set with <function>xml_set_object</function> are now checked to
-   see if the method exists on the class of the previously passed object.
-   This means that <function>xml_set_object</function> must now always be
-   called prior to setting method names as <type>callable</type>s.
-   Passing an empty string to disable the handler is still allowed,
-   but deprecated.
+   <function>xml_set_<replaceable>*</replaceable>_handler</function>
+   関数は、<parameter>handler</parameter> パラメータに対して
+   <type class="union"><type>callable</type><type>string</type><type>null</type></type> の
+   有効なシグネチャを宣言し、チェックするようになりました。
+   さらに、<function>xml_set_object</function> で設定されたオブジェクトのメソッド名に対応する
+   <type>string</type> 型の値は、事前に渡されたオブジェクトのクラス上にメソッドが存在するかどうかが
+   チェックされるようになりました。
+   従って、<function>xml_set_object</function> は、
+   <type>callable</type> メソッドを設定する前に呼び出す必要があります。
+   ハンドラを無効にするために空文字列を渡すことは引き続き許可されていますが、
+   非推奨となりました。
   </simpara>
 
   <simpara>
-   However, as <function>xml_set_object</function> and passing
-   non-<type>callable</type> strings is deprecated.
-   It is recommended to change such instances with a <type>callable</type>
-   referring to the method directly.
+   しかし、<function>xml_set_object</function> と
+   <type>callable</type> でない文字列を渡すことは非推奨です。
+   そのようなインスタンスをメソッドを直接参照する <type>callable</type> に
+   変更することをお勧めします。
   </simpara>
  </sect2>
 

--- a/appendices/migration84/new-classes.xml
+++ b/appendices/migration84/new-classes.xml
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="utf-8"?>
+<sect1 xml:id="migration84.new-classes">
+ <title>New Classes, Enums, and Interfaces</title>
+
+ <sect2 xml:id="migration84.new-classes.core">
+  <title>Core</title>
+  <simplelist>
+   <member><classname>Deprecated</classname></member>
+   <member><classname>RequestParseBodyException</classname></member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration84.new-classes.bcmath">
+  <title>BCMath</title>
+  <simplelist>
+   <member><classname>BcMath\Number</classname></member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration84.new-classes.dba">
+  <title>DBA</title>
+  <simplelist>
+   <member><classname>Dba\Connection</classname></member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration84.new-classes.dom">
+  <title>DOM</title>
+  <simplelist>
+   <member><classname>Dom\HTMLDocument</classname></member>
+   <member><classname>Dom\XMLDocument</classname></member>
+   <member><classname>Dom\Document</classname></member>
+   <member><classname>Dom\ParentNode</classname></member>
+   <member><classname>Dom\ChildNode</classname></member>
+   <member><classname>Dom\Implementation</classname></member>
+   <member><classname>Dom\Node</classname></member>
+   <member><classname>Dom\NodeList</classname></member>
+   <member><classname>Dom\NamedNodeMap</classname></member>
+   <member><classname>Dom\DtdNamedNodeMap</classname></member>
+   <member><classname>Dom\HTMLCollection</classname></member>
+   <member><classname>Dom\AdjacentPosition</classname></member>
+   <member><classname>Dom\Element</classname></member>
+   <member><classname>Dom\HTMLElement</classname></member>
+   <member><classname>Dom\Attr</classname></member>
+   <member><classname>Dom\CharacterData</classname></member>
+   <member><classname>Dom\Text</classname></member>
+   <member><classname>Dom\CDATASection</classname></member>
+   <member><classname>Dom\ProcessingInstruction</classname></member>
+   <member><classname>Dom\Comment</classname></member>
+   <member><classname>Dom\DocumentType</classname></member>
+   <member><classname>Dom\DocumentFragment</classname></member>
+   <member><classname>Dom\Entity</classname></member>
+   <member><classname>Dom\EntityReference</classname></member>
+   <member><classname>Dom\Notation</classname></member>
+   <member><classname>Dom\TokenList</classname></member>
+   <member><classname>Dom\NamespaceInfo</classname></member>
+   <member><classname>Dom\XPath</classname></member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration84.new-classes.odbc">
+  <title>ODBC</title>
+  <simplelist>
+   <member><classname>Odbc\Connection</classname></member>
+   <member><classname>Odbc\Result</classname></member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration84.new-classes.pcntl">
+  <title>PCNTL</title>
+  <simplelist>
+   <!-- Should this use <enumname> ? -->
+   <member><classname>Pcntl\QosClass</classname> (macOS only)</member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration84.new-classes.pdo-dblib">
+  <title>PDO_DBLIB</title>
+  <simplelist>
+   <member><classname>Pdo\DbLib</classname></member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration84.new-classes.pdo-firebird">
+  <title>PDO_FIREBIRD</title>
+  <simplelist>
+   <member><classname>Pdo\Firebird</classname></member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration84.new-classes.pdo-mysql">
+  <title>PDO_MYSQL</title>
+  <simplelist>
+   <member><classname>Pdo\Mysql</classname></member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration84.new-classes.pdo-odbc">
+  <title>PDO_ODBC</title>
+  <simplelist>
+   <member><classname>Pdo\Odbc</classname></member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration84.new-classes.pdo-pgsql">
+  <title>PDO_PGSQL</title>
+  <simplelist>
+   <member><classname>Pdo\Pgsql</classname></member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration84.new-classes.pdo-sqlite">
+  <title>PDO_SQLITE</title>
+  <simplelist>
+   <member><classname>Pdo\Sqlite</classname></member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration84.new-classes.reflection">
+  <title>Reflection</title>
+  <simplelist>
+   <member><classname>ReflectionConstant</classname></member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration84.new-classes.soap">
+  <title>SOAP</title>
+  <simplelist>
+   <member><classname>Soap\Url</classname></member>
+   <member><classname>Soap\Sdl</classname></member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration84.new-classes.standard">
+  <title>Standard</title>
+
+  <simplelist>
+   <!-- Should this use <enumname> ? -->
+   <member><classname>RoundingMode</classname></member>
+   <member><classname>StreamBucket</classname></member>
+  </simplelist>
+ </sect2>
+
+</sect1>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/appendices/migration84/new-classes.xml
+++ b/appendices/migration84/new-classes.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 5743f224cd541f744a4867574b5d6dc40ef42cb9 Maintainer: KentarouTakeda Status: ready -->
+<!-- Credits: KentarouTakeda -->
 <sect1 xml:id="migration84.new-classes">
- <title>New Classes, Enums, and Interfaces</title>
+ <title>新しいクラス、列挙型、インターフェイス</title>
 
  <sect2 xml:id="migration84.new-classes.core">
   <title>Core</title>
@@ -70,7 +73,7 @@
   <title>PCNTL</title>
   <simplelist>
    <!-- Should this use <enumname> ? -->
-   <member><classname>Pcntl\QosClass</classname> (macOS only)</member>
+   <member><classname>Pcntl\QosClass</classname> (macOSのみ)</member>
   </simplelist>
  </sect2>
 

--- a/appendices/migration84/new-features.xml
+++ b/appendices/migration84/new-features.xml
@@ -1,0 +1,627 @@
+<?xml version="1.0" encoding="utf-8"?>
+<sect1 xml:id="migration84.new-features">
+ <title>New Features</title>
+
+ <!-- TODO: Core features for 8.4 -->
+ <sect2 xml:id="migration84.new-features.core">
+  <title>PHP Core</title>
+
+  <!-- RFC: https://wiki.php.net/rfc/property-hooks -->
+  <sect3 xml:id="migration84.new-features.core.property-hooks">
+   <title>Property Hooks</title>
+
+   <simpara>
+    Object properties may now have additional logic associated with their
+    <literal>get</literal> and <literal>set</literal> operations.
+    Depending on the usage, that may or may not make the property virtual,
+    that is, it has no backing value at all.
+   </simpara>
+
+   <informalexample>
+    <programlisting role="php">
+<![CDATA[
+<?php
+class Person
+{
+    // A "virtual" property.  It may not be set explicitly.
+    public string $fullName {
+        get => $this->firstName . ' ' . $this->lastName;
+    }
+
+    // All write operations go through this hook, and the result is what is written.
+    // Read access happens normally.
+    public string $firstName {
+        set => ucfirst(strtolower($value));
+    }
+
+    // All write operations go through this hook, which has to write to the backing value itself.
+    // Read access happens normally.
+    public string $lastName {
+        set {
+            if (strlen($value) < 2) {
+                throw new \InvalidArgumentException('Too short');
+            }
+            $this->lastName = $value;
+        }
+    }
+}
+
+$p = new Person();
+
+$p->firstName = 'peter';
+print $p->firstName; // Prints "Peter"
+$p->lastName = 'Peterson';
+print $p->fullName; // Prints "Peter Peterson"
+]]>
+    </programlisting>
+   </informalexample>
+  </sect3>
+
+  <!-- RFC: https://wiki.php.net/rfc/asymmetric-visibility-v2 -->
+  <sect3 xml:id="migration84.new-features.core.asymmetric-property-visibility">
+   <title>Asymmetric Property Visibility</title>
+
+   <simpara>
+    Object properties may now have their <literal>set</literal> visibility
+    controlled separately from the <literal>get</literal> visibility.
+   </simpara>
+   <informalexample>
+    <programlisting role="php">
+<![CDATA[
+<?php
+class Example
+{
+    // The first visibility modifier controls the get-visibility, and the second modifier
+    // controls the set-visibility. The get-visibility must not be narrower than set-visibility.
+    public protected(set) string $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+}
+]]>
+    </programlisting>
+   </informalexample>
+  </sect3>
+
+  <!-- RFC: https://wiki.php.net/rfc/lazy-objects -->
+  <sect3 xml:id="migration84.new-features.core.lazy-objects">
+   <title>Lazy Objects</title>
+   <simpara>
+    It is now possible to create objects whose initialization is deferred until
+    they are accessed. Libraries and frameworks can leverage these lazy objects
+    to defer fetching data or dependencies required for initialization.
+   </simpara>
+   <informalexample>
+    <programlisting role="php">
+<![CDATA[
+<?php
+class Example
+{
+    public function __construct(private int $data)
+    {
+    }
+
+    // ...
+}
+
+$initializer = static function (Example $ghost): void {
+    // Fetch data or dependencies
+    $data = ...;
+    // Initialize
+    $ghost->__construct($data);
+};
+
+$reflector = new ReflectionClass(Example::class);
+$object = $reflector->newLazyGhost($initializer);
+]]>
+    </programlisting>
+   </informalexample>
+  </sect3>
+
+  <!-- RFC: https://wiki.php.net/rfc/deprecated_attribute -->
+  <sect3 xml:id="migration84.new-features.core.deprecated-attribute">
+   <title><code>#[\Deprecated]</code> attribute</title>
+
+   <simpara>
+    The new <classname>Deprecated</classname> attribute can be used to mark functions, methods,
+    and class constants as deprecated. The behavior of functionality deprecated with this
+    attribute matches the behavior of the existing deprecation mechanism for functionality
+    provided by PHP itself. The only exception is that the emitted error code is
+    <constant>E_USER_DEPRECATED</constant> instead of <constant>E_DEPRECATED</constant>.
+   </simpara>
+
+   <simpara>
+    Existing deprecations in functionality provided by PHP itself have been updated to use
+    the attribute, improving the emitted error messages by including a short explanation.
+   </simpara>
+  </sect3>
+
+  <!-- RFC: https://wiki.php.net/rfc/rfc1867-non-post -->
+  <sect3 xml:id="migration84.new-features.core.rfc1867">
+   <title>Parsing RFC1867 (multipart) requests in non-POST HTTP requests</title>
+
+   <!-- TODO: expand? -->
+   <simpara>
+    Added <function>request_parse_body</function> function that allows parsing
+    RFC1867 (multipart) requests in non-POST HTTP requests.
+   </simpara>
+  </sect3>
+
+  <!-- RFC: https://wiki.php.net/rfc/new_without_parentheses -->
+  <sect3 xml:id="migration84.new-features.core.new-chaining">
+   <title>Chaining &new; expressions without parentheses</title>
+
+   <!-- TODO: expand and examples? -->
+   <simpara>
+    New expressions with constructor arguments are now dereferencable, meaning
+    they allow chaining method calls, property accesses, etc. without enclosing
+    the expression in parentheses.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.new-features.core.debug-weakref">
+   <title>Improved Debugging Info for <classname>WeakReference</classname></title>
+
+   <!-- TODO: expand and examples? -->
+   <simpara>
+    Getting the debug info for <classname>WeakReference</classname> will now
+    also output the object it references, or &null; if the reference is no
+    longer valid.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.new-features.core.debug-closure">
+   <title>Improved Debugging Info for <classname>Closure</classname></title>
+
+   <!-- TODO: expand and examples? -->
+   <simpara>
+    The output of <methodname>Closure::__debugInfo</methodname> now includes
+    the name, file, and line of the <classname>Closure</classname>.
+   </simpara>
+  </sect3>
+
+  <!-- Is this really a feature? Should this be moved to other changes? -->
+  <sect3 xml:id="migration84.new-features.core.multiple-namespaces-symbols">
+   <title>Defining Identical Symbols in Different Namespace Blocks</title>
+
+   <!-- TODO: expand and examples? -->
+   <simpara>
+    Exiting a namespace now clears seen symbols.
+    This allows using a symbol in a namespace block, even if a previous
+    namespace block declared a symbol with the same name.
+    <!-- See Zend/tests/use_function/ns_end_resets_seen_symbols_1.phpt. -->
+   </simpara>
+  </sect3>
+
+ </sect2>
+
+ <sect2 xml:id="migration84.new-features.curl">
+  <title>cURL</title>
+
+  <simpara>
+   <function>curl_version</function> returns an additional
+   <literal>feature_list</literal> value, which is an associative array
+   of all known cURL features, and whether they are supported (&true;)
+   or not (&false;).
+  </simpara>
+
+  <simpara>
+   Added <constant>CURL_HTTP_VERSION_3</constant> and
+   <constant>CURL_HTTP_VERSION_3ONLY</constant> constants (available
+   since libcurl 7.66 and 7.88) as available options for
+   <constant>CURLOPT_HTTP_VERSION</constant>.
+  </simpara>
+
+  <simpara>
+   Added <constant>CURLOPT_PREREQFUNCTION</constant> as a cURL option that
+   accepts a <type>callable</type> to be called after the connection is made,
+   but before the request is sent.
+   This callable must return either <constant>CURL_PREREQFUNC_OK</constant> or
+   <constant>CURL_PREREQFUNC_ABORT</constant> to allow or abort the request.
+  </simpara>
+
+  <simpara>
+   Added <constant>CURLOPT_SERVER_RESPONSE_TIMEOUT</constant>,
+   which was formerly known as <constant>CURLOPT_FTP_RESPONSE_TIMEOUT</constant>.
+   Both constants hold the same value.
+  </simpara>
+
+  <para>
+   Added <constant>CURLOPT_DEBUGFUNCTION</constant> as a cURL option that
+   accepts a <type>callable</type> that gets called during the request lifetime
+   with the <classname>CurlHandle</classname> object,
+   an integer containing the debug message type, and a string containing the
+   debug message.
+   The debug message type is one of the following constants:
+   <simplelist>
+    <member><constant>CURLINFO_TEXT</constant></member>
+    <member><constant>CURLINFO_HEADER_IN</constant></member>
+    <member><constant>CURLINFO_HEADER_OUT</constant></member>
+    <member><constant>CURLINFO_DATA_IN</constant></member>
+    <member><constant>CURLINFO_DATA_OUT</constant></member>
+    <member><constant>CURLINFO_SSL_DATA_IN</constant></member>
+    <member><constant>CURLINFO_SSL_DATA_OUT</constant></member>
+   </simplelist>
+   Once this option is set, <constant>CURLINFO_HEADER_OUT</constant>
+   must not be set because it uses the same libcurl functionality.
+  </para>
+
+  <simpara>
+   The <function>curl_getinfo</function> now returns an additional
+   <literal>posttransfer_time_us</literal> key, containing the number of
+   microseconds from the start until the last byte is sent.
+   When a redirect is followed, the time from each request is added together.
+   This value can also be retrieved by passing
+   <constant>CURLINFO_POSTTRANSFER_TIME_T</constant> to the
+   <function>curl_getinfo</function> <parameter>option</parameter> parameter.
+   This requires libcurl 8.10.0 or later.
+  </simpara>
+ </sect2>
+
+ <sect2 xml:id="migration84.new-features.dom">
+  <title>DOM</title>
+
+  <!-- RFC: https://wiki.php.net/rfc/domdocument_html5_parser -->
+  <!-- RFC: https://wiki.php.net/rfc/opt_in_dom_spec_compliance -->
+  <simpara>
+   Added the <package>Dom</package> namespace with new classes as counterparts
+   to the existing DOM classes (e.g. <classname>Dom\Node</classname> is the new
+   <classname>DOMNode</classname>).
+   These classes are compatible with HTML 5 and are WHATWG spec-compliant;
+   solving long-standing bugs in the DOM extension.
+   The old DOM classes remain available for backwards compatibility.
+  </simpara>
+
+  <para>
+   Added the <methodname>DOMNode::compareDocumentPosition</methodname>
+   with its associated constants:
+   <simplelist>
+    <member><constant>DOMNode::DOCUMENT_POSITION_DISCONNECTED</constant></member>
+    <member><constant>DOMNode::DOCUMENT_POSITION_PRECEDING</constant></member>
+    <member><constant>DOMNode::DOCUMENT_POSITION_FOLLOWING</constant></member>
+    <member><constant>DOMNode::DOCUMENT_POSITION_CONTAINS</constant></member>
+    <member><constant>DOMNode::DOCUMENT_POSITION_CONTAINED_BY</constant></member>
+    <member><constant>DOMNode::DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC</constant></member>
+   </simplelist>
+  </para>
+
+  <!-- RFC: https://wiki.php.net/rfc/improve_callbacks_dom_and_xsl -->
+  <simpara>
+   It is now possible to pass any callable to
+   <methodname>DOMXPath::registerPhpFunctions</methodname>.
+
+   Furthermore, with <methodname>DOMXPath::registerPhpFunctionNs</methodname>,
+   callbacks can now be registered that will use native function call syntax
+   rather than using <code>php:function('name')</code>.
+  </simpara>
+ </sect2>
+
+ <!-- TODO: Should this be moved to "other changes" in the SAPI section? - Girgias -->
+ <sect2 xml:id="migration84.new-features.fpm">
+  <title>FPM</title>
+
+  <simpara>
+   Flushing headers without a body will now succeed.
+   <!-- See GH-12785. -->
+  </simpara>
+
+  <simpara>
+   Status page has a new field to display a memory peak.
+  </simpara>
+ </sect2>
+
+ <sect2 xml:id="migration84.new-features.intl">
+  <title>Intl</title>
+
+  <simpara>
+   Added the <constant>NumberFormatter::ROUND_HALFODD</constant> to
+   complement the existing <constant>NumberFormatter::ROUND_HALFEVEN</constant>
+   functionality.
+  </simpara>
+ </sect2>
+
+ <sect2 xml:id="migration84.new-features.openssl">
+  <title>OpenSSL</title>
+
+  <simpara>
+   Added support for Curve25519 + Curve448 based keys.
+   Specifically x25519, ed25519, x448 and ed448 fields are supported in
+   <function>openssl_pkey_new</function>,
+   <function>openssl_pkey_get_details</function>,
+   <function>openssl_sign</function>, and
+   <function>openssl_verify</function> were extended to support those keys.
+  </simpara>
+
+  <simpara>
+   Implement PASSWORD_ARGON2 password hashing.
+   Requires OpenSSL 3.2 and NTS build.
+  </simpara>
+ </sect2>
+
+ <sect2 xml:id="migration84.new-features.pcre">
+  <title>PCRE</title>
+
+  <simpara>
+   The bundled pcre2lib has been updated to version 10.44.
+   As a consequence, LoongArch JIT support has been added, spaces
+   are now allowed between braces in Perl-compatible items, and
+   variable-length lookbehind assertions are now supported.
+  </simpara>
+
+  <simpara>
+   With pcre2lib version 10.44, the maximum length of named capture groups
+   has changed from <literal>32</literal> to <literal>128</literal>.
+  </simpara>
+
+  <simpara>
+   Added support for the <literal>r</literal> (PCRE2_EXTRA_CASELESS_RESTRICT)
+   modifier, as well as the <literal>(?r)</literal> mode modifier.
+   When enabled along with the case-insensitive modifier (<literal>i</literal>),
+   the expression locks out mixing of ASCII and non-ASCII characters.
+  </simpara>
+ </sect2>
+
+ <sect2 xml:id="migration84.new-features.pdo">
+  <title>PDO</title>
+
+  <!-- RFC: https://wiki.php.net/rfc/pdo_driver_specific_subclasses -->
+  <simpara>
+   Added support for driver-specific subclasses.
+   This RFC adds subclasses for PDO in order to better support
+   database-specific functionalities.
+   The new classes are instantiatable either via calling the
+   <methodname>PDO::connect</methodname> method or by instantiating an instance
+   of the driver-specific subclass directly.
+  </simpara>
+
+  <!-- RFC: https://wiki.php.net/rfc/pdo_driver_specific_parsers -->
+  <para>
+   Added support for driver specific SQL parsers.
+   The default parser supports:
+   <simplelist>
+    <member>
+     single and double-quoted literals, with doubling as escaping mechanism
+    </member>
+    <member>
+     two-dashes and non-nested C-style comments
+    </member>
+   </simplelist>
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration84.new-features.pdo-mysql">
+  <title>PDO_MYSQL</title>
+
+  <!-- RFC: https://wiki.php.net/rfc/pdo_driver_specific_parsers -->
+  <para>
+   Added a custom parser supporting:
+   <simplelist>
+    <member>
+     single and double-quoted literals, with doubling and backslash as escaping
+     mechanism
+    </member>
+    <member>
+     backtick literal identifiers and with doubling as escaping mechanism
+    </member>
+    <member>
+     two dashes followed by at least 1 whitespace, non-nested C-style comments,
+     and hash-comments
+    </member>
+   </simplelist>
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration84.new-features.pdo-pgsql">
+  <title>PDO_PGSQL</title>
+
+  <!-- RFC: https://wiki.php.net/rfc/pdo_driver_specific_parsers -->
+  <para>
+   Added a custom parser supporting:
+   <simplelist>
+    <member>
+     single and double-quoted literals, with doubling as escaping mechanism
+    </member>
+    <member>
+     C-style "escape" string literals (<literal>E'string'</literal>)
+    </member>
+    <member>
+     dollar-quoted string literals
+    </member>
+    <member>
+     two-dashes and C-style comments (non-nested)
+    </member>
+    <member>
+     support for <literal>??</literal> as escape sequence for the
+     <literal>?</literal> operator
+    </member>
+   </simplelist>
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration84.new-features.pdo-sqlite">
+  <title>PDO_SQLITE</title>
+
+  <!-- RFC: https://wiki.php.net/rfc/pdo_driver_specific_parsers -->
+  <para>
+   Added a custom parser supporting:
+   <simplelist>
+    <member>
+     single, double-quoted, and backtick literals, with doubling as
+     escaping mechanism
+    </member>
+    <member>
+     square brackets quoting for identifiers
+    </member>
+    <member>
+     two-dashes and C-style comments (non-nested)
+    </member>
+   </simplelist>
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration84.new-features.phar">
+  <title>Phar</title>
+
+  <simpara>
+   Added support for the Unix timestamp extension for Zip archives.
+  </simpara>
+ </sect2>
+
+ <sect2 xml:id="migration84.new-features.readfile">
+  <title>Readfile</title>
+
+  <simpara>
+   Added ability to change the <literal>.php_history</literal> path through
+   the <envar>PHP_HISTFILE</envar> environment variable.
+  </simpara>
+ </sect2>
+
+ <sect2 xml:id="migration84.new-features.reflection">
+  <title>Reflection</title>
+
+  <simpara>
+   <classname>ReflectionAttribute</classname> now contains a
+   <property>name</property> property to improve the debugging experience.
+  </simpara>
+
+  <simpara>
+   <methodname>ReflectionClassConstant::__toString</methodname> and
+   <methodname>ReflectionProperty::__toString</methodname> now returns the
+   attached doc comments.
+  </simpara>
+
+  <!-- RFC: https://wiki.php.net/rfc/lazy-objects -->
+  <para>
+   Multiple new methods and constants which are related to the lazy objects
+   feature have been added:
+
+   <simplelist>
+    <member>
+     <methodname>ReflectionClass::newLazyGhost</methodname>
+    </member>
+    <member>
+     <methodname>ReflectionClass::newLazyProxy</methodname>
+    </member>
+    <member>
+     <methodname>ReflectionClass::resetAsLazyGhost</methodname>
+    </member>
+    <member>
+     <methodname>ReflectionClass::resetAsLazyProxy</methodname>
+    </member>
+    <member>
+     <methodname>ReflectionClass::isUninitializedLazyObject</methodname>
+    </member>
+    <member>
+     <methodname>ReflectionClass::initializeLazyObject</methodname>
+    </member>
+    <member>
+     <methodname>ReflectionClass::markLazyObjectAsInitialized</methodname>
+    </member>
+    <member>
+     <methodname>ReflectionClass::getLazyInitializer</methodname>
+    </member>
+    <member>
+     <methodname>ReflectionClass::skipLazyInitialization</methodname>
+    </member>
+    <member>
+     <methodname>ReflectionClass::setRawValueWithoutLazyInitialization</methodname>
+    </member>
+    <member>
+     <constant>ReflectionClass::SKIP_INITIALIZATION_ON_SERIALIZE</constant>
+    </member>
+    <member>
+     <constant>ReflectionClass::SKIP_DESTRUCTOR</constant>
+    </member>
+   </simplelist>
+  </para>
+ </sect2>
+
+ <sect2 xml:id="migration84.new-features.soap">
+  <title>SOAP</title>
+
+  <simpara>
+   Added support for clark notation for namespaces in class map.
+   It is now possible to specify entries in a class map with clark notation
+   to resolve a type with a specific namespace to a specific class.
+   For example: <code>'{http://example.com}foo' => 'FooClass'</code>.
+  </simpara>
+
+  <simpara>
+   Instances of <interfacename>DateTimeInterface</interfacename> that are
+   passed to <literal>xsd:datetime</literal> or similar elements are now
+   serialized as such instead of being serialized as an empty string.
+  </simpara>
+
+  <simpara>
+   Session persistence now works with a shared session module.
+  </simpara>
+ </sect2>
+
+ <sect2 xml:id="migration84.new-features.standard">
+  <title>Standard</title>
+
+  <!-- RFC: https://wiki.php.net/rfc/correctly_name_the_rounding_mode_and_make_it_an_enum -->
+  <simpara>
+   <!-- Should this use <enumname> -->
+   Added a new <classname>RoundingMode</classname> enum with clearer naming
+   and improved discoverability compared to the
+   <constant>PHP_ROUND_<replaceable>*</replaceable></constant> constants.
+   Moreover, four new rounding modes were added which are only available via
+   the new <classname>RoundingMode</classname> enum.
+  </simpara>
+ </sect2>
+
+ <sect2 xml:id="migration84.new-features.xsl">
+  <title>XSL</title>
+
+  <simpara>
+   It is now possible to use parameters that contain both single and double
+   quotes.
+  </simpara>
+
+  <!-- RFC: https://wiki.php.net/rfc/improve_callbacks_dom_and_xsl -->
+  <simpara>
+   It is now possible to pass any callable to
+   <methodname>XSLTProcessor::registerPhpFunctions</methodname>.
+   <!-- TODO Mention XSLTProcessor::registerPHPFunctionNS ? -->
+  </simpara>
+
+  <simpara>
+   Added <property>XSLTProcessor::$maxTemplateDepth</property> and
+   <property>XSLTProcessor::$maxTemplateVars</property>
+   to control the recursion depth of XSL template evaluation.
+  </simpara>
+ </sect2>
+
+ <sect2 xml:id="migration84.new-features.zip">
+  <title>Zip</title>
+
+  <simpara>
+   Added the <constant>ZipArchive::ER_TRUNCATED_ZIP</constant>
+   constant, which was added in libzip 1.11.
+  </simpara>
+ </sect2>
+
+</sect1>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/appendices/migration84/new-features.xml
+++ b/appendices/migration84/new-features.xml
@@ -1,20 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 56b4b1960e07355f889ef6e4e3b75ebdc59507b9 Maintainer: KentarouTakeda Status: ready -->
+<!-- Credits: KentarouTakeda -->
 <sect1 xml:id="migration84.new-features">
- <title>New Features</title>
+ <title>新機能</title>
 
  <!-- TODO: Core features for 8.4 -->
  <sect2 xml:id="migration84.new-features.core">
-  <title>PHP Core</title>
+  <title>PHP コア</title>
 
   <!-- RFC: https://wiki.php.net/rfc/property-hooks -->
   <sect3 xml:id="migration84.new-features.core.property-hooks">
-   <title>Property Hooks</title>
+   <title>プロパティフック</title>
 
    <simpara>
-    Object properties may now have additional logic associated with their
-    <literal>get</literal> and <literal>set</literal> operations.
-    Depending on the usage, that may or may not make the property virtual,
-    that is, it has no backing value at all.
+    オブジェクトのプロパティは、
+    <literal>get</literal> および <literal>set</literal> 操作に
+    追加のロジックを関連付けることができるようになりました。
+    使用方法に応じてそのプロパティは、値を持つ場合もありますし、
+    仮想的、つまり値を持たない場合もあります。
    </simpara>
 
    <informalexample>
@@ -23,19 +27,19 @@
 <?php
 class Person
 {
-    // A "virtual" property.  It may not be set explicitly.
+    // 「仮想」プロパティ。明示的に設定されることはありません。
     public string $fullName {
         get => $this->firstName . ' ' . $this->lastName;
     }
 
-    // All write operations go through this hook, and the result is what is written.
-    // Read access happens normally.
+    // すべての書き込み操作はこのフックを通り、返却値が書き込まれます。
+    // 読み取りアクセスは通常通り行われます。
     public string $firstName {
         set => ucfirst(strtolower($value));
     }
 
-    // All write operations go through this hook, which has to write to the backing value itself.
-    // Read access happens normally.
+    // すべての書き込み操作はこのフックを通り、フックの中で値が書き込まれます。
+    // 読み取りアクセスは通常通り行われます。
     public string $lastName {
         set {
             if (strlen($value) < 2) {
@@ -59,11 +63,10 @@ print $p->fullName; // Prints "Peter Peterson"
 
   <!-- RFC: https://wiki.php.net/rfc/asymmetric-visibility-v2 -->
   <sect3 xml:id="migration84.new-features.core.asymmetric-property-visibility">
-   <title>Asymmetric Property Visibility</title>
+   <title>非対称可視性プロパティ</title>
 
    <simpara>
-    Object properties may now have their <literal>set</literal> visibility
-    controlled separately from the <literal>get</literal> visibility.
+    オブジェクトのプロパティは、<literal>set</literal> の可視性を <literal>get</literal> の可視性とは別に制御できるようになりました。
    </simpara>
    <informalexample>
     <programlisting role="php">
@@ -71,8 +74,8 @@ print $p->fullName; // Prints "Peter Peterson"
 <?php
 class Example
 {
-    // The first visibility modifier controls the get-visibility, and the second modifier
-    // controls the set-visibility. The get-visibility must not be narrower than set-visibility.
+    // 最初の可視性修飾子は取得時の可視性を制御し、2つ目の修飾子は設定時の可視性を制御します。
+    // 取得時の可視性は設定時の可視性よりも狭くなってはいけません。
     public protected(set) string $name;
 
     public function __construct(string $name)
@@ -87,11 +90,11 @@ class Example
 
   <!-- RFC: https://wiki.php.net/rfc/lazy-objects -->
   <sect3 xml:id="migration84.new-features.core.lazy-objects">
-   <title>Lazy Objects</title>
+   <title>レイジーオブジェクト</title>
    <simpara>
-    It is now possible to create objects whose initialization is deferred until
-    they are accessed. Libraries and frameworks can leverage these lazy objects
-    to defer fetching data or dependencies required for initialization.
+    アクセスされるまで初期化が延期されるオブジェクトを作成できるようになりました。
+    ライブラリやフレームワークは、これらのレイジーオブジェクトを利用して、
+    初期化に必要なデータや依存関係の取得を遅延させることができます。
    </simpara>
    <informalexample>
     <programlisting role="php">
@@ -122,75 +125,75 @@ $object = $reflector->newLazyGhost($initializer);
 
   <!-- RFC: https://wiki.php.net/rfc/deprecated_attribute -->
   <sect3 xml:id="migration84.new-features.core.deprecated-attribute">
-   <title><code>#[\Deprecated]</code> attribute</title>
+   <title><code>#[\Deprecated]</code> アトリビュート</title>
 
    <simpara>
-    The new <classname>Deprecated</classname> attribute can be used to mark functions, methods,
-    and class constants as deprecated. The behavior of functionality deprecated with this
-    attribute matches the behavior of the existing deprecation mechanism for functionality
-    provided by PHP itself. The only exception is that the emitted error code is
-    <constant>E_USER_DEPRECATED</constant> instead of <constant>E_DEPRECATED</constant>.
+    新しい <classname>Deprecated</classname> 属性を使用して、関数、メソッド、
+    およびクラス定数を非推奨としてマークできます。このアトリビュートで非推奨となった機能の動作は、
+    PHP 自身が提供する既存の非推奨メカニズムの動作と一致します。
+    唯一の例外は、発生するエラーコードが
+    <constant>E_DEPRECATED</constant> ではなく <constant>E_USER_DEPRECATED</constant> であることです。
    </simpara>
 
    <simpara>
-    Existing deprecations in functionality provided by PHP itself have been updated to use
-    the attribute, improving the emitted error messages by including a short explanation.
+    PHP 自身が提供する機能の既存の非推奨は、この属性を使用するように更新され、
+    短い説明を含むことでエラーメッセージが改善されました。
    </simpara>
   </sect3>
 
   <!-- RFC: https://wiki.php.net/rfc/rfc1867-non-post -->
   <sect3 xml:id="migration84.new-features.core.rfc1867">
-   <title>Parsing RFC1867 (multipart) requests in non-POST HTTP requests</title>
+   <title>POST 以外の HTTP リクエストでの RFC1867 (マルチパート)リクエストの解析</title>
 
    <!-- TODO: expand? -->
    <simpara>
-    Added <function>request_parse_body</function> function that allows parsing
-    RFC1867 (multipart) requests in non-POST HTTP requests.
+    POST 以外の HTTP リクエストで RFC1867（マルチパート）リクエストを解析するための
+    <function>request_parse_body</function> 関数が追加されました。
    </simpara>
   </sect3>
 
   <!-- RFC: https://wiki.php.net/rfc/new_without_parentheses -->
   <sect3 xml:id="migration84.new-features.core.new-chaining">
-   <title>Chaining &new; expressions without parentheses</title>
+   <title>括弧なしでの &new; 式のチェーン</title>
 
    <!-- TODO: expand and examples? -->
    <simpara>
-    New expressions with constructor arguments are now dereferencable, meaning
-    they allow chaining method calls, property accesses, etc. without enclosing
-    the expression in parentheses.
+    コンストラクタ引数を持つ &new; 式は直接参照できるようになり、
+    式を括弧で囲むことなくメソッド呼び出しや
+    プロパティアクセスなどのチェーンが可能になりました。
    </simpara>
   </sect3>
 
   <sect3 xml:id="migration84.new-features.core.debug-weakref">
-   <title>Improved Debugging Info for <classname>WeakReference</classname></title>
+   <title><classname>WeakReference</classname> のデバッグ情報の改善</title>
 
    <!-- TODO: expand and examples? -->
    <simpara>
-    Getting the debug info for <classname>WeakReference</classname> will now
-    also output the object it references, or &null; if the reference is no
-    longer valid.
+    <classname>WeakReference</classname> のデバッグ情報を取得すると、
+    参照しているオブジェクト、または参照が無効になっている場合は
+    &null; が出力されるようになりました。
    </simpara>
   </sect3>
 
   <sect3 xml:id="migration84.new-features.core.debug-closure">
-   <title>Improved Debugging Info for <classname>Closure</classname></title>
+   <title><classname>Closure</classname> のデバッグ情報の改善</title>
 
    <!-- TODO: expand and examples? -->
    <simpara>
-    The output of <methodname>Closure::__debugInfo</methodname> now includes
-    the name, file, and line of the <classname>Closure</classname>.
+    <methodname>Closure::__debugInfo</methodname> の出力には、
+    <classname>Closure</classname> の名前、ファイル名、および行が含まれるようになりました。
    </simpara>
   </sect3>
 
   <!-- Is this really a feature? Should this be moved to other changes? -->
   <sect3 xml:id="migration84.new-features.core.multiple-namespaces-symbols">
-   <title>Defining Identical Symbols in Different Namespace Blocks</title>
+   <title>異なる名前空間ブロックで同一のシンボルを定義</title>
 
    <!-- TODO: expand and examples? -->
    <simpara>
-    Exiting a namespace now clears seen symbols.
-    This allows using a symbol in a namespace block, even if a previous
-    namespace block declared a symbol with the same name.
+    名前空間を終了すると、そこで定義されたシンボルがクリアされるようになりました。
+    これにより、以前の名前空間ブロックで同じ名前のシンボルが宣言されていても、
+    名前空間ブロック内でシンボルを使用できるようになりました。
     <!-- See Zend/tests/use_function/ns_end_resets_seen_symbols_1.phpt. -->
    </simpara>
   </sect3>
@@ -201,40 +204,41 @@ $object = $reflector->newLazyGhost($initializer);
   <title>cURL</title>
 
   <simpara>
-   <function>curl_version</function> returns an additional
-   <literal>feature_list</literal> value, which is an associative array
-   of all known cURL features, and whether they are supported (&true;)
-   or not (&false;).
+   <function>curl_version</function> は、新たに
+   <literal>feature_list</literal> 値を返すようになりました。これは、
+   既知のすべての cURL 機能と、それらがサポートされているか(&true;)されていないか
+   (&false;)を示す連想配列です。
   </simpara>
 
   <simpara>
-   Added <constant>CURL_HTTP_VERSION_3</constant> and
-   <constant>CURL_HTTP_VERSION_3ONLY</constant> constants (available
-   since libcurl 7.66 and 7.88) as available options for
-   <constant>CURLOPT_HTTP_VERSION</constant>.
+   <constant>CURLOPT_HTTP_VERSION</constant> のオプションとして、
+   <constant>CURL_HTTP_VERSION_3</constant> および
+   <constant>CURL_HTTP_VERSION_3ONLY</constant> 定数
+   （libcurl 7.66 および 7.88 から利用可能）
+   が追加されました。
   </simpara>
 
   <simpara>
-   Added <constant>CURLOPT_PREREQFUNCTION</constant> as a cURL option that
-   accepts a <type>callable</type> to be called after the connection is made,
-   but before the request is sent.
-   This callable must return either <constant>CURL_PREREQFUNC_OK</constant> or
-   <constant>CURL_PREREQFUNC_ABORT</constant> to allow or abort the request.
+   cURL オプションとして<constant>CURLOPT_PREREQFUNCTION</constant> が追加されました。
+   接続が確立された後、リクエストが送信される前に呼び出される
+   <type>callable</type> を受け入れます。
+   この callable は、リクエストを許可または中止するために <constant>CURL_PREREQFUNC_OK</constant> または
+   <constant>CURL_PREREQFUNC_ABORT</constant> のいずれかを返す必要があります。
   </simpara>
 
   <simpara>
-   Added <constant>CURLOPT_SERVER_RESPONSE_TIMEOUT</constant>,
-   which was formerly known as <constant>CURLOPT_FTP_RESPONSE_TIMEOUT</constant>.
-   Both constants hold the same value.
+   <constant>CURLOPT_SERVER_RESPONSE_TIMEOUT</constant> が追加されました。
+   これは以前は <constant>CURLOPT_FTP_RESPONSE_TIMEOUT</constant> として知られていました。
+   両方の定数は同じ値を持ちます。
   </simpara>
 
   <para>
-   Added <constant>CURLOPT_DEBUGFUNCTION</constant> as a cURL option that
-   accepts a <type>callable</type> that gets called during the request lifetime
-   with the <classname>CurlHandle</classname> object,
-   an integer containing the debug message type, and a string containing the
-   debug message.
-   The debug message type is one of the following constants:
+   cURL オプションとして <constant>CURLOPT_DEBUGFUNCTION</constant> が追加されました。
+   リクエストの実行中に呼び出される <type>callable</type> を受け入れます。
+   この callable は、<classname>CurlHandle</classname> オブジェクト、
+   デバッグメッセージの種類を含む整数、
+   およびデバッグメッセージを含む文字列を受け取ります。
+   デバッグメッセージの種類は、次の定数のいずれかです:
    <simplelist>
     <member><constant>CURLINFO_TEXT</constant></member>
     <member><constant>CURLINFO_HEADER_IN</constant></member>
@@ -244,19 +248,19 @@ $object = $reflector->newLazyGhost($initializer);
     <member><constant>CURLINFO_SSL_DATA_IN</constant></member>
     <member><constant>CURLINFO_SSL_DATA_OUT</constant></member>
    </simplelist>
-   Once this option is set, <constant>CURLINFO_HEADER_OUT</constant>
-   must not be set because it uses the same libcurl functionality.
+   このオプションを設定した場合、<constant>CURLINFO_HEADER_OUT</constant> を設定してはいけません。
+   同じ libcurl の機能を使用するためです。
   </para>
 
   <simpara>
-   The <function>curl_getinfo</function> now returns an additional
-   <literal>posttransfer_time_us</literal> key, containing the number of
-   microseconds from the start until the last byte is sent.
-   When a redirect is followed, the time from each request is added together.
-   This value can also be retrieved by passing
-   <constant>CURLINFO_POSTTRANSFER_TIME_T</constant> to the
-   <function>curl_getinfo</function> <parameter>option</parameter> parameter.
-   This requires libcurl 8.10.0 or later.
+   <function>curl_getinfo</function> は、新たに
+   <literal>posttransfer_time_us</literal> キーを返すようになりました。
+   これは、開始から最後のバイトが送信されるまでのマイクロ秒数を示します。
+   リダイレクトが行われた場合、各リクエストの時間が合計されます。
+   この値は、<function>curl_getinfo</function> の
+   <parameter>option</parameter> パラメータに
+   <constant>CURLINFO_POSTTRANSFER_TIME_T</constant> を渡すことでも取得できます。
+   libcurl 8.10.0 以降が必要です。
   </simpara>
  </sect2>
 
@@ -266,17 +270,17 @@ $object = $reflector->newLazyGhost($initializer);
   <!-- RFC: https://wiki.php.net/rfc/domdocument_html5_parser -->
   <!-- RFC: https://wiki.php.net/rfc/opt_in_dom_spec_compliance -->
   <simpara>
-   Added the <package>Dom</package> namespace with new classes as counterparts
-   to the existing DOM classes (e.g. <classname>Dom\Node</classname> is the new
-   <classname>DOMNode</classname>).
-   These classes are compatible with HTML 5 and are WHATWG spec-compliant;
-   solving long-standing bugs in the DOM extension.
-   The old DOM classes remain available for backwards compatibility.
+   <package>Dom</package> 名前空間と、既存の DOM クラスに対応する
+   新たなクラスが追加されました(例: <classname>Dom\Node</classname> は
+   <classname>DOMNode</classname> に対応する新しいクラスです)。
+   これらのクラスは HTML 5 に対応しており、WHATWG の仕様に準拠しています。
+   これは DOM 拡張の長年のバグを解決します。
+   従来の DOM クラスも後方互換性のために引き続き利用可能です。
   </simpara>
 
   <para>
-   Added the <methodname>DOMNode::compareDocumentPosition</methodname>
-   with its associated constants:
+   <methodname>DOMNode::compareDocumentPosition</methodname>
+   と関連する定数が追加されました:
    <simplelist>
     <member><constant>DOMNode::DOCUMENT_POSITION_DISCONNECTED</constant></member>
     <member><constant>DOMNode::DOCUMENT_POSITION_PRECEDING</constant></member>
@@ -289,26 +293,12 @@ $object = $reflector->newLazyGhost($initializer);
 
   <!-- RFC: https://wiki.php.net/rfc/improve_callbacks_dom_and_xsl -->
   <simpara>
-   It is now possible to pass any callable to
-   <methodname>DOMXPath::registerPhpFunctions</methodname>.
+   <methodname>DOMXPath::registerPhpFunctions</methodname>
+   に任意の callable を渡すことが可能になりました。
 
-   Furthermore, with <methodname>DOMXPath::registerPhpFunctionNs</methodname>,
-   callbacks can now be registered that will use native function call syntax
-   rather than using <code>php:function('name')</code>.
-  </simpara>
- </sect2>
-
- <!-- TODO: Should this be moved to "other changes" in the SAPI section? - Girgias -->
- <sect2 xml:id="migration84.new-features.fpm">
-  <title>FPM</title>
-
-  <simpara>
-   Flushing headers without a body will now succeed.
-   <!-- See GH-12785. -->
-  </simpara>
-
-  <simpara>
-   Status page has a new field to display a memory peak.
+   さらに、<methodname>DOMXPath::registerPhpFunctionNs</methodname> により、
+   <code>php:function('name')</code> ではなく、ネイティブな関数呼び出し構文で
+   コールバックを登録できるようになりました。
   </simpara>
  </sect2>
 
@@ -316,9 +306,9 @@ $object = $reflector->newLazyGhost($initializer);
   <title>Intl</title>
 
   <simpara>
-   Added the <constant>NumberFormatter::ROUND_HALFODD</constant> to
-   complement the existing <constant>NumberFormatter::ROUND_HALFEVEN</constant>
-   functionality.
+   <constant>NumberFormatter::ROUND_HALFODD</constant> が追加されました。
+   既存の <constant>NumberFormatter::ROUND_HALFEVEN</constant> 機能を
+   補完します。
   </simpara>
  </sect2>
 
@@ -326,17 +316,17 @@ $object = $reflector->newLazyGhost($initializer);
   <title>OpenSSL</title>
 
   <simpara>
-   Added support for Curve25519 + Curve448 based keys.
-   Specifically x25519, ed25519, x448 and ed448 fields are supported in
-   <function>openssl_pkey_new</function>,
-   <function>openssl_pkey_get_details</function>,
-   <function>openssl_sign</function>, and
-   <function>openssl_verify</function> were extended to support those keys.
+   Curve25519 および Curve448 ベースのキーのサポートが追加されました。
+   具体的には、x25519、ed25519、x448、ed448 フィールドが
+   <function>openssl_pkey_new</function>、
+   <function>openssl_pkey_get_details</function>、
+   <function>openssl_sign</function>、および
+   <function>openssl_verify</function> を、サポートするよう拡張されました。
   </simpara>
 
   <simpara>
-   Implement PASSWORD_ARGON2 password hashing.
-   Requires OpenSSL 3.2 and NTS build.
+   パスワードのハッシュ方法として PASSWORD_ARGON2 が実装されました。
+   これは OpenSSL 3.2 および NTS ビルドが必要です。
   </simpara>
  </sect2>
 
@@ -344,22 +334,22 @@ $object = $reflector->newLazyGhost($initializer);
   <title>PCRE</title>
 
   <simpara>
-   The bundled pcre2lib has been updated to version 10.44.
-   As a consequence, LoongArch JIT support has been added, spaces
-   are now allowed between braces in Perl-compatible items, and
-   variable-length lookbehind assertions are now supported.
+   同梱の pcre2lib がバージョン 10.44 に更新されました。
+   これにより、LoongArch JIT サポートが追加され、
+   Perl 互換のアイテムで波括弧間のスペースが許可され、
+   可変長の後読みアサーションがサポートされるようになりました。
   </simpara>
 
   <simpara>
-   With pcre2lib version 10.44, the maximum length of named capture groups
-   has changed from <literal>32</literal> to <literal>128</literal>.
+   pcre2lib バージョン 10.44 では、名前付きキャプチャグループの最大長が
+   <literal>32</literal> から <literal>128</literal> に変更されました。
   </simpara>
 
   <simpara>
-   Added support for the <literal>r</literal> (PCRE2_EXTRA_CASELESS_RESTRICT)
-   modifier, as well as the <literal>(?r)</literal> mode modifier.
-   When enabled along with the case-insensitive modifier (<literal>i</literal>),
-   the expression locks out mixing of ASCII and non-ASCII characters.
+   <literal>r</literal> (PCRE2_EXTRA_CASELESS_RESTRICT)
+   修飾子と <literal>(?r)</literal> モード修飾子のサポートされました。
+   大文字・小文字を区別しない修飾子 (<literal>i</literal>) と一緒に有効にすると、
+   ASCII と非 ASCII 文字の混在が禁止されます。
   </simpara>
  </sect2>
 
@@ -368,24 +358,24 @@ $object = $reflector->newLazyGhost($initializer);
 
   <!-- RFC: https://wiki.php.net/rfc/pdo_driver_specific_subclasses -->
   <simpara>
-   Added support for driver-specific subclasses.
-   This RFC adds subclasses for PDO in order to better support
-   database-specific functionalities.
-   The new classes are instantiatable either via calling the
-   <methodname>PDO::connect</methodname> method or by instantiating an instance
-   of the driver-specific subclass directly.
+   ドライバ固有のサブクラスのサポートが追加されました。
+   PDO のサブクラスを追加することで、
+   データベース固有の機能のサポートを向上します。
+   新しいクラスは、<methodname>PDO::connect</methodname> メソッドを呼び出すか、
+   ドライバ固有のサブクラスを直接インスタンス化することで
+   利用できます。
   </simpara>
 
   <!-- RFC: https://wiki.php.net/rfc/pdo_driver_specific_parsers -->
   <para>
-   Added support for driver specific SQL parsers.
-   The default parser supports:
+   ドライバ固有の SQL パーサーのサポートが追加されました。
+   デフォルトのパーサーは以下をサポートします:
    <simplelist>
     <member>
-     single and double-quoted literals, with doubling as escaping mechanism
+     シングルクオートやダブルクオートで囲まれたリテラルでのクオートの二重化によるエスケープ
     </member>
     <member>
-     two-dashes and non-nested C-style comments
+     2 つのハイフンとネストされていない C スタイルのコメント
     </member>
    </simplelist>
   </para>
@@ -396,18 +386,18 @@ $object = $reflector->newLazyGhost($initializer);
 
   <!-- RFC: https://wiki.php.net/rfc/pdo_driver_specific_parsers -->
   <para>
-   Added a custom parser supporting:
+   以下をサポートするカスタムパーサーが追加されました:
    <simplelist>
     <member>
-     single and double-quoted literals, with doubling and backslash as escaping
-     mechanism
+     シングルクオートやダブルクオートで囲まれたリテラルでのクオートの二重化やバックスラッシュによる
+     エスケープ
     </member>
     <member>
-     backtick literal identifiers and with doubling as escaping mechanism
+     バッククオートで囲まれたリテラルでのクオートの二重化によるエスケープ
     </member>
     <member>
-     two dashes followed by at least 1 whitespace, non-nested C-style comments,
-     and hash-comments
+     1 つの空白が続く 2 つのハイフン、ネストされていない C スタイルのコメント、
+     <literal>#</literal> によるコメント
     </member>
    </simplelist>
   </para>
@@ -418,23 +408,22 @@ $object = $reflector->newLazyGhost($initializer);
 
   <!-- RFC: https://wiki.php.net/rfc/pdo_driver_specific_parsers -->
   <para>
-   Added a custom parser supporting:
+   以下をサポートするカスタムパーサーが追加されました:
    <simplelist>
     <member>
-     single and double-quoted literals, with doubling as escaping mechanism
+     シングルクオートやダブルクオートで囲まれたリテラルでのクオートの二重化によるエスケープ
     </member>
     <member>
-     C-style "escape" string literals (<literal>E'string'</literal>)
+     C スタイルの「エスケープ」文字列リテラル (<literal>E'string'</literal>)
     </member>
     <member>
-     dollar-quoted string literals
+     ドル記号で囲まれた文字列リテラル
     </member>
     <member>
-     two-dashes and C-style comments (non-nested)
+     2 つのハイフンとネストされていない C スタイルのコメント
     </member>
     <member>
-     support for <literal>??</literal> as escape sequence for the
-     <literal>?</literal> operator
+     <literal>?</literal> 演算子のエスケープシーケンスとしての <literal>??</literal> のサポート
     </member>
    </simplelist>
   </para>
@@ -445,17 +434,17 @@ $object = $reflector->newLazyGhost($initializer);
 
   <!-- RFC: https://wiki.php.net/rfc/pdo_driver_specific_parsers -->
   <para>
-   Added a custom parser supporting:
+   以下をサポートするカスタムパーサーが追加されました:
    <simplelist>
     <member>
-     single, double-quoted, and backtick literals, with doubling as
-     escaping mechanism
+     シングルクオート、ダブルクオート、バッククオートで囲まれたリテラルでのクオートの二重化による
+     エスケープ
     </member>
     <member>
-     square brackets quoting for identifiers
+     識別子の角括弧によるクオート
     </member>
     <member>
-     two-dashes and C-style comments (non-nested)
+     2 つのハイフンとネストされていない C スタイルのコメント
     </member>
    </simplelist>
   </para>
@@ -465,7 +454,7 @@ $object = $reflector->newLazyGhost($initializer);
   <title>Phar</title>
 
   <simpara>
-   Added support for the Unix timestamp extension for Zip archives.
+   Zip アーカイブの Unix タイムスタンプ拡張のサポートが追加されました。
   </simpara>
  </sect2>
 
@@ -473,8 +462,8 @@ $object = $reflector->newLazyGhost($initializer);
   <title>Readfile</title>
 
   <simpara>
-   Added ability to change the <literal>.php_history</literal> path through
-   the <envar>PHP_HISTFILE</envar> environment variable.
+   <envar>PHP_HISTFILE</envar> 環境変数を利用し
+   <literal>.php_history</literal> パスを変更する機能が追加されました。
   </simpara>
  </sect2>
 
@@ -482,20 +471,20 @@ $object = $reflector->newLazyGhost($initializer);
   <title>Reflection</title>
 
   <simpara>
-   <classname>ReflectionAttribute</classname> now contains a
-   <property>name</property> property to improve the debugging experience.
+   <classname>ReflectionAttribute</classname> に
+   デバッグ体験を向上させるための <property>name</property> プロパティが追加されました。
   </simpara>
 
   <simpara>
-   <methodname>ReflectionClassConstant::__toString</methodname> and
-   <methodname>ReflectionProperty::__toString</methodname> now returns the
-   attached doc comments.
+   <methodname>ReflectionClassConstant::__toString</methodname>および
+   <methodname>ReflectionProperty::__toString</methodname> は、
+   添付されたドキュメントコメントを返すようになりました。
   </simpara>
 
   <!-- RFC: https://wiki.php.net/rfc/lazy-objects -->
   <para>
-   Multiple new methods and constants which are related to the lazy objects
-   feature have been added:
+   レイジーオブジェクト機能に関連する複数の新しいメソッドと定数が
+   追加されました:
 
    <simplelist>
     <member>
@@ -523,10 +512,10 @@ $object = $reflector->newLazyGhost($initializer);
      <methodname>ReflectionClass::getLazyInitializer</methodname>
     </member>
     <member>
-     <methodname>ReflectionClass::skipLazyInitialization</methodname>
+     <methodname>ReflectionProperty::skipLazyInitialization</methodname>
     </member>
     <member>
-     <methodname>ReflectionClass::setRawValueWithoutLazyInitialization</methodname>
+     <methodname>ReflectionProperty::setRawValueWithoutLazyInitialization</methodname>
     </member>
     <member>
      <constant>ReflectionClass::SKIP_INITIALIZATION_ON_SERIALIZE</constant>
@@ -542,20 +531,20 @@ $object = $reflector->newLazyGhost($initializer);
   <title>SOAP</title>
 
   <simpara>
-   Added support for clark notation for namespaces in class map.
-   It is now possible to specify entries in a class map with clark notation
-   to resolve a type with a specific namespace to a specific class.
-   For example: <code>'{http://example.com}foo' => 'FooClass'</code>.
+   クラスマップでの名前空間のクラーク式記法のサポートが追加されました。
+   クラスマップ内でクラーク式記法を使用して、
+   特定の名前空間の型を特定のクラスに解決するエントリを指定できるようになりました。
+   例: <code>'{http://example.com}foo' => 'FooClass'</code>
   </simpara>
 
   <simpara>
-   Instances of <interfacename>DateTimeInterface</interfacename> that are
-   passed to <literal>xsd:datetime</literal> or similar elements are now
-   serialized as such instead of being serialized as an empty string.
+   <interfacename>DateTimeInterface</interfacename> のインスタンスが
+   <literal>xsd:datetime</literal> や類似の要素に渡されると、
+   空の文字列としてではなく、そのままシリアライズされるようになりました。
   </simpara>
 
   <simpara>
-   Session persistence now works with a shared session module.
+   持続的セッションが共有セッションモジュールで動作するようになりました。
   </simpara>
  </sect2>
 
@@ -565,11 +554,11 @@ $object = $reflector->newLazyGhost($initializer);
   <!-- RFC: https://wiki.php.net/rfc/correctly_name_the_rounding_mode_and_make_it_an_enum -->
   <simpara>
    <!-- Should this use <enumname> -->
-   Added a new <classname>RoundingMode</classname> enum with clearer naming
-   and improved discoverability compared to the
-   <constant>PHP_ROUND_<replaceable>*</replaceable></constant> constants.
-   Moreover, four new rounding modes were added which are only available via
-   the new <classname>RoundingMode</classname> enum.
+   <classname>RoundingMode</classname> 列挙型が追加されました。
+   <constant>PHP_ROUND_<replaceable>*</replaceable></constant> 定数より
+   明確な名前と発見性を提供します。
+   さらに、4 つの新しい丸めモードが追加されました。これらは
+   <classname>RoundingMode</classname> 列挙型を介してのみ利用可能です。
   </simpara>
  </sect2>
 
@@ -577,21 +566,21 @@ $object = $reflector->newLazyGhost($initializer);
   <title>XSL</title>
 
   <simpara>
-   It is now possible to use parameters that contain both single and double
-   quotes.
+   シングルクオートとダブルクオートの両方を含むパラメータを
+   使用できるようになりました。
   </simpara>
 
   <!-- RFC: https://wiki.php.net/rfc/improve_callbacks_dom_and_xsl -->
   <simpara>
-   It is now possible to pass any callable to
-   <methodname>XSLTProcessor::registerPhpFunctions</methodname>.
+   <methodname>XSLTProcessor::registerPhpFunctions</methodname> に
+   任意の callable を渡すことが可能になりました。
    <!-- TODO Mention XSLTProcessor::registerPHPFunctionNS ? -->
   </simpara>
 
   <simpara>
-   Added <property>XSLTProcessor::$maxTemplateDepth</property> and
-   <property>XSLTProcessor::$maxTemplateVars</property>
-   to control the recursion depth of XSL template evaluation.
+   <property>XSLTProcessor::$maxTemplateDepth</property> および
+   <property>XSLTProcessor::$maxTemplateVars</property> が追加されました。
+   XSL テンプレート評価の再帰の深さを制御することができます。
   </simpara>
  </sect2>
 
@@ -599,8 +588,8 @@ $object = $reflector->newLazyGhost($initializer);
   <title>Zip</title>
 
   <simpara>
-   Added the <constant>ZipArchive::ER_TRUNCATED_ZIP</constant>
-   constant, which was added in libzip 1.11.
+  <constant>ZipArchive::ER_TRUNCATED_ZIP</constant>
+  定数が追加されました。これは libzip 1.11 で追加されました。
   </simpara>
  </sect2>
 

--- a/appendices/migration84/new-functions.xml
+++ b/appendices/migration84/new-functions.xml
@@ -1,0 +1,331 @@
+<?xml version="1.0" encoding="utf-8"?>
+<sect1 xml:id="migration84.new-functions">
+ <title>New Functions</title>
+
+ <sect2 xml:id="migration84.new-functions.core">
+  <title>Core</title>
+
+  <simplelist>
+   <!-- RFC: https://wiki.php.net/rfc/rfc1867-non-post -->
+   <member><function>request_parse_body</function></member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration84.new-functions.bcmath">
+  <title>BCMath</title>
+
+  <simplelist>
+   <!-- RFC: https://wiki.php.net/rfc/adding_bcround_bcfloor_bcceil_to_bcmath -->
+   <!-- RFC: https://wiki.php.net/rfc/add_bcdivmod_to_bcmath -->
+   <member><function>bcceil</function></member>
+   <member><function>bcdivmod</function></member>
+   <member><function>bcfloor</function></member>
+   <member><function>bcround</function></member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration84.new-functions.date">
+  <title>Date</title>
+  <simplelist>
+   <member>
+    <methodname>DateTime::createFromTimestamp</methodname>
+   </member>
+   <member>
+    <methodname>DateTime::getMicrosecond</methodname>
+   </member>
+   <member>
+    <methodname>DateTime::setMicrosecond</methodname>
+   </member>
+   <member>
+    <methodname>DateTimeImmutable::createFromTimestamp</methodname>
+   </member>
+   <member>
+    <methodname>DateTimeImmutable::getMicrosecond</methodname>
+   </member>
+   <member>
+    <methodname>DateTimeImmutable::setMicrosecond</methodname>
+   </member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration84.new-functions.dom">
+  <title>DOM</title>
+  <simplelist>
+   <member>
+    <methodname>DOMNode::compareDocumentPosition</methodname>
+   </member>
+   <!-- RFC: https://wiki.php.net/rfc/improve_callbacks_dom_and_xsl -->
+   <member>
+    <methodname>DOMXPath::registerPhpFunctionNS</methodname>
+   </member>
+   <member>
+    <methodname>DOMXPath::quote</methodname>
+   </member>
+   <member>
+    <methodname>DOMNode::compareDocumentPosition</methodname>
+   </member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration84.new-functions.hash">
+  <title>Hash</title>
+  <simplelist>
+   <member>
+    <methodname>HashContext::__debugInfo</methodname>
+   </member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration84.new-functions.intl">
+  <title>Intl</title>
+  <simplelist>
+   <member>
+    <methodname>IntlDateFormatter::getIanaID</methodname>
+   </member>
+   <member><function>intltz_get_iana_id</function></member>
+   <member>
+    <methodname>IntlDateFormatter::parseToCalendar</methodname>
+   </member>
+   <member>
+    <methodname>SpoofChecker::setAllowedChars</methodname>
+   </member>
+   <!-- RFC: https://wiki.php.net/rfc/grapheme_str_split -->
+   <member><function>grapheme_str_split</function></member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration84.new-functions.mbstring">
+  <title>MBString</title>
+
+  <simplelist>
+   <!-- RFC: https://wiki.php.net/rfc/mb_trim -->
+   <member><function>mb_trim</function></member>
+   <member><function>mb_ltrim</function></member>
+   <member><function>mb_rtrim</function></member>
+   <!-- RFC: https://wiki.php.net/rfc/mb_ucfirst -->
+   <member><function>mb_ucfirst</function></member>
+   <member><function>mb_lcfirst</function></member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration84.new-functions.opcache">
+  <title>Opcache</title>
+  <simplelist>
+   <member><function>opcache_jit_blacklist</function></member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration84.new-functions.pcntl">
+  <title>PCNTL</title>
+
+  <simplelist>
+   <member><function>pcntl_getcpu</function></member>
+   <member><function>pcntl_getcpuaffinity</function></member>
+   <member><function>pcntl_getqos_class</function></member>
+   <member><function>pcntl_setns</function></member>
+   <member><function>pcntl_waitid</function></member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration84.new-functions.pdo-pgsql">
+  <title>PDO_PGSQL</title>
+  <simplelist>
+   <member>
+    <methodname>Pdo\Pgsql::setNoticeCallback</methodname>
+   </member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration84.new-functions.pgsql">
+  <title>PGSQL</title>
+
+  <simplelist>
+   <member><function>pg_change_password</function></member>
+   <member><function>pg_jit</function></member>
+   <member><function>pg_put_copy_data</function></member>
+   <member><function>pg_put_copy_end</function></member>
+   <member><function>pg_result_memory_size</function></member>
+   <member><function>pg_set_chunked_rows_size</function></member>
+   <member><function>pg_socket_poll</function></member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration84.new-functions.reflection">
+  <title>Reflection</title>
+
+  <para>
+   <!-- TODO: Link when feature is documented -->
+   <!-- RFC: https://wiki.php.net/rfc/lazy-objects -->
+   The following methods relate to the new lazy object feature:
+   <simplelist>
+    <member>
+     <methodname>ReflectionClass::newLazyGhost</methodname>
+    </member>
+    <member>
+     <methodname>ReflectionClass::newLazyProxy</methodname>
+    </member>
+    <member>
+     <methodname>ReflectionClass::resetAsLazyGhost</methodname>
+    </member>
+    <member>
+     <methodname>ReflectionClass::resetAsLazyProxy</methodname>
+    </member>
+    <member>
+     <methodname>ReflectionClass::isUninitializedLazyObject</methodname>
+    </member>
+    <member>
+     <methodname>ReflectionClass::initializeLazyObject</methodname>
+    </member>
+    <member>
+     <methodname>ReflectionClass::markLazyObjectAsInitialized</methodname>
+    </member>
+    <member>
+     <methodname>ReflectionClass::getLazyInitializer</methodname>
+    </member>
+    <member>
+     <methodname>ReflectionClass::skipLazyInitialization</methodname>
+    </member>
+    <member>
+     <methodname>ReflectionClass::setRawValueWithoutLazyInitialization</methodname>
+    </member>
+   </simplelist>
+  </para>
+
+  <simplelist>
+   <member>
+    <methodname>ReflectionClassConstant::isDeprecated</methodname>
+   </member>
+   <member>
+    <methodname>ReflectionGenerator::isClosed</methodname>
+   </member>
+   <member>
+    <methodname>ReflectionProperty::isDynamic</methodname>
+   </member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration84.new-functions.sodium">
+  <title>Sodium</title>
+
+  <simplelist>
+   <member><function>sodium_crypto_aead_aegis128l_<replaceable>*</replaceable></function></member>
+   <member><function>sodium_crypto_aead_aegis256l_<replaceable>*</replaceable></function></member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration84.new-functions.spl">
+  <title>SPL</title>
+
+  <simplelist>
+   <member>
+    <methodname>SplObjectStorage::seek</methodname>
+   </member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration84.new-functions.soap">
+  <title>SOAP</title>
+
+  <simplelist>
+   <member>
+    <methodname>SoapServer::__getLastResponse</methodname>
+   </member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration84.new-functions.standard">
+  <title>Standard</title>
+
+  <simplelist>
+   <member><function>http_get_last_response_headers</function></member>
+   <member><function>http_clear_last_response_headers</function></member>
+   <!-- RFC: https://wiki.php.net/rfc/http-last-response-headers -->
+   <member><function>fpow</function></member>
+   <!-- RFC: https://wiki.php.net/rfc/raising_zero_to_power_of_negative_number -->
+   <member><function>array_all</function></member>
+   <member><function>array_any</function></member>
+   <member><function>array_find</function></member>
+   <member><function>array_find_key</function></member>
+   <!-- RFC: https://wiki.php.net/rfc/array_find -->
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration84.new-functions.tidy">
+  <title>Tidy</title>
+
+  <simplelist>
+   <member>
+    <methodname>tidyNode::getNextSibling</methodname>
+   </member>
+   <member>
+    <methodname>tidyNode::getPreviousSibling</methodname>
+   </member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration84.new-functions.xmlreader">
+  <title>XMLReader</title>
+
+  <!-- RFC: https://wiki.php.net/rfc/xmlreader_writer_streams -->
+  <simplelist>
+   <member>
+    <methodname>XMLReader::fromStream</methodname>
+   </member>
+   <member>
+    <methodname>XMLReader::fromUri</methodname>
+   </member>
+   <member>
+    <methodname>XMLReader::fromString</methodname>
+   </member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration84.new-functions.xmlwriter">
+  <title>XMLWriter</title>
+
+  <!-- RFC: https://wiki.php.net/rfc/xmlreader_writer_streams -->
+  <simplelist>
+   <member>
+    <methodname>XMLWriter::toStream</methodname>
+   </member>
+   <member>
+    <methodname>XMLWriter::toUri</methodname>
+   </member>
+   <member>
+    <methodname>XMLWriter::toMemory</methodname>
+   </member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="migration84.new-functions.xsl">
+  <title>XSL</title>
+
+  <!-- RFC: https://wiki.php.net/rfc/improve_callbacks_dom_and_xsl -->
+  <simplelist>
+   <member>
+    <methodname>XSLTProcessor::registerPhpFunctionNS</methodname>
+   </member>
+  </simplelist>
+ </sect2>
+
+</sect1>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/appendices/migration84/new-functions.xml
+++ b/appendices/migration84/new-functions.xml
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: b719f01467440fa9cfb52b09a1fc8b832ccb5d18 Maintainer: KentarouTakeda Status: ready -->
+<!-- Credits: KentarouTakeda -->
 <sect1 xml:id="migration84.new-functions">
- <title>New Functions</title>
+ <title>新しく追加された関数</title>
 
  <sect2 xml:id="migration84.new-functions.core">
-  <title>Core</title>
+  <title>PHP コア</title>
 
   <simplelist>
    <!-- RFC: https://wiki.php.net/rfc/rfc1867-non-post -->
@@ -156,7 +159,7 @@
   <para>
    <!-- TODO: Link when feature is documented -->
    <!-- RFC: https://wiki.php.net/rfc/lazy-objects -->
-   The following methods relate to the new lazy object feature:
+   次のメソッドは新しいレイジーオブジェクト機能に関連しています:
    <simplelist>
     <member>
      <methodname>ReflectionClass::newLazyGhost</methodname>
@@ -183,10 +186,10 @@
      <methodname>ReflectionClass::getLazyInitializer</methodname>
     </member>
     <member>
-     <methodname>ReflectionClass::skipLazyInitialization</methodname>
+     <methodname>ReflectionProperty::skipLazyInitialization</methodname>
     </member>
     <member>
-     <methodname>ReflectionClass::setRawValueWithoutLazyInitialization</methodname>
+     <methodname>ReflectionProperty::setRawValueWithoutLazyInitialization</methodname>
     </member>
    </simplelist>
   </para>

--- a/appendices/migration84/other-changes.xml
+++ b/appendices/migration84/other-changes.xml
@@ -1,0 +1,783 @@
+<?xml version="1.0" encoding="utf-8"?>
+<sect1 xml:id="migration84.other-changes">
+ <title>Other Changes</title>
+
+ <sect2 xml:id="migration84.other-changes.core">
+  <title>Core changes</title>
+
+  <sect3 xml:id="migration84.other-changes.core.closures">
+   <title>Closures</title>
+
+   <simpara>
+    Closure names have been adjusted to include the parent function's name
+    and the line of definition to make them easier to distinguish, for example
+    within stack traces.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.other-changes.core.fibers">
+   <title>Fibers</title>
+
+   <simpara>
+    Fiber switching during destructor execution is now allowed. It was previously
+    blocked due to conflicts with garbage collection.
+   </simpara>
+
+   <simpara>
+    Destructors may now be executed in a separate Fiber:
+   </simpara>
+
+   <simpara>
+    When garbage collection is triggered in a Fiber,
+    destructors called by the GC are executed in a separate Fiber:
+    the gc_destructor_fiber.
+    If this Fiber suspends, a new one is created to execute the remaining
+    destructors.
+    The previous gc_destructor_fiber is not referenced anymore by the GC
+    and may be collected if it's not referenced anywhere else.
+    Objects whose destructor is suspended will not be collected until the
+    destructor returns or the <classname>Fiber</classname> is collected.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.other-changes.core.output">
+   <title>Output Handlers</title>
+
+   <simpara>
+    Output handler status flags passed to the <parameter>flags</parameter>
+    parameter of <function>ob_start</function> are now cleared.
+   </simpara>
+
+   <simpara>
+    <function>output_add_rewrite_var</function> now uses
+    <link linkend="ini.url-rewriter.hosts"><literal>url_rewriter.hosts</literal></link>
+    instead of
+    <link linkend="ini.session.trans-sid-hosts"><literal>session.trans_sid_hosts</literal></link>
+    for selecting hosts that will be rewritten.
+   </simpara>
+  </sect3>
+ </sect2>
+
+ <sect2 xml:id="migration84.other-changes.sapi">
+  <title>Changes in SAPI Modules</title>
+
+  <sect3 xml:id="migration84.other-changes.sapi.apache">
+   <title>apache2handler</title>
+
+   <simpara>
+    Support for EOL Apache 2.0 and 2.2 has been removed.
+    Minimum required Apache version is now 2.4.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.other-changes.sapi.cli">
+   <title>CLI</title>
+
+   <simpara>
+    The builtin server looks for an index file recursively by traversing parent
+    directories in case the specified file cannot be located.
+    This process was previously skipped if the path looked like it was
+    referring to a file, i.e. if the last path component contained a period.
+    In that case, a 404 error was returned.
+    The behavior has been changed to look for an index file in all cases.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.other-changes.sapi.fpm">
+   <title>FPM</title>
+
+   <simpara>
+    <!-- TODO Does this need a link? -->
+    The <filename>/dev/poll</filename> <literal>events.mechanism</literal>
+    setting for Solaris/Illumos had been retired.
+   </simpara>
+  </sect3>
+ </sect2>
+
+ <sect2 xml:id="migration84.other-changes.functions">
+  <title>Changed Functions</title>
+
+  <sect3 xml:id="migration84.other-changes.functions.core">
+   <title>Core</title>
+
+   <simpara>
+    <function>trigger_error</function> and <function>user_error</function>
+    now have a return type of <type>true</type> instead of <type>bool</type>.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.other-changes.functions.dom">
+   <title>DOM</title>
+
+   <simpara>
+    <methodname>DOMDocument::registerNodeClass</methodname>
+    now has a tentative return type of <type>true</type> instead of
+    <type>bool</type>.
+    It could only ever return &true; in practice.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.other-changes.functions.hash">
+   <title>Hash</title>
+
+   <simpara>
+    <function>hash_update</function>
+    now has a tentative return type of <type>true</type> instead of
+    <type>bool</type>.
+    It could only ever return &true; in practice.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.other-changes.functions.intl">
+   <title>Intl</title>
+
+   <simpara>
+    <constant>NumberFormatter::ROUND_TOWARD_ZERO</constant> and
+    <constant>NumberFormatter::ROUND_AWAY_FROM_ZERO</constant>
+    have been added as aliases for
+    <constant>NumberFormatter::ROUND_DOWN</constant> and
+    <constant>NumberFormatter::ROUND_UP</constant>
+    to be consistent with the new
+    <constant>PHP_ROUND_<replaceable>*</replaceable></constant> modes.
+   </simpara>
+
+   <simpara>
+    <methodname>ResourceBundle::get</methodname>
+    <!-- TODO Use a proper union type for the return type -->
+    now has a tentative return type of <literal>ResourceBundle|array|string|int|null</literal>.
+   </simpara>
+
+   <simpara>
+    The <function>idn_to_ascii</function> and <function>idn_to_utf8</function>
+    functions now always throw <exceptionname>ValueError</exceptionname>s
+    if the <parameter>domain</parameter> name is empty or too long.
+   </simpara>
+
+   <simpara>
+    The <function>idn_to_ascii</function> and <function>idn_to_utf8</function>
+    functions now always throw <exceptionname>ValueError</exceptionname>
+    if the <parameter>variant</parameter> parameter is not
+    <constant>INTL_IDNA_VARIANT_UTS46</constant>.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.other-changes.functions.libxml">
+   <title>LibXML</title>
+
+   <simpara>
+    <function>libxml_set_streams_context</function> now immediately throws a
+    <exceptionname>TypeError</exceptionname> when a non-stream-context
+    resource is passed to the function,
+    instead of throwing later when the stream context is used.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.other-changes.functions.mbstring">
+   <title>MBString</title>
+
+   <simpara>
+    The behavior of <function>mb_strcut</function> is more consistent
+    now on invalid UTF-8 and UTF-16 strings.
+    There is no behavioural change for valid UTF-8 and UTF-16 strings.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.other-changes.functions.odbc">
+   <title>ODBC</title>
+
+   <simpara>
+    The <parameter>row</parameter> of
+    <function>odbc_fetch_object</function>,
+    <function>odbc_fetch_array</function>, and
+    <function>odbc_fetch_into</function> now have a default value of &null;,
+    consistent with <function>odbc_fetch_row</function>.
+    Previously, the default values were
+    <literal>-1</literal>,
+    <literal>-1</literal>,
+    and <literal>0</literal>,
+    respectively.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.other-changes.functions.openssl">
+   <title>OpenSSL</title>
+
+   <simpara>
+    The <parameter>extra_attributes</parameter> in
+    <function>openssl_csr_new</function> sets the <acronym>CSR</acronym>
+    attributes instead of subject DN, which incorrectly done previously.
+   </simpara>
+
+   <simpara>
+    The <parameter>dn</parameter> in
+    <function>openssl_csr_new</function> allows setting an <type>array</type>
+    of values for a single entry.
+   </simpara>
+
+   <simpara>
+    New <parameter>serial_hex</parameter> added to
+    <function>openssl_csr_sign</function> to allow setting serial numbers
+    in the hexadecimal format.
+   </simpara>
+
+   <simpara>
+    Parsing ASN.1 UTCTime with <function>openssl_x509_parse</function>
+    fails if seconds are omitted for OpenSSL version below 3.2
+    (<literal>-1</literal> is returned for such fields).
+    OpenSSL version above 3.3 did not load such certificates already.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.other-changes.functions.pdo">
+   <title>PDO</title>
+
+   <simpara>
+    It is now possible to fetch the value of the
+    <constant>PDO::ATTR_STRINGIFY_FETCHES</constant> attribute with
+    <methodname>PDO::getAttribute</methodname>.
+   </simpara>
+
+   <simpara>
+    A new <constant>PDO::PGSQL_ATTR_RESULT_MEMORY_SIZE</constant>
+    has been added to retrieve the memory usage of query results with
+    <methodname>PDO::getAttribute</methodname> for drivers that support it.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.other-changes.functions.pdo-firebird">
+   <title>PDO_FIREBIRD</title>
+
+   <simpara>
+    It is now possible to fetch the value of the
+    <!-- TODO Is this a class constant of the driver class? -->
+    <constant>FB_ATTR_DATE_FORMAT</constant>,
+    <constant>FB_ATTR_TIME_FORMAT</constant>,
+    <constant>FB_ATTR_TIMESTAMP_FORMAT</constant>,
+    attributes with
+    <!-- TODO Only for the specific driver class? -->
+    <methodname>PDO::getAttribute</methodname>.
+   </simpara>
+
+   <para>
+    Added new attributes to specify transaction isolation level and access mode.
+    Five constants relating to this functionality have been added:
+
+    <simplelist>
+     <member><constant>Pdo\Firebird::TRANSACTION_ISOLATION_LEVEL</constant></member>
+     <member><constant>Pdo\Firebird::READ_COMMITTED</constant></member>
+     <member><constant>Pdo\Firebird::REPEATABLE_READ</constant></member>
+     <member><constant>Pdo\Firebird::SERIALIZABLE</constant></member>
+     <member><constant>Pdo\Firebird::WRITABLE_TRANSACTION</constant></member>
+    </simplelist>
+   </para>
+
+   <simpara>
+    When using persistent connections, there is now a liveliness check in the
+    constructor.
+   </simpara>
+
+   <simpara>
+    The content that is built changes depending on the value of
+    <constant>FB_API_VER</constant> in
+    <filename class="headerfile">ibase.h</filename>.
+    A new static method <methodname>Pdo\Firebird::getApiVersion</methodname>
+    can be used to obtain this information.
+    This information is also now referenced in <function>phpinfo</function>.
+   </simpara>
+
+   <para>
+    Five new data types are now available:
+    <simplelist type="inline">
+     <member><literal>INT128</literal></member>
+     <member><literal>DEC16</literal></member>
+     <member><literal>DEC34</literal></member>
+     <member><literal>TIMESTAMP_TZ</literal></member>
+     <member><literal>TIME_TZ</literal></member>
+    </simplelist>
+    .
+    These are available starting with Firebird 4.0.
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration84.other-changes.functions.pdo-mysql">
+   <title>PDO_MYSQL</title>
+
+   <simpara>
+    It is now possible to fetch the value of the
+    <constant>PDO::ATTR_FETCH_TABLE_NAMES</constant> attribute with
+    <!-- TODO Only for the specific driver class? -->
+    <methodname>PDO::getAttribute</methodname>.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.other-changes.functions.pdo-pgsql">
+   <title>PDO_PGSQL</title>
+
+   <simpara>
+    Support retrieving the memory usage of queries for
+    <constant>PDO::PGSQL_ATTR_RESULT_MEMORY_SIZE</constant>.
+   </simpara>
+
+   <simpara>
+    If the column is of type <literal>FLOAT4OID</literal> or
+    <literal>FLOAT8OID</literal> the value will now be returned as a
+    <type>float</type> instead of a <type>string</type>.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.other-changes.functions.pgsql">
+   <title>PGSQL</title>
+
+   <simpara>
+    The <parameter>conditions</parameter> parameter of
+    <function>pg_select</function> is now optional and accepts an empty array.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.other-changes.functions.phar">
+   <title>Phar</title>
+
+   <para>
+    The
+    <simplelist type="inline">
+     <member><methodname>Phar::setAlias</methodname></member>
+     <member><methodname>Phar::setDefaultStub</methodname></member>
+    </simplelist>
+    methods now have a tentative return type of <type>true</type>
+    instead of <type>bool</type>.
+   </para>
+  </sect3>
+
+  <sect3 xml:id="migration84.other-changes.functions.posix">
+   <title>POSIX</title>
+
+   <simpara>
+    <function>posix_isatty</function> now sets the error number when the
+    file descriptor/stream argument is invalid.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.other-changes.functions.reflection">
+   <title>Reflection</title>
+
+   <simpara>
+    <methodname>ReflectionGenerator::getFunction</methodname>
+    may now be called after the generator finished executing.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.other-changes.functions.sockets">
+   <title>Sockets</title>
+
+   <simpara>
+    The <parameter>backlog</parameter> parameter of
+    <function>socket_create_listen</function> now has a default value of
+    <constant>SOMAXCONN</constant>.
+    Previously, it was <literal>128</literal>.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.other-changes.functions.sodium">
+   <title>Sodium</title>
+
+   <simpara>
+    The <function>sodium_crypto_aead_aes256gcm_<replaceable>*</replaceable></function>
+    functions are now available on aarch64 CPUs with the ARM cryptographic
+    extensions.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.other-changes.functions.spl">
+   <title>SPL</title>
+
+   <para>
+    The
+    <simplelist type="inline">
+     <member><methodname>SplPriorityQueue::insert</methodname></member>
+     <member><methodname>SplPriorityQueue::recoverFromCorruption</methodname></member>
+     <member><methodname>SplHeap::insert</methodname></member>
+     <member><methodname>SplHeap::recoverFromCorruption</methodname></member>
+    </simplelist>
+    methods now have a tentative return type of <type>true</type>
+    instead of <type>bool</type>.
+   </para>
+
+   <simpara>
+    <classname>SplObjectStorage</classname> now implements
+    <interfacename>SeekableIterator</interfacename>.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.other-changes.functions.standard">
+   <title>Standard</title>
+
+   <simpara>
+
+    The default <literal>'cost'</literal> value for the <constant>PASSWORD_BCRYPT</constant>
+    hashing algorithm for <function>password_hash</function> has been increased from
+    <literal>10</literal> to <literal>12</literal>.
+    <!-- RFC: https://wiki.php.net/rfc/bcrypt_cost_2023 -->
+   </simpara>
+
+   <simpara>
+    <function>debug_zval_dump</function> now indicates whether an array is packed.
+   </simpara>
+
+   <simpara>
+    <function>long2ip</function> now has a return type of <type>string</type>
+    <!-- TODO Proper union type -->
+    instead of <literal>string|false</literal>.
+   </simpara>
+
+   <simpara>
+    <!-- TODO Proper union type -->
+    <function>highlight_string</function> now has a return type of
+    <type>string|true</type> instead of <literal>string|bool</literal>.
+   </simpara>
+
+   <simpara>
+    <!-- TODO Proper union type -->
+    <function>print_r</function> now has a return type of
+    <type>string|true</type> instead of <literal>string|bool</literal>.
+   </simpara>
+
+   <!-- TODO: Someone else take care of this - Girgias -->
+   <sect4>
+    <title>Rounding with <function>round</function></title>
+
+    <simpara>
+     The <parameter>mode</parameter> parameter of the
+     <function>round</function> function has been widened to
+     <!-- TODO Proper union type -->
+     <literal>RoundingMode|int</literal>,
+     <!-- TODO should be <enumname> ? -->
+     accepting instances of a new <classname>RoundingMode</classname> enum.
+     <!-- RFC: https://wiki.php.net/rfc/correctly_name_the_rounding_mode_and_make_it_an_enum -->
+    </simpara>
+
+    <para>
+     Four new modes have been added to the <function>round</function> function:
+     <simplelist type="inline">
+      <member><!-- <enumidentifier> -->RoundingMode::PositiveInfinity<!-- </enumidentifier> --></member>
+      <member><!-- <enumidentifier> -->RoundingMode::NegativeInfinity<!-- </enumidentifier> --></member>
+      <member><!-- <enumidentifier> -->RoundingMode::TowardsZero<!-- </enumidentifier> --></member>
+      <member><!-- <enumidentifier> -->RoundingMode::AwayFromZero<!-- </enumidentifier> --></member>
+     </simplelist>
+     <!-- RFC: https://wiki.php.net/rfc/new_rounding_modes_to_round_function -->
+    </para>
+
+    <simpara>
+     The internal implementation for rounding to integers has been rewritten
+     to be easier to verify for correctness and to be easier to maintain.
+     Some rounding bugs have been fixed as a result of the rewrite.
+     For example previously rounding <literal>0.49999999999999994</literal>
+     to the nearest integer would have resulted in <literal>1.0</literal>
+     instead of the correct result <literal>0.0</literal>.
+     Additional inputs might also be affected and result in different outputs
+     compared to earlier PHP versions.
+    </simpara>
+
+    <simpara>
+     Fixed a bug caused by "pre-rounding" of the <function>round</function> function.
+     Previously, using "pre-rounding" to treat a value like <literal>0.285</literal>
+     (actually <literal>0.28499999999999998</literal>) as a decimal number
+     and round it to <literal>0.29</literal>.
+     However, "pre-rounding" incorrectly rounds certain numbers,
+     so this fix removes "pre-rounding" and changes the way numbers are compared,
+     so that the values are correctly rounded as decimal numbers.
+    </simpara>
+
+    <simpara>
+     The maximum precision that can be handled by <function>round</function>
+     has been extended by one digit.
+     For example, <code>round(4503599627370495.5)</code> returned in
+     <literal>4503599627370495.5</literal>,
+     but now returns <literal>4503599627370496</literal>.
+    </simpara>
+
+   </sect4>
+  </sect3>
+
+ </sect2>
+
+ <sect2 xml:id="migration84.other-changes.extensions">
+  <title>Other Changes to Extensions</title>
+
+  <sect3 xml:id="migration84.other-changes.extensions.curl">
+   <title>cURL</title>
+
+   <simpara>
+    The minimum libcurl version required is now 7.61.0.
+   </simpara>
+
+   <simpara>
+    The <constant>CURLOPT_DNS_USE_GLOBAL_CACHE</constant> option no longer
+    has any effect, and is silently ignored.
+    This underlying feature was deprecated in libcurl 7.11.1,
+    and removed in libcurl 7.62.0.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.other-changes.extensions.gmp">
+   <title>GMP</title>
+
+   <!-- RFC: https://wiki.php.net/rfc/fix_up_bcmath_number_class -->
+   <simpara>
+    Casting a <classname>GMP</classname> object to <type>bool</type> is now
+    possible instead of emitting a <constant>E_RECOVERABLE_ERROR</constant>.
+    The casting behaviour is overloaded such that a <classname>GMP</classname>
+    object representing the value <literal>0</literal> is cast to &false;.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.other-changes.extensions.libxml">
+   <title>LibXML</title>
+
+   <simpara>
+    The minimum libxml2 version required is now 2.9.4.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.other-changes.extensions.intl">
+   <title>Intl</title>
+
+   <simpara>
+    The behaviour of Intl class has been normalized to always throw
+    <exceptionname>Error</exceptionname> exceptions when attempting to use
+    a non-initialized object, or when cloning fails.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.other-changes.extensions.mbstring">
+   <title>MBString</title>
+
+   <simpara>
+    Unicode data tables have been updated to Unicode 16.0.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.other-changes.extensions.mysqlnd">
+   <title>MySQLnd</title>
+
+   <simpara>
+    Support for the new VECTOR data type from MySQL 9.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.other-changes.extensions.openssl">
+   <title>OpenSSL</title>
+
+   <simpara>
+    The minimum OpenSSL version required is now 1.1.1.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.other-changes.extensions.pdo-pgsql">
+   <title>PDO_PGSQL</title>
+
+   <simpara>
+    The minimum libpq version required is now 10.0.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.other-changes.extensions.pgsql">
+   <title>PGSQL</title>
+
+   <simpara>
+    The minimum libpq version required is now 10.0.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.other-changes.extensions.spl">
+   <title>SPL</title>
+
+   <simpara>
+    Out of bounds accesses in <classname>SplFixedArray</classname> now throw
+    exceptions of type <exceptionname>OutOfBoundsException</exceptionname>
+    instead of <exceptionname>RuntimeException</exceptionname>.
+    Because <exceptionname>OutOfBoundsException</exceptionname> is a child
+    class of <exceptionname>RuntimeException</exceptionname> no behavioural
+    changes are exhibited when attempting to catch those exceptions.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.other-changes.extensions.xsl">
+   <title>XSL</title>
+
+   <simpara>
+    The typed properties <property>XSLTProcessor::$cloneDocument</property>
+    and <property>XSLTProcessor::$doXInclude</property> are now declared
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.other-changes.extensions.zlib">
+   <title>Zlib</title>
+
+   <simpara>
+    The minimum zlib version required is now 1.2.11.
+   </simpara>
+  </sect3>
+ </sect2>
+
+ <sect2 xml:id="migration84.other-changes.performance">
+  <title>Performance</title>
+
+  <sect3 xml:id="migration84.other-changes.performance.core">
+   <title>Core</title>
+
+   <simpara>
+    Improved the performance of floating point number parsing and formatting in
+    ZTS builds under highly concurrent loads.
+    This affects the <function>printf</function> family of functions as well
+    as serialization functions such as <function>json_encode</function>,
+    or <function>serialize</function>.
+   </simpara>
+
+   <simpara>
+    <function>sprintf</function> using only <literal>%s</literal> and
+    <literal>%d</literal> specifiers will be compiled into the equivalent
+    string interpolation, avoiding the overhead of a function call and
+    repeatedly parsing the format string.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.other-changes.performance.bcmath">
+   <title>BCMath</title>
+
+   <simpara>
+    Improved performance of number conversions and operations.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.other-changes.performance.dom">
+   <title>DOM</title>
+
+   <simpara>
+    The performance of <methodname>DOMNode::C14N</methodname> is greatly
+    improved for the case without an xpath query.
+    This can give a time improvement of easily two order of
+    magnitude for documents with tens of thousands of nodes.
+   </simpara>
+
+   <simpara>
+    Improved performance and reduce memory consumption of XML serialization.
+   </simpara>
+
+   <simpara>
+    Reduced memory usage of node classes.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.other-changes.performance.ftp">
+   <title>FTP</title>
+
+   <simpara>
+    Improved the performance of FTP uploads up to a factor of 10x for large
+    uploads.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.other-changes.performance.hash">
+   <title>Hash</title>
+
+   <simpara>
+    Added SSE2 and SHA-NI implementations of SHA-256.
+    This improves the performance on supported CPUs by ~1.3x (SSE2),
+    and 3x - 5x (SHA-NI).
+    Credit to Colin Percival / Tarsnap for this optimization.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.other-changes.performance.mbstring">
+   <title>MBString</title>
+
+   <simpara>
+    <function>mb_strcut</function> is much faster now for UTF-8
+    and UTF-16 strings.
+   </simpara>
+
+   <simpara>
+    Looking up mbstring encoding names is much faster now.
+   </simpara>
+
+   <simpara>
+    The performance of converting SJIS-win to Unicode is greatly improved.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.other-changes.performance.mysqlnd">
+   <title>MySQLnd</title>
+
+   <simpara>
+    Improved the performance of MySQLnd quoting.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.other-changes.performance.pcre">
+   <title>PCRE</title>
+
+   <simpara>
+    Improved the performance of named capture groups.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.other-changes.performance.random">
+   <title>Random</title>
+
+   <simpara>
+    Improved the performance of <classname>Random\Randomizer</classname>,
+    with a specific focus on the
+    <methodname>Random\Randomizer::getBytes</methodname>,
+    and <methodname>Random\Randomizer::getBytesFromString</methodname> methods.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.other-changes.performance.simplexml">
+   <title>SimpleXML</title>
+
+   <simpara>
+    Improved performance and reduce memory consumption of XML serialization.
+   </simpara>
+  </sect3>
+
+  <sect3 xml:id="migration84.other-changes.performance.standard">
+   <title>Standard</title>
+
+   <simpara>
+    The performance of <function>strspn</function> and
+    <function>strcspn</function> is greatly improved.
+    They now run in linear time instead of being bounded by quadratic time.
+   </simpara>
+
+   <simpara>
+    Improved the performance of <function>strpbrk</function>.
+   </simpara>
+
+   <simpara>
+    <function>get_browser</function> is much faster now,
+    up to 1.5x - 2.5x for some test cases.
+   </simpara>
+  </sect3>
+ </sect2>
+
+</sect1>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/appendices/migration84/other-changes.xml
+++ b/appendices/migration84/other-changes.xml
@@ -1,72 +1,76 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 0f1d7fba407bd1385616508a1e42e31fe009bff2 Maintainer: KentarouTakeda Status: ready -->
+<!-- Credits: KentarouTakeda -->
 <sect1 xml:id="migration84.other-changes">
- <title>Other Changes</title>
+ <title>その他の変更</title>
 
  <sect2 xml:id="migration84.other-changes.core">
-  <title>Core changes</title>
+  <title>PHP コア</title>
 
   <sect3 xml:id="migration84.other-changes.core.closures">
-   <title>Closures</title>
+   <title>クロージャ</title>
 
    <simpara>
-    Closure names have been adjusted to include the parent function's name
-    and the line of definition to make them easier to distinguish, for example
-    within stack traces.
+    クロージャの名前が調整され、親関数の名前と
+    定義の行番号を含むようになりました。これにより、
+    スタックトレース内などでの識別が容易になります。
    </simpara>
   </sect3>
 
   <sect3 xml:id="migration84.other-changes.core.fibers">
-   <title>Fibers</title>
+   <title>ファイバー(Fibers)</title>
 
    <simpara>
-    Fiber switching during destructor execution is now allowed. It was previously
-    blocked due to conflicts with garbage collection.
+    デストラクタ実行中にファイバーを切り替えられるようになりました。
+    以前はガベージコレクションとの競合のためブロックされていました。
    </simpara>
 
    <simpara>
-    Destructors may now be executed in a separate Fiber:
+    デストラクタは別のファイバー内で実行される場合があります。
    </simpara>
 
    <simpara>
-    When garbage collection is triggered in a Fiber,
-    destructors called by the GC are executed in a separate Fiber:
-    the gc_destructor_fiber.
-    If this Fiber suspends, a new one is created to execute the remaining
-    destructors.
-    The previous gc_destructor_fiber is not referenced anymore by the GC
-    and may be collected if it's not referenced anywhere else.
-    Objects whose destructor is suspended will not be collected until the
-    destructor returns or the <classname>Fiber</classname> is collected.
+    ガベージコレクションがファイバー内でトリガーされると、
+    GC によって呼び出されるデストラクタは
+    別のファイバー(gc_destructor_fiber)内で実行されます。
+    このファイバーが中断された場合、残りのデストラクタを実行するために
+    新しいファイバーが作成されます。
+    以前の gc_destructor_fiber は GC によって参照されなくなり、
+    他に参照されていなければ回収される可能性があります。
+    デストラクタが中断されたオブジェクトは、
+    デストラクタが戻るか <classname>Fiber</classname> が回収されるまで回収されません。
    </simpara>
   </sect3>
 
   <sect3 xml:id="migration84.other-changes.core.output">
-   <title>Output Handlers</title>
+   <title>出力ハンドラ</title>
 
    <simpara>
-    Output handler status flags passed to the <parameter>flags</parameter>
-    parameter of <function>ob_start</function> are now cleared.
+    <function>ob_start</function> の <parameter>flags</parameter> パラメータに渡された
+    出力ハンドラのステータスフラグがクリアされるようになりました。
    </simpara>
 
    <simpara>
-    <function>output_add_rewrite_var</function> now uses
-    <link linkend="ini.url-rewriter.hosts"><literal>url_rewriter.hosts</literal></link>
-    instead of
+    <function>output_add_rewrite_var</function> は、
+    リライトされるホストを選択するために
+    <link linkend="ini.url-rewriter.hosts"><literal>url_rewriter.hosts</literal></link> を使用するようになりました。
+    以前は
     <link linkend="ini.session.trans-sid-hosts"><literal>session.trans_sid_hosts</literal></link>
-    for selecting hosts that will be rewritten.
+    を使用していました。
    </simpara>
   </sect3>
  </sect2>
 
  <sect2 xml:id="migration84.other-changes.sapi">
-  <title>Changes in SAPI Modules</title>
+  <title>SAPI モジュールへの変更</title>
 
   <sect3 xml:id="migration84.other-changes.sapi.apache">
    <title>apache2handler</title>
 
    <simpara>
-    Support for EOL Apache 2.0 and 2.2 has been removed.
-    Minimum required Apache version is now 2.4.
+    EOLを迎えた Apache 2.0 および 2.2 のサポートが削除されました。
+    最小必要 Apache バージョンは 2.4 になりました。
    </simpara>
   </sect3>
 
@@ -74,12 +78,12 @@
    <title>CLI</title>
 
    <simpara>
-    The builtin server looks for an index file recursively by traversing parent
-    directories in case the specified file cannot be located.
-    This process was previously skipped if the path looked like it was
-    referring to a file, i.e. if the last path component contained a period.
-    In that case, a 404 error was returned.
-    The behavior has been changed to look for an index file in all cases.
+    組み込みサーバーは、指定されたファイルが見つからない場合、
+    親ディレクトリをたどってインデックスファイルを再帰的に探します。
+    このプロセスは、パスがファイルを指しているように見える場合
+    （最後のパスコンポーネントにピリオドが含まれる場合）はスキップされていました。
+    その場合、404 エラーが返されていました。
+    この動作は、すべての場合にインデックスファイルを探すように変更されました。
    </simpara>
   </sect3>
 
@@ -87,22 +91,31 @@
    <title>FPM</title>
 
    <simpara>
+    本文なしでヘッダをフラッシュできるようになりました。
+    <!-- See GH-12785. -->
+   </simpara>
+
+   <simpara>
+    ステータスページにメモリの最大使用量を表示するフィールドが追加されました。
+   </simpara>
+
+   <simpara>
     <!-- TODO Does this need a link? -->
-    The <filename>/dev/poll</filename> <literal>events.mechanism</literal>
-    setting for Solaris/Illumos had been retired.
+    Solaris/Illumos 用の <filename>/dev/poll</filename> <literal>events.mechanism</literal>
+    設定は廃止されました。
    </simpara>
   </sect3>
  </sect2>
 
  <sect2 xml:id="migration84.other-changes.functions">
-  <title>Changed Functions</title>
+  <title>変更された関数</title>
 
   <sect3 xml:id="migration84.other-changes.functions.core">
-   <title>Core</title>
+   <title>PHP コア</title>
 
    <simpara>
-    <function>trigger_error</function> and <function>user_error</function>
-    now have a return type of <type>true</type> instead of <type>bool</type>.
+    <function>trigger_error</function> および <function>user_error</function>
+    は、戻り値の型が <type>bool</type> ではなく <type>true</type> になりました。
    </simpara>
   </sect3>
 
@@ -111,9 +124,8 @@
 
    <simpara>
     <methodname>DOMDocument::registerNodeClass</methodname>
-    now has a tentative return type of <type>true</type> instead of
-    <type>bool</type>.
-    It could only ever return &true; in practice.
+    は、戻り値の型が <type>bool</type> ではなく <type>true</type> になりました。
+    実際には常に &true; を返すことしかできませんでした。
    </simpara>
   </sect3>
 
@@ -122,9 +134,8 @@
 
    <simpara>
     <function>hash_update</function>
-    now has a tentative return type of <type>true</type> instead of
-    <type>bool</type>.
-    It could only ever return &true; in practice.
+    は、戻り値の型が <type>bool</type> ではなく <type>true</type> になりました。
+    実際には常に &true; を返すことしかできませんでした。
    </simpara>
   </sect3>
 
@@ -132,32 +143,32 @@
    <title>Intl</title>
 
    <simpara>
-    <constant>NumberFormatter::ROUND_TOWARD_ZERO</constant> and
+    <constant>NumberFormatter::ROUND_TOWARD_ZERO</constant> および
     <constant>NumberFormatter::ROUND_AWAY_FROM_ZERO</constant>
-    have been added as aliases for
-    <constant>NumberFormatter::ROUND_DOWN</constant> and
+    が、新しい <constant>PHP_ROUND_<replaceable>*</replaceable></constant>
+    モードと一致するように、
+    <constant>NumberFormatter::ROUND_DOWN</constant> および
     <constant>NumberFormatter::ROUND_UP</constant>
-    to be consistent with the new
-    <constant>PHP_ROUND_<replaceable>*</replaceable></constant> modes.
+    のエイリアスとして追加されました。
    </simpara>
 
    <simpara>
     <methodname>ResourceBundle::get</methodname>
     <!-- TODO Use a proper union type for the return type -->
-    now has a tentative return type of <literal>ResourceBundle|array|string|int|null</literal>.
+    は、戻り値の型が <literal>ResourceBundle|array|string|int|null</literal> になりました。
    </simpara>
 
    <simpara>
-    The <function>idn_to_ascii</function> and <function>idn_to_utf8</function>
-    functions now always throw <exceptionname>ValueError</exceptionname>s
-    if the <parameter>domain</parameter> name is empty or too long.
+    <function>idn_to_ascii</function> および <function>idn_to_utf8</function>
+    関数は、<parameter>domain</parameter> 名が空または長すぎる場合、
+    <exceptionname>ValueError</exceptionname> をスローするようになりました。
    </simpara>
 
    <simpara>
-    The <function>idn_to_ascii</function> and <function>idn_to_utf8</function>
-    functions now always throw <exceptionname>ValueError</exceptionname>
-    if the <parameter>variant</parameter> parameter is not
-    <constant>INTL_IDNA_VARIANT_UTS46</constant>.
+    <function>idn_to_ascii</function> および <function>idn_to_utf8</function>
+    関数は、<parameter>variant</parameter> パラメータが
+    <constant>INTL_IDNA_VARIANT_UTS46</constant> でない場合、
+    <exceptionname>ValueError</exceptionname> をスローするようになりました。
    </simpara>
   </sect3>
 
@@ -165,10 +176,10 @@
    <title>LibXML</title>
 
    <simpara>
-    <function>libxml_set_streams_context</function> now immediately throws a
-    <exceptionname>TypeError</exceptionname> when a non-stream-context
-    resource is passed to the function,
-    instead of throwing later when the stream context is used.
+    <function>libxml_set_streams_context</function> は、
+    非ストリームコンテキストリソースが関数に渡された場合、
+    ストリームコンテキストが使用されるときではなく、
+    直ちに <exceptionname>TypeError</exceptionname> をスローするようになりました。
    </simpara>
   </sect3>
 
@@ -176,9 +187,9 @@
    <title>MBString</title>
 
    <simpara>
-    The behavior of <function>mb_strcut</function> is more consistent
-    now on invalid UTF-8 and UTF-16 strings.
-    There is no behavioural change for valid UTF-8 and UTF-16 strings.
+    <function>mb_strcut</function> の動作は、
+    無効な UTF-8 および UTF-16 文字列に対してより一貫性のあるものになりました。
+    有効な UTF-8 および UTF-16 文字列に対する動作の変更はありません。
    </simpara>
   </sect3>
 
@@ -186,16 +197,16 @@
    <title>ODBC</title>
 
    <simpara>
-    The <parameter>row</parameter> of
-    <function>odbc_fetch_object</function>,
-    <function>odbc_fetch_array</function>, and
-    <function>odbc_fetch_into</function> now have a default value of &null;,
-    consistent with <function>odbc_fetch_row</function>.
-    Previously, the default values were
-    <literal>-1</literal>,
-    <literal>-1</literal>,
-    and <literal>0</literal>,
-    respectively.
+    <function>odbc_fetch_object</function>、
+    <function>odbc_fetch_array</function>、および
+    <function>odbc_fetch_into</function> の
+    <parameter>row</parameter> は、デフォルト値が &null; になり、
+    <function>odbc_fetch_row</function> と一致するようになりました。
+    以前は、それぞれデフォルト値が
+    <literal>-1</literal>、
+    <literal>-1</literal>、
+    <literal>0</literal>
+    でした。
    </simpara>
   </sect3>
 
@@ -203,28 +214,29 @@
    <title>OpenSSL</title>
 
    <simpara>
-    The <parameter>extra_attributes</parameter> in
-    <function>openssl_csr_new</function> sets the <acronym>CSR</acronym>
-    attributes instead of subject DN, which incorrectly done previously.
+    <function>openssl_csr_new</function> の
+    <parameter>extra_attributes</parameter> は、
+    <acronym>CSR</acronym> 属性を設定します。
+    以前はサブジェクト DN が誤って設定されていました。
    </simpara>
 
    <simpara>
-    The <parameter>dn</parameter> in
-    <function>openssl_csr_new</function> allows setting an <type>array</type>
-    of values for a single entry.
+    <function>openssl_csr_new</function> の
+    <parameter>dn</parameter> は、
+    単一のエントリに対して値の <type>array</type> を設定できるようになりました。
    </simpara>
 
    <simpara>
-    New <parameter>serial_hex</parameter> added to
-    <function>openssl_csr_sign</function> to allow setting serial numbers
-    in the hexadecimal format.
+    <function>openssl_csr_sign</function> に新たに
+    <parameter>serial_hex</parameter> が追加され、
+    16 進形式でシリアル番号を設定できるようになりました。
    </simpara>
 
    <simpara>
-    Parsing ASN.1 UTCTime with <function>openssl_x509_parse</function>
-    fails if seconds are omitted for OpenSSL version below 3.2
-    (<literal>-1</literal> is returned for such fields).
-    OpenSSL version above 3.3 did not load such certificates already.
+    <function>openssl_x509_parse</function> で ASN.1 UTCTime を解析する際、
+    OpenSSL バージョン 3.2 未満では秒が省略されていると失敗します
+    (そのようなフィールドでは <literal>-1</literal> が返されます)。
+    OpenSSL バージョン 3.3 以降では、そのような証明書は読み込むことができません。
    </simpara>
   </sect3>
 
@@ -232,15 +244,15 @@
    <title>PDO</title>
 
    <simpara>
-    It is now possible to fetch the value of the
-    <constant>PDO::ATTR_STRINGIFY_FETCHES</constant> attribute with
-    <methodname>PDO::getAttribute</methodname>.
+    <methodname>PDO::getAttribute</methodname> で
+    <constant>PDO::ATTR_STRINGIFY_FETCHES</constant>
+    属性の値を取得できるようになりました。
    </simpara>
 
    <simpara>
-    A new <constant>PDO::PGSQL_ATTR_RESULT_MEMORY_SIZE</constant>
-    has been added to retrieve the memory usage of query results with
-    <methodname>PDO::getAttribute</methodname> for drivers that support it.
+    <constant>PDO::PGSQL_ATTR_RESULT_MEMORY_SIZE</constant> が追加されました。
+    サポートされているドライバで <methodname>PDO::getAttribute</methodname> を使用して
+    クエリ結果のメモリ使用量を取得できるようになりました。
    </simpara>
   </sect3>
 
@@ -248,19 +260,17 @@
    <title>PDO_FIREBIRD</title>
 
    <simpara>
-    It is now possible to fetch the value of the
-    <!-- TODO Is this a class constant of the driver class? -->
-    <constant>FB_ATTR_DATE_FORMAT</constant>,
-    <constant>FB_ATTR_TIME_FORMAT</constant>,
-    <constant>FB_ATTR_TIMESTAMP_FORMAT</constant>,
-    attributes with
     <!-- TODO Only for the specific driver class? -->
-    <methodname>PDO::getAttribute</methodname>.
+    <methodname>PDO::getAttribute</methodname> で
+    <!-- TODO Is this a class constant of the driver class? -->
+    <constant>FB_ATTR_DATE_FORMAT</constant>、
+    <constant>FB_ATTR_TIME_FORMAT</constant>、
+    <constant>FB_ATTR_TIMESTAMP_FORMAT</constant> 属性の値を取得できるようになりました。
    </simpara>
 
    <para>
-    Added new attributes to specify transaction isolation level and access mode.
-    Five constants relating to this functionality have been added:
+    トランザクションの分離レベルとアクセスモードを指定するための新しい属性が追加されました。
+    この機能のため 5 つの定数が追加されました:
 
     <simplelist>
      <member><constant>Pdo\Firebird::TRANSACTION_ISOLATION_LEVEL</constant></member>
@@ -272,21 +282,20 @@
    </para>
 
    <simpara>
-    When using persistent connections, there is now a liveliness check in the
-    constructor.
+    永続的な接続を使用する場合、コンストラクタ内での生存チェックが追加されました。
    </simpara>
 
    <simpara>
-    The content that is built changes depending on the value of
-    <constant>FB_API_VER</constant> in
-    <filename class="headerfile">ibase.h</filename>.
-    A new static method <methodname>Pdo\Firebird::getApiVersion</methodname>
-    can be used to obtain this information.
-    This information is also now referenced in <function>phpinfo</function>.
+    ビルドされる内容は、
+    <filename class="headerfile">ibase.h</filename> 内の
+    <constant>FB_API_VER</constant> の値によって変わります。
+    この情報を取得するために新しい静的メソッド <methodname>Pdo\Firebird::getApiVersion</methodname>
+    が追加されました。
+    この情報は <function>phpinfo</function> からも参照できます。
    </simpara>
 
    <para>
-    Five new data types are now available:
+    5 つの新しいデータ型が利用可能になりました:
     <simplelist type="inline">
      <member><literal>INT128</literal></member>
      <member><literal>DEC16</literal></member>
@@ -294,8 +303,8 @@
      <member><literal>TIMESTAMP_TZ</literal></member>
      <member><literal>TIME_TZ</literal></member>
     </simplelist>
-    .
-    These are available starting with Firebird 4.0.
+
+    これらは Firebird 4.0 以降で利用可能です。
    </para>
   </sect3>
 
@@ -303,10 +312,10 @@
    <title>PDO_MYSQL</title>
 
    <simpara>
-    It is now possible to fetch the value of the
-    <constant>PDO::ATTR_FETCH_TABLE_NAMES</constant> attribute with
     <!-- TODO Only for the specific driver class? -->
-    <methodname>PDO::getAttribute</methodname>.
+    <methodname>PDO::getAttribute</methodname> で
+    <constant>PDO::ATTR_FETCH_TABLE_NAMES</constant> 属性の
+    値を取得できるようになりました。
    </simpara>
   </sect3>
 
@@ -314,14 +323,14 @@
    <title>PDO_PGSQL</title>
 
    <simpara>
-    Support retrieving the memory usage of queries for
-    <constant>PDO::PGSQL_ATTR_RESULT_MEMORY_SIZE</constant>.
+    <constant>PDO::PGSQL_ATTR_RESULT_MEMORY_SIZE</constant>
+    によるクエリのメモリ使用量の取得をサポートしました。
    </simpara>
 
    <simpara>
-    If the column is of type <literal>FLOAT4OID</literal> or
-    <literal>FLOAT8OID</literal> the value will now be returned as a
-    <type>float</type> instead of a <type>string</type>.
+    カラムが <literal>FLOAT4OID</literal> または
+    <literal>FLOAT8OID</literal> 型の場合、値は
+    <type>string</type> ではなく <type>float</type> として返されるようになりました。
    </simpara>
   </sect3>
 
@@ -329,8 +338,8 @@
    <title>PGSQL</title>
 
    <simpara>
-    The <parameter>conditions</parameter> parameter of
-    <function>pg_select</function> is now optional and accepts an empty array.
+    <function>pg_select</function> の <parameter>conditions</parameter> パラメータ
+    はオプションになり、空の配列を受け入れるようになりました。
    </simpara>
   </sect3>
 
@@ -338,13 +347,12 @@
    <title>Phar</title>
 
    <para>
-    The
     <simplelist type="inline">
      <member><methodname>Phar::setAlias</methodname></member>
      <member><methodname>Phar::setDefaultStub</methodname></member>
     </simplelist>
-    methods now have a tentative return type of <type>true</type>
-    instead of <type>bool</type>.
+    は、戻り値の型が <type>bool</type> ではなく
+    <type>true</type> になりました。
    </para>
   </sect3>
 
@@ -352,8 +360,8 @@
    <title>POSIX</title>
 
    <simpara>
-    <function>posix_isatty</function> now sets the error number when the
-    file descriptor/stream argument is invalid.
+    <function>posix_isatty</function> は、
+    ファイル記述子/ストリーム引数が無効な場合エラー番号を設定するようになりました。
    </simpara>
   </sect3>
 
@@ -362,7 +370,7 @@
 
    <simpara>
     <methodname>ReflectionGenerator::getFunction</methodname>
-    may now be called after the generator finished executing.
+    は、ジェネレータの実行が終了した後でも呼び出すことができるようになりました。
    </simpara>
   </sect3>
 
@@ -370,10 +378,10 @@
    <title>Sockets</title>
 
    <simpara>
-    The <parameter>backlog</parameter> parameter of
-    <function>socket_create_listen</function> now has a default value of
-    <constant>SOMAXCONN</constant>.
-    Previously, it was <literal>128</literal>.
+    <function>socket_create_listen</function> の
+    <parameter>backlog</parameter> パラメータのデフォルト値は
+    <constant>SOMAXCONN</constant> になりました。
+    以前は <literal>128</literal> でした。
    </simpara>
   </sect3>
 
@@ -381,9 +389,9 @@
    <title>Sodium</title>
 
    <simpara>
-    The <function>sodium_crypto_aead_aes256gcm_<replaceable>*</replaceable></function>
-    functions are now available on aarch64 CPUs with the ARM cryptographic
-    extensions.
+    <function>sodium_crypto_aead_aes256gcm_<replaceable>*</replaceable></function>
+    関数は、ARM 暗号化拡張を持つ aarch64 CPU で
+    利用可能になりました。
    </simpara>
   </sect3>
 
@@ -391,20 +399,19 @@
    <title>SPL</title>
 
    <para>
-    The
     <simplelist type="inline">
      <member><methodname>SplPriorityQueue::insert</methodname></member>
      <member><methodname>SplPriorityQueue::recoverFromCorruption</methodname></member>
      <member><methodname>SplHeap::insert</methodname></member>
      <member><methodname>SplHeap::recoverFromCorruption</methodname></member>
     </simplelist>
-    methods now have a tentative return type of <type>true</type>
-    instead of <type>bool</type>.
+    メソッドは、戻り値の型が <type>bool</type> ではなく
+    <type>true</type> になりました。
    </para>
 
    <simpara>
-    <classname>SplObjectStorage</classname> now implements
-    <interfacename>SeekableIterator</interfacename>.
+    <classname>SplObjectStorage</classname> は
+    <interfacename>SeekableIterator</interfacename> を実装するようになりました。
    </simpara>
   </sect3>
 
@@ -413,50 +420,50 @@
 
    <simpara>
 
-    The default <literal>'cost'</literal> value for the <constant>PASSWORD_BCRYPT</constant>
-    hashing algorithm for <function>password_hash</function> has been increased from
-    <literal>10</literal> to <literal>12</literal>.
+    <constant>PASSWORD_BCRYPT</constant> ハッシュアルゴリズムの
+    <function>password_hash</function> のデフォルトの <literal>'cost'</literal> 値が
+    <literal>10</literal> から <literal>12</literal> に引き上げられました。
     <!-- RFC: https://wiki.php.net/rfc/bcrypt_cost_2023 -->
    </simpara>
 
    <simpara>
-    <function>debug_zval_dump</function> now indicates whether an array is packed.
-   </simpara>
-
-   <simpara>
-    <function>long2ip</function> now has a return type of <type>string</type>
-    <!-- TODO Proper union type -->
-    instead of <literal>string|false</literal>.
+    <function>debug_zval_dump</function> は、配列がパックされているかどうかを示すようになりました。
    </simpara>
 
    <simpara>
     <!-- TODO Proper union type -->
-    <function>highlight_string</function> now has a return type of
-    <type>string|true</type> instead of <literal>string|bool</literal>.
+    <function>long2ip</function> は、戻り値の型が <literal>string|false</literal> ではなく
+    <type>string</type> になりました。
    </simpara>
 
    <simpara>
+    <function>highlight_string</function> は、戻り値の型が
     <!-- TODO Proper union type -->
-    <function>print_r</function> now has a return type of
-    <type>string|true</type> instead of <literal>string|bool</literal>.
+    <literal>string|bool</literal> ではなく<type>string|true</type> になりました。
+   </simpara>
+
+   <simpara>
+    <function>print_r</function> は、戻り値の型が
+    <!-- TODO Proper union type -->
+    <literal>string|bool</literal> ではなく <type>string|true</type> になりました。
    </simpara>
 
    <!-- TODO: Someone else take care of this - Girgias -->
    <sect4>
-    <title>Rounding with <function>round</function></title>
+    <title><function>round</function> による丸め処理</title>
 
     <simpara>
-     The <parameter>mode</parameter> parameter of the
-     <function>round</function> function has been widened to
+     <function>round</function> 関数の
+     <parameter>mode</parameter> パラメータは、
      <!-- TODO Proper union type -->
-     <literal>RoundingMode|int</literal>,
+     <literal>RoundingMode|int</literal> に拡張され、
      <!-- TODO should be <enumname> ? -->
-     accepting instances of a new <classname>RoundingMode</classname> enum.
+     新たに追加された <classname>RoundingMode</classname> 列挙型のインスタンスを受け入れます。
      <!-- RFC: https://wiki.php.net/rfc/correctly_name_the_rounding_mode_and_make_it_an_enum -->
     </simpara>
 
     <para>
-     Four new modes have been added to the <function>round</function> function:
+     <function>round</function> 関数に 4 つの新しいモードが追加されました:
      <simplelist type="inline">
       <member><!-- <enumidentifier> -->RoundingMode::PositiveInfinity<!-- </enumidentifier> --></member>
       <member><!-- <enumidentifier> -->RoundingMode::NegativeInfinity<!-- </enumidentifier> --></member>
@@ -467,32 +474,32 @@
     </para>
 
     <simpara>
-     The internal implementation for rounding to integers has been rewritten
-     to be easier to verify for correctness and to be easier to maintain.
-     Some rounding bugs have been fixed as a result of the rewrite.
-     For example previously rounding <literal>0.49999999999999994</literal>
-     to the nearest integer would have resulted in <literal>1.0</literal>
-     instead of the correct result <literal>0.0</literal>.
-     Additional inputs might also be affected and result in different outputs
-     compared to earlier PHP versions.
+     整数への丸めのための内部実装が、正確さの検証と
+     メンテナンスの容易さのために書き直されました。
+     その結果、いくつかの丸め処理のバグが修正されました。
+     例えば、以前は <literal>0.49999999999999994</literal>を最も近い整数に丸めると、
+     正しい結果の <literal>0.0</literal> ではなく
+     <literal>1.0</literal> になっていました。
+     他の入力も影響を受け、以前の PHP バージョンと比較して
+     異なる出力になる場合があります。
     </simpara>
 
     <simpara>
-     Fixed a bug caused by "pre-rounding" of the <function>round</function> function.
-     Previously, using "pre-rounding" to treat a value like <literal>0.285</literal>
-     (actually <literal>0.28499999999999998</literal>) as a decimal number
-     and round it to <literal>0.29</literal>.
-     However, "pre-rounding" incorrectly rounds certain numbers,
-     so this fix removes "pre-rounding" and changes the way numbers are compared,
-     so that the values are correctly rounded as decimal numbers.
+     <function>round</function> 関数の「事前丸め」によるバグが修正されました。
+     以前は、「事前丸め」により <literal>0.285</literal>
+     (実際には <literal>0.28499999999999998</literal>)のような値を
+     10 進数として、<literal>0.29</literal> に丸めていました。
+     しかし、「事前丸め」は特定の数値を誤って丸めるため、
+     この修正では「事前丸め」を削除し、値同士の比較方法を変更することで、
+     値が 10 進数として正しく丸められるようにしました。
     </simpara>
 
     <simpara>
-     The maximum precision that can be handled by <function>round</function>
-     has been extended by one digit.
-     For example, <code>round(4503599627370495.5)</code> returned in
-     <literal>4503599627370495.5</literal>,
-     but now returns <literal>4503599627370496</literal>.
+     <function>round</function> が処理できる最大精度が
+     1桁増えました。
+     例えば、<code>round(4503599627370495.5)</code> は以前は
+     <literal>4503599627370495.5</literal> を返していましたが、
+     現在は <literal>4503599627370496</literal> を返します。
     </simpara>
 
    </sect4>
@@ -501,20 +508,20 @@
  </sect2>
 
  <sect2 xml:id="migration84.other-changes.extensions">
-  <title>Other Changes to Extensions</title>
+  <title>拡張モジュールへのその他の変更</title>
 
   <sect3 xml:id="migration84.other-changes.extensions.curl">
    <title>cURL</title>
 
    <simpara>
-    The minimum libcurl version required is now 7.61.0.
+    最小必要 libcurl バージョンは 7.61.0 になりました。
    </simpara>
 
    <simpara>
-    The <constant>CURLOPT_DNS_USE_GLOBAL_CACHE</constant> option no longer
-    has any effect, and is silently ignored.
-    This underlying feature was deprecated in libcurl 7.11.1,
-    and removed in libcurl 7.62.0.
+    <constant>CURLOPT_DNS_USE_GLOBAL_CACHE</constant> オプションは
+    もはや効果がなく、通知なく無視されます。
+    この基本機能は libcurl 7.11.1 で非推奨となり、
+    libcurl 7.62.0 で削除されました。
    </simpara>
   </sect3>
 
@@ -523,10 +530,10 @@
 
    <!-- RFC: https://wiki.php.net/rfc/fix_up_bcmath_number_class -->
    <simpara>
-    Casting a <classname>GMP</classname> object to <type>bool</type> is now
-    possible instead of emitting a <constant>E_RECOVERABLE_ERROR</constant>.
-    The casting behaviour is overloaded such that a <classname>GMP</classname>
-    object representing the value <literal>0</literal> is cast to &false;.
+    <classname>GMP</classname> オブジェクトを <type>bool</type> に
+    キャストできるようになりました。以前は <constant>E_RECOVERABLE_ERROR</constant> が発生していました。
+    キャストの動作はオーバーロードされ、値が <literal>0</literal> を表す
+    <classname>GMP</classname> オブジェクトは &false; にキャストされます。
    </simpara>
   </sect3>
 
@@ -534,7 +541,7 @@
    <title>LibXML</title>
 
    <simpara>
-    The minimum libxml2 version required is now 2.9.4.
+    最小必要 libxml2 バージョンは 2.9.4 になりました。
    </simpara>
   </sect3>
 
@@ -542,9 +549,9 @@
    <title>Intl</title>
 
    <simpara>
-    The behaviour of Intl class has been normalized to always throw
-    <exceptionname>Error</exceptionname> exceptions when attempting to use
-    a non-initialized object, or when cloning fails.
+    Intl クラスの動作が統一され、
+    初期化されていないオブジェクトを使用しようとした場合やクローンに失敗した場合に、
+    <exceptionname>Error</exceptionname> 例外をスローするようになりました。
    </simpara>
   </sect3>
 
@@ -552,7 +559,7 @@
    <title>MBString</title>
 
    <simpara>
-    Unicode data tables have been updated to Unicode 16.0.
+    Unicode データテーブルが Unicode 16.0 に更新されました。
    </simpara>
   </sect3>
 
@@ -560,7 +567,7 @@
    <title>MySQLnd</title>
 
    <simpara>
-    Support for the new VECTOR data type from MySQL 9.
+    MySQL 9 の新しい VECTOR データ型のサポート。
    </simpara>
   </sect3>
 
@@ -568,7 +575,7 @@
    <title>OpenSSL</title>
 
    <simpara>
-    The minimum OpenSSL version required is now 1.1.1.
+    最小必要 OpenSSL バージョンは 1.1.1 になりました。
    </simpara>
   </sect3>
 
@@ -576,7 +583,7 @@
    <title>PDO_PGSQL</title>
 
    <simpara>
-    The minimum libpq version required is now 10.0.
+    最小必要 libpq バージョンは 10.0 になりました。
    </simpara>
   </sect3>
 
@@ -584,7 +591,7 @@
    <title>PGSQL</title>
 
    <simpara>
-    The minimum libpq version required is now 10.0.
+    最小必要 libpq バージョンは 10.0 になりました。
    </simpara>
   </sect3>
 
@@ -592,12 +599,12 @@
    <title>SPL</title>
 
    <simpara>
-    Out of bounds accesses in <classname>SplFixedArray</classname> now throw
-    exceptions of type <exceptionname>OutOfBoundsException</exceptionname>
-    instead of <exceptionname>RuntimeException</exceptionname>.
-    Because <exceptionname>OutOfBoundsException</exceptionname> is a child
-    class of <exceptionname>RuntimeException</exceptionname> no behavioural
-    changes are exhibited when attempting to catch those exceptions.
+    <classname>SplFixedArray</classname> での範囲外アクセスは、
+    <exceptionname>RuntimeException</exceptionname> ではなく
+    <exceptionname>OutOfBoundsException</exceptionname> 型の例外をスローするようになりました。
+    <exceptionname>OutOfBoundsException</exceptionname> は
+    <exceptionname>RuntimeException</exceptionname> の子クラスであるため、
+    これらの例外をキャッチしようとする際の動作に変更はありません。
    </simpara>
   </sect3>
 
@@ -605,8 +612,8 @@
    <title>XSL</title>
 
    <simpara>
-    The typed properties <property>XSLTProcessor::$cloneDocument</property>
-    and <property>XSLTProcessor::$doXInclude</property> are now declared
+    型付きプロパティ <property>XSLTProcessor::$cloneDocument</property>
+    および <property>XSLTProcessor::$doXInclude</property> が定義されました。
    </simpara>
   </sect3>
 
@@ -614,30 +621,30 @@
    <title>Zlib</title>
 
    <simpara>
-    The minimum zlib version required is now 1.2.11.
+    最小必要 zlib バージョンは 1.2.11 になりました。
    </simpara>
   </sect3>
  </sect2>
 
  <sect2 xml:id="migration84.other-changes.performance">
-  <title>Performance</title>
+  <title>パフォーマンス</title>
 
   <sect3 xml:id="migration84.other-changes.performance.core">
-   <title>Core</title>
+   <title>PHP コア</title>
 
    <simpara>
-    Improved the performance of floating point number parsing and formatting in
-    ZTS builds under highly concurrent loads.
-    This affects the <function>printf</function> family of functions as well
-    as serialization functions such as <function>json_encode</function>,
-    or <function>serialize</function>.
+    ZTS ビルドにおける高負荷の並行処理環境下で、
+    浮動小数点数の解析とフォーマットのパフォーマンスが向上しました。
+    これは <function>printf</function> 系の関数や
+    <function>json_encode</function>、<function>serialize</function>
+    などのシリアライズ関数に影響します。
    </simpara>
 
    <simpara>
-    <function>sprintf</function> using only <literal>%s</literal> and
-    <literal>%d</literal> specifiers will be compiled into the equivalent
-    string interpolation, avoiding the overhead of a function call and
-    repeatedly parsing the format string.
+    <literal>%s</literal> と <literal>%d</literal> 指定子のみを使用する
+    <function>sprintf</function> は、同等の文字列補間にコンパイルされ、
+    関数呼び出しのオーバーヘッドとフォーマット文字列の
+    繰り返し解析を回避します。
    </simpara>
   </sect3>
 
@@ -645,7 +652,7 @@
    <title>BCMath</title>
 
    <simpara>
-    Improved performance of number conversions and operations.
+    数値の変換と演算のパフォーマンスが向上しました。
    </simpara>
   </sect3>
 
@@ -653,18 +660,18 @@
    <title>DOM</title>
 
    <simpara>
-    The performance of <methodname>DOMNode::C14N</methodname> is greatly
-    improved for the case without an xpath query.
-    This can give a time improvement of easily two order of
-    magnitude for documents with tens of thousands of nodes.
+    <methodname>DOMNode::C14N</methodname> のパフォーマンスが、
+    xpath クエリなしの場合に大幅に向上しました。
+    これは数万ノードのドキュメントで簡単に 2 桁の
+    時間改善をもたらします。
    </simpara>
 
    <simpara>
-    Improved performance and reduce memory consumption of XML serialization.
+    XML シリアライズのパフォーマンスが向上し、メモリ消費が削減されました。
    </simpara>
 
    <simpara>
-    Reduced memory usage of node classes.
+    ノードクラスのメモリ使用量が削減されました。
    </simpara>
   </sect3>
 
@@ -672,8 +679,8 @@
    <title>FTP</title>
 
    <simpara>
-    Improved the performance of FTP uploads up to a factor of 10x for large
-    uploads.
+    大きなアップロードで FTP アップロードのパフォーマンスが
+    最大 10 倍向上しました。
    </simpara>
   </sect3>
 
@@ -681,10 +688,10 @@
    <title>Hash</title>
 
    <simpara>
-    Added SSE2 and SHA-NI implementations of SHA-256.
-    This improves the performance on supported CPUs by ~1.3x (SSE2),
-    and 3x - 5x (SHA-NI).
-    Credit to Colin Percival / Tarsnap for this optimization.
+    SHA-256 の SSE2 および SHA-NI 実装が追加されました。
+    これにより、サポートされている CPU でのパフォーマンスが SSE2 で最大 1.3 倍、
+    SHA-NIで 3から 5 倍向上します。
+    この最適化は Colin Percival / Tarsnap の功績です。
    </simpara>
   </sect3>
 
@@ -692,16 +699,16 @@
    <title>MBString</title>
 
    <simpara>
-    <function>mb_strcut</function> is much faster now for UTF-8
-    and UTF-16 strings.
+    <function>mb_strcut</function> は UTF-8 および
+    UTF-16 文字列で大幅に高速になりました。
    </simpara>
 
    <simpara>
-    Looking up mbstring encoding names is much faster now.
+    mbstring のエンコーディング名の検索が大幅に高速になりました。
    </simpara>
 
    <simpara>
-    The performance of converting SJIS-win to Unicode is greatly improved.
+    SJIS-win から Unicode への変換のパフォーマンスが大幅に向上しました。
    </simpara>
   </sect3>
 
@@ -709,7 +716,7 @@
    <title>MySQLnd</title>
 
    <simpara>
-    Improved the performance of MySQLnd quoting.
+    MySQLnd のクオートのパフォーマンスが向上しました。
    </simpara>
   </sect3>
 
@@ -717,7 +724,7 @@
    <title>PCRE</title>
 
    <simpara>
-    Improved the performance of named capture groups.
+    名前付きキャプチャグループのパフォーマンスが向上しました。
    </simpara>
   </sect3>
 
@@ -725,10 +732,9 @@
    <title>Random</title>
 
    <simpara>
-    Improved the performance of <classname>Random\Randomizer</classname>,
-    with a specific focus on the
-    <methodname>Random\Randomizer::getBytes</methodname>,
-    and <methodname>Random\Randomizer::getBytesFromString</methodname> methods.
+    <classname>Random\Randomizer</classname> のパフォーマンスが向上しました。
+    特に <methodname>Random\Randomizer::getBytes</methodname> と
+    <methodname>Random\Randomizer::getBytesFromString</methodname> メソッドで顕著です。
    </simpara>
   </sect3>
 
@@ -736,7 +742,7 @@
    <title>SimpleXML</title>
 
    <simpara>
-    Improved performance and reduce memory consumption of XML serialization.
+    XML シリアライズのパフォーマンスが向上し、メモリ消費が削減されました。
    </simpara>
   </sect3>
 
@@ -744,18 +750,18 @@
    <title>Standard</title>
 
    <simpara>
-    The performance of <function>strspn</function> and
-    <function>strcspn</function> is greatly improved.
-    They now run in linear time instead of being bounded by quadratic time.
+    <function>strspn</function> および <function>strcspn</function> の
+    パフォーマンスが大幅に向上しました。
+    二乗時間ではなく、線形時間で実行されるようになりました。
    </simpara>
 
    <simpara>
-    Improved the performance of <function>strpbrk</function>.
+    <function>strpbrk</function> のパフォーマンスが向上しました。
    </simpara>
 
    <simpara>
-    <function>get_browser</function> is much faster now,
-    up to 1.5x - 2.5x for some test cases.
+    <function>get_browser</function> は大幅に高速になり、
+    いくつかのテストケースで最大 1.5 倍から 2.5 倍の速度向上を実現しました。
    </simpara>
   </sect3>
  </sect2>

--- a/appendices/migration84/removed-extensions.xml
+++ b/appendices/migration84/removed-extensions.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<sect1 xml:id="migration84.removed-extensions">
+ <title>Removed Extensions</title>
+
+ <simpara>
+  These extensions have been moved to PECL and are no longer part of the PHP
+  distribution. New releases for the PECL packages will be published on an
+  ad-hoc basis according to user demand.
+ </simpara>
+
+ <simplelist>
+  <member><link linkend="book.imap">IMAP</link></member>
+  <member><link linkend="book.oci8">OCI8</link></member>
+  <member><link linkend="ref.pdo-oci">PDO_OCI</link></member>
+  <member><link linkend="book.pspell">PSpell</link></member>
+ </simplelist>
+</sect1>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/appendices/migration84/removed-extensions.xml
+++ b/appendices/migration84/removed-extensions.xml
@@ -1,11 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 5fbf0f0cbce2dda6a379d8bda33d5b1869702e47 Maintainer: KentarouTakeda Status: ready -->
+<!-- Credits: KentarouTakeda -->
 <sect1 xml:id="migration84.removed-extensions">
- <title>Removed Extensions</title>
+ <title>削除された拡張モジュール</title>
 
  <simpara>
-  These extensions have been moved to PECL and are no longer part of the PHP
-  distribution. New releases for the PECL packages will be published on an
-  ad-hoc basis according to user demand.
+  これらの拡張モジュールは PECL に移行され、
+  PHP 配布の一部ではなくなりました。PECL パッケージの新しいリリースは、
+  ユーザーの需要に応じて随時公開されます。
  </simpara>
 
  <simplelist>

--- a/appendices/migration84/windows-support.xml
+++ b/appendices/migration84/windows-support.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<sect1 xml:id="migration84.windows-support">
+ <title>Windows Support</title>
+
+ <sect2 xml:id="migration84.windows-support.core">
+  <title>Core</title>
+
+  <simpara>
+   Building with Visual Studio now requires at least Visual Studio 2019.
+   However, Visual Studio 2022 is recommended.
+  </simpara>
+
+  <simpara>
+   AVX(2) CPU support is now properly detected for MSVC builds.
+  </simpara>
+
+  <simpara>
+   Native AVX-512 builds are now supported via the
+   <option role="configure">--enable-native-intrinsics=avx512</option>
+   configure option.
+  </simpara>
+ </sect2>
+
+</sect1>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/appendices/migration84/windows-support.xml
+++ b/appendices/migration84/windows-support.xml
@@ -1,23 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: d64e811eac61a5c7c744312d8bc6e2244de81488 Maintainer: KentarouTakeda Status: ready -->
+<!-- Credits: KentarouTakeda -->
 <sect1 xml:id="migration84.windows-support">
- <title>Windows Support</title>
+ <title>Windows のサポート</title>
 
  <sect2 xml:id="migration84.windows-support.core">
-  <title>Core</title>
+  <title>PHP コア</title>
 
   <simpara>
-   Building with Visual Studio now requires at least Visual Studio 2019.
-   However, Visual Studio 2022 is recommended.
+   Visual Studio でのビルドには、 Visual Studio 2019 以降が必要になりました。
+   ただし、Visual Studio 2022 が推奨されます。
   </simpara>
 
   <simpara>
-   AVX(2) CPU support is now properly detected for MSVC builds.
+   MSVC ビルドでは、AVX(2) CPU のサポートが正しく検出されるようになりました。
   </simpara>
 
   <simpara>
-   Native AVX-512 builds are now supported via the
+   ネイティブ AVX-512 ビルドが、configure オプション
    <option role="configure">--enable-native-intrinsics=avx512</option>
-   configure option.
+   でサポートされました。
   </simpara>
  </sect2>
 


### PR DESCRIPTION
## 翻訳の元となるコミットとプルリクエスト

* php/doc-en@d64e811
  * php/doc-en#3822
* php/doc-en@5fbf0f0
  * *N/A*
* php/doc-en@5743f22
  * *N/A*
* php/doc-en@b1b0396
  * php/doc-en#3910
* php/doc-en@8a6397d
  * php/doc-en#3936
* php/doc-en@5dc029d
  * php/doc-en#3995
* php/doc-en@3843755
  * php/doc-en#3989
* php/doc-en@0f1d7fb: 2024-11-07追加
  * php/doc-en#4009
* php/doc-en@b719f01: 2024-11-07追加
  * *N/A*
* php/doc-en@56b4b19: 2024-11-07追加
  * *N/A*
* php/doc-en@f20fa04: 2024-11-07追加
  * php/doc-en#3913
* php/doc-en@e3fc9c4: 2024-11-09追加 
  * php/doc-en#4021

## 備考

コミットを2つに分割しました。前半で英語版のコピー、次のコミットでその翻訳、という順序にしています。

これにより、後半のコミットでは、オリジナルと日本語版との対訳という形で Change Set を見ることができます。