### PR TITLE
`.editorconfig`と`.gitattributes`を英語版と同様に設定

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+; This file is for unifying the coding style for different editors and IDEs.
+; More information at https://editorconfig.org
+
+root = true
+
+[*.xml]
+charset = utf-8
+indent_size = 1
+indent_style = space
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.xml linguist-detectable
+*.ent linguist-language=XML linguist-detectable


### PR DESCRIPTION
`.editorconfig`と`.gitattributes`を英語版と同様に設定。ファイル内容は全く同じ。

既に各ファイル末尾のmodelineでは、タブ幅を初めとするテキストフォーマットが指定されている。
「インデントサイズ = 1」など `php/doc-*` 固有の設定が多いが、対応エディタが少ないため強制力に乏しい。

*php/doc-en* では同様の指定が `.editorconfig` にも設定されているが *doc-ja* には無い。
そのため、指定されたタブ幅と異なるファイルがcommitされるなど不統一を招いている。

EditorConfigにも同様の指定を行うことでそれらの事故を防ぐ。
同時に `.gitattributes` も同じ内容を指定。