### PR TITLE
session.sid_lengthとsession.sid_bits_per_characterの非推奨について追記

### DIFF
--- a/reference/session/ini.xml
+++ b/reference/session/ini.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: be3a4367c932abe7cc2d1297f9c983daad1c204f Maintainer: hirokawa Status: ready -->
-<!-- CREDITS: shimooka,takagi,mumumu -->
+<!-- EN-Revision: 4841e3291543ae71e747f8448463c801b8a28e42 Maintainer: hirokawa Status: ready -->
+<!-- CREDITS: shimooka,takagi,mumumu,jdkfx -->
 <section xml:id="session.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;
  &extension.runtime;
@@ -160,13 +160,13 @@
      <entry><link linkend="ini.session.sid-length">session.sid_length</link></entry>
      <entry>"32"</entry>
      <entry><constant>INI_ALL</constant></entry>
-     <entry>PHP 7.1.0 から利用可能</entry>
+     <entry>PHP 7.1.0 から利用可能。PHP 8.4.0 以降では非推奨。</entry>
     </row>
     <row>
      <entry><link linkend="ini.session.sid-bits-per-character">session.sid_bits_per_character</link></entry>
      <entry>"4"</entry>
      <entry><constant>INI_ALL</constant></entry>
-     <entry>PHP 7.1.0 から利用可能</entry>
+     <entry>PHP 7.1.0 から利用可能。PHP 8.4.0 以降では非推奨。</entry>
     </row>
     <row>
      <entry><link linkend="ini.session.upload-progress.enabled">session.upload_progress.enabled</link></entry>


### PR DESCRIPTION
以下の変更を取り込みました

https://github.com/php/doc-en/pull/3993