### PR TITLE
非推奨となった関数の引数のnullable型について

### DIFF
--- a/language/functions.xml
+++ b/language/functions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 74976cdb263ef841c5fc2c3f91ca7e284adce552 Maintainer: takagi Status: ready -->
-<!-- CREDITS: hirokawa,mumumu -->
+<!-- EN-Revision: 489d46bc2598784bd3711454ccab8940107cde67 Maintainer: takagi Status: ready -->
+<!-- CREDITS: hirokawa,mumumu,jdkfx -->
  <chapter xml:id="language.functions" xmlns="http://docbook.org/ns/docbook">
   <title>関数</title>
   
@@ -456,10 +456,9 @@ Making a bowl of raspberry natural yogurt.
      <code>Type $param = null</code> と書かれた引数です。
      &null; をデフォルトにすることは、
      型が暗黙のうちに nullable であることを示しています。
-     この書き方はまだ許可されていますが、
-     以下のようにして 明示的に
+     この使い方はPHP 8.4.0で非推奨となり、代わりに明示的な
      <link linkend="language.types.declarations.nullable">nullable 型</link>
-     を使うことを推奨します:
+     を使用する必要があります。
      <example>
       <title>デフォルト値を指定した引数は、必須の引数の後に宣言する</title>
       <programlisting role="php">
@@ -468,7 +467,9 @@ Making a bowl of raspberry natural yogurt.
  function foo($a = [], $b) {} // デフォルト値が使われないため、PHP 8.0.0 以降は推奨されません
  function foo($a, $b) {}      // 上のコードと機能的には同じですが、推奨されない警告は発生しません。
 
- function bar(A $a = null, $b) {} // まだ許可されています。$a は必須ですが、nullable です。
+ // PHP 8.1.0以降、$a は暗黙的に必須（必須の引数の前にあるため）ですが、
+ // デフォルトのパラメータ値が null であるため、暗黙的に nullable とみなされます（PHP 8.4.0で非推奨）。
+ function bar(A $a = null, $b) {}
  function bar(?A $a, $b) {}       // 推奨される書き方です。
  ?>
  ]]>


### PR DESCRIPTION
以下の変更を取り込みました

https://github.com/php/doc-en/pull/4008
https://github.com/php/doc-en/pull/4012