### PR TITLE
[PHP 8.4] `PDO::PGSQL_ATTR_RESULT_MEMORY_SIZE` の翻訳

### DIFF
--- a/reference/pdo_pgsql/constants.xml
+++ b/reference/pdo_pgsql/constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: f8718da894c5160e571d74774c083090569ecebd Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 462a8fbc0b6cbb5112392ba61a596e206c7659f9 Maintainer: mumumu Status: ready -->
 <section xml:id="pdo-pgsql.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
  &pdo.driver-constants;
@@ -21,6 +21,21 @@
    </listitem>
   </varlistentry>
   
+  <varlistentry xml:id="pdo.constants.pgsql-attr-result-memory-size">
+   <term>
+    <constant>PDO::PGSQL_ATTR_RESULT_MEMORY_SIZE</constant>
+     (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     指定されたクエリ結果 <classname>PDOStatement</classname>
+     インスタンスに割り当てられたメモリ使用量をバイト単位で返します。
+     クエリ実行前で結果が存在しない場合は <literal>&null;</literal> を返します。
+     PHP 8.4.0 から利用可能です。
+    </para>
+   </listitem>
+  </varlistentry>
+
  </variablelist>
 </section>
 


### PR DESCRIPTION
## 翻訳の元となるコミットとプルリクエスト

* php/doc-en@abbba1f
  * php/doc-en#3983
* php/doc-en@462a8fb
  * php/doc-en#3997
