### PR TITLE
[PHP 8.4] `array_all`, `array_any`, `array_find`, `array_find_key` の翻訳

### DIFF
--- a/reference/array/functions/array-all.xml
+++ b/reference/array/functions/array-all.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 596c11440dc232b8ed1836d7e3afe2ed5b225a7b Maintainer: KentarouTakeda Status: ready -->
+<!-- CREDITS: KentarouTakeda -->
+<refentry xml:id="function.array-all" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>array_all</refname>
+  <refpurpose>Checks if all &array; elements satisfy a callback function</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>mixed</type><methodname>array_all</methodname>
+   <methodparam><type>array</type><parameter>array</parameter></methodparam>
+   <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   <function>array_all</function> returns &true;, if the given
+   <parameter>callback</parameter> returns &true; for all elements.
+   Otherwise the function returns &false;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>array</parameter></term>
+    <listitem>
+     <simpara>
+      The &array; that should be searched.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>callback</parameter></term>
+    <listitem>
+     <para>
+      The callback function to call to check each element, which must be
+      <methodsynopsis>
+       <type>bool</type><methodname><replaceable>callback</replaceable></methodname>
+       <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
+       <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
+      </methodsynopsis>
+      If this function returns &false;, &false; is returned from
+      <function>array_all</function> and the callback will not be called for
+      further elements.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   The function returns &true;, if <parameter>callback</parameter> returns
+   &true; for all elements. Otherwise the function returns &false;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><function>array_all</function> example</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$array = [
+    'a' => 'dog',
+    'b' => 'cat',
+    'c' => 'cow',
+    'd' => 'duck',
+    'e' => 'goose',
+    'f' => 'elephant'
+];
+
+// Check, if all animal names are shorter than 12 letters.
+var_dump(array_all($array, function (string $value) {
+    return strlen($value) < 12;
+}));
+
+// Check, if all animal names are longer than 5 letters.
+var_dump(array_all($array, function (string $value) {
+    return strlen($value) > 5;
+}));
+
+// Check, if all array keys are strings.
+var_dump(array_all($array, function (string $value, $key) {
+   return is_string($key);
+}));
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+bool(true)
+bool(false)
+bool(true)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>array_any</function></member>
+   <member><function>array_filter</function></member>
+   <member><function>array_find</function></member>
+   <member><function>array_find_key</function></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/array/functions/array-all.xml
+++ b/reference/array/functions/array-all.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="function.array-all" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>array_all</refname>
-  <refpurpose>Checks if all &array; elements satisfy a callback function</refpurpose>
+  <refpurpose>&array; のすべての要素がコールバック関数を満たすかどうかを調べる</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -16,9 +16,9 @@
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   <function>array_all</function> returns &true;, if the given
-   <parameter>callback</parameter> returns &true; for all elements.
-   Otherwise the function returns &false;.
+   <function>array_all</function> は、指定された <parameter>callback</parameter> が
+   すべての要素に対して &true; を返す場合 &true; を返します。
+   そうでない場合 &false; を返します。
   </simpara>
  </refsect1>
 
@@ -29,7 +29,7 @@
     <term><parameter>array</parameter></term>
     <listitem>
      <simpara>
-      The &array; that should be searched.
+      検索する &array;。
      </simpara>
     </listitem>
    </varlistentry>
@@ -37,15 +37,15 @@
     <term><parameter>callback</parameter></term>
     <listitem>
      <para>
-      The callback function to call to check each element, which must be
+      各要素を調べるコールバック関数。シグネチャは次の通りです:
       <methodsynopsis>
        <type>bool</type><methodname><replaceable>callback</replaceable></methodname>
        <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
        <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
       </methodsynopsis>
-      If this function returns &false;, &false; is returned from
-      <function>array_all</function> and the callback will not be called for
-      further elements.
+      この関数が &false; を返すと、
+      <function>array_all</function> から &false; が返され、
+      以降の要素に対してはコールバックは呼び出されません。
      </para>
     </listitem>
    </varlistentry>
@@ -55,15 +55,15 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   The function returns &true;, if <parameter>callback</parameter> returns
-   &true; for all elements. Otherwise the function returns &false;.
+   <parameter>callback</parameter> がすべての要素に対して &true; を返す場合、
+   この関数は &true; を返します。そうでない場合 &false; を返します。
   </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title><function>array_all</function> example</title>
+   <title><function>array_all</function> の例</title>
    <programlisting role="php">
 <![CDATA[
 <?php
@@ -76,17 +76,17 @@ $array = [
     'f' => 'elephant'
 ];
 
-// Check, if all animal names are shorter than 12 letters.
+// すべての動物名が12文字未満かどうかをチェックします。
 var_dump(array_all($array, function (string $value) {
     return strlen($value) < 12;
 }));
 
-// Check, if all animal names are longer than 5 letters.
+// すべての動物名が5文字より長いかどうかをチェックします。
 var_dump(array_all($array, function (string $value) {
     return strlen($value) > 5;
 }));
 
-// Check, if all array keys are strings.
+// すべての配列キーが文字列かどうかをチェックします。
 var_dump(array_all($array, function (string $value, $key) {
    return is_string($key);
 }));

--- a/reference/array/functions/array-any.xml
+++ b/reference/array/functions/array-any.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="function.array-any" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>array_any</refname>
-  <refpurpose>Checks if at least one &array; element satisfies a callback function</refpurpose>
+  <refpurpose>&array; のいずれかの要素がコールバック関数を満たすかどうかを調べる</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -16,9 +16,9 @@
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   <function>array_any</function> returns &true;, if the given
-   <parameter>callback</parameter> returns &true; for any element.
-   Otherwise the function returns &false;.
+   <function>array_any</function> は、指定された<parameter>callback</parameter> が
+   いずれかの要素に対して &true; を返す場合 &true; を返します。
+   そうでない場合 &false; を返します。
   </simpara>
  </refsect1>
 
@@ -29,7 +29,7 @@
     <term><parameter>array</parameter></term>
     <listitem>
      <simpara>
-      The &array; that should be searched.
+      検索する &array;。
      </simpara>
     </listitem>
    </varlistentry>
@@ -37,15 +37,15 @@
     <term><parameter>callback</parameter></term>
     <listitem>
      <para>
-      The callback function to call to check each element, which must be
+      各要素を調べるコールバック関数。シグネチャは次の通りです:
       <methodsynopsis>
        <type>bool</type><methodname><replaceable>callback</replaceable></methodname>
        <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
        <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
       </methodsynopsis>
-      If this function returns &true;, &true; is returned from
-      <function>array_any</function> and the callback will not be called for
-      further elements.
+      この関数が &true; を返すと、
+      <function>array_any</function> から &true; が返され、
+      以降の要素に対してはコールバックは呼び出されません。
      </para>
     </listitem>
    </varlistentry>
@@ -55,16 +55,16 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   The function returns &true;, if there is at least one element for which
-   <parameter>callback</parameter> returns &true;. Otherwise the function
-   returns &false;.
+   この関数は、<parameter>callback</parameter> が &true; を返す要素が
+   少なくとも1つある場合、&true; を返します。
+   そうでない場合 &false; を返します。
   </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title><function>array_any</function> example</title>
+   <title><function>array_any</function> の例</title>
    <programlisting role="php">
 <![CDATA[
 <?php
@@ -77,17 +77,17 @@ $array = [
     'f' => 'elephant'
 ];
 
-// Check, if any animal name is longer than 5 letters.
+// いずれかの動物名が5文字より長いかどうかをチェックします。
 var_dump(array_any($array, function (string $value) {
     return strlen($value) > 5;
 }));
 
-// Check, if any animal name is shorter than 3 letters.
+// いずれかの動物名が3文字より短いかどうかをチェックします。
 var_dump(array_any($array, function (string $value) {
     return strlen($value) < 3;
 }));
 
-// Check, if any array key is not a string.
+// 配列キーに文字列でないものがあるかどうかをチェックします。
 var_dump(array_any($array, function (string $value, $key) {
    return !is_string($key);
 }));

--- a/reference/array/functions/array-any.xml
+++ b/reference/array/functions/array-any.xml
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 596c11440dc232b8ed1836d7e3afe2ed5b225a7b Maintainer: KentarouTakeda Status: ready -->
+<!-- CREDITS: KentarouTakeda -->
+<refentry xml:id="function.array-any" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>array_any</refname>
+  <refpurpose>Checks if at least one &array; element satisfies a callback function</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>mixed</type><methodname>array_any</methodname>
+   <methodparam><type>array</type><parameter>array</parameter></methodparam>
+   <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   <function>array_any</function> returns &true;, if the given
+   <parameter>callback</parameter> returns &true; for any element.
+   Otherwise the function returns &false;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>array</parameter></term>
+    <listitem>
+     <simpara>
+      The &array; that should be searched.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>callback</parameter></term>
+    <listitem>
+     <para>
+      The callback function to call to check each element, which must be
+      <methodsynopsis>
+       <type>bool</type><methodname><replaceable>callback</replaceable></methodname>
+       <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
+       <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
+      </methodsynopsis>
+      If this function returns &true;, &true; is returned from
+      <function>array_any</function> and the callback will not be called for
+      further elements.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   The function returns &true;, if there is at least one element for which
+   <parameter>callback</parameter> returns &true;. Otherwise the function
+   returns &false;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><function>array_any</function> example</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$array = [
+    'a' => 'dog',
+    'b' => 'cat',
+    'c' => 'cow',
+    'd' => 'duck',
+    'e' => 'goose',
+    'f' => 'elephant'
+];
+
+// Check, if any animal name is longer than 5 letters.
+var_dump(array_any($array, function (string $value) {
+    return strlen($value) > 5;
+}));
+
+// Check, if any animal name is shorter than 3 letters.
+var_dump(array_any($array, function (string $value) {
+    return strlen($value) < 3;
+}));
+
+// Check, if any array key is not a string.
+var_dump(array_any($array, function (string $value, $key) {
+   return !is_string($key);
+}));
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+bool(true)
+bool(false)
+bool(false)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>array_all</function></member>
+   <member><function>array_filter</function></member>
+   <member><function>array_find</function></member>
+   <member><function>array_find_key</function></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/array/functions/array-filter.xml
+++ b/reference/array/functions/array-filter.xml
@@ -9,7 +9,7 @@
    コールバック関数を使用して、配列の要素をフィルタリングする
   </refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
@@ -259,9 +259,10 @@ array(2) {
   <para>
    <simplelist>
     <member><function>array_intersect</function></member>
+    <member><function>array_find</function></member>
+    <member><function>array_any</function></member>
     <member><function>array_map</function></member>
     <member><function>array_reduce</function></member>
-    <member><function>array_walk</function></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/array/functions/array-find-key.xml
+++ b/reference/array/functions/array-find-key.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="function.array-find-key" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>array_find_key</refname>
-  <refpurpose>Returns the key of the first element satisfying a callback function</refpurpose>
+  <refpurpose>コールバック関数を満たす最初の要素のキーを返す</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -16,9 +16,9 @@
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   <function>array_find_key</function> returns the key of the first element of an
-   &array; for which the given <parameter>callback</parameter> returns &true;.
-   If no matching element is found the function returns &null;.
+   <function>array_find_key</function> は、指定された
+   <parameter>callback</parameter> が &true; を返す &array; の最初の要素のキーを返します。
+   見つからない場合 &null; を返します。
   </simpara>
  </refsect1>
 
@@ -29,7 +29,7 @@
     <term><parameter>array</parameter></term>
     <listitem>
      <simpara>
-      The &array; that should be searched.
+      検索する &array;。
      </simpara>
     </listitem>
    </varlistentry>
@@ -37,15 +37,15 @@
     <term><parameter>callback</parameter></term>
     <listitem>
      <para>
-      The callback function to call to check each element, which must be
+      各要素を調べるコールバック関数。シグネチャは次の通りです:
       <methodsynopsis>
        <type>bool</type><methodname><replaceable>callback</replaceable></methodname>
        <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
        <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
       </methodsynopsis>
-      If this function returns &true;, the key is returned from
-      <function>array_find_key</function> and the callback will not be called
-      for further elements.
+      この関数が &true; を返すと、
+      その要素のキーが <function>array_find_key</function> から返され、
+      以降の要素に対してはコールバックは呼び出されません。
      </para>
     </listitem>
    </varlistentry>
@@ -55,16 +55,16 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   The function returns the key of the first element for which the
-   <parameter>callback</parameter> returns &true;. If no matching element is
-   found the function returns &null;.
+   <parameter>callback</parameter> が &true; を返す最初の要素のキーを返します。
+   一致する要素が見つからない場合、
+   &null; を返します。
   </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title><function>array_find_key</function> example</title>
+   <title><function>array_find_key</function> の例</title>
    <programlisting role="php">
 <![CDATA[
 <?php
@@ -77,22 +77,22 @@ $array = [
     'f' => 'elephant'
 ];
 
-// Find the first animal with a name longer than 4 characters.
+// 名前が4文字より長い最初の動物を探します。
 var_dump(array_find_key($array, function (string $value) {
     return strlen($value) > 4;
 }));
 
-// Find the first animal whose name begins with f.
+// 名前がfで始まる最初の動物を探します。
 var_dump(array_find_key($array, function (string $value) {
     return str_starts_with($value, 'f');
 }));
 
-// Find the first animal where the array key is the first symbol of the animal.
+// 配列キーが動物の最初の文字と一致する最初の動物を探します。
 var_dump(array_find_key($array, function (string $value, $key) {
    return $value[0] === $key;
 }));
 
-// Find the first animal where the array key matching a RegEx.
+// 配列キーが正規表現にマッチする最初の動物を探します。
 var_dump(array_find_key($array, function ($value, $key) {
    return preg_match('/^([a-f])$/', $key);
 }));

--- a/reference/array/functions/array-find-key.xml
+++ b/reference/array/functions/array-find-key.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 596c11440dc232b8ed1836d7e3afe2ed5b225a7b Maintainer: KentarouTakeda Status: ready -->
+<!-- CREDITS: KentarouTakeda -->
+<refentry xml:id="function.array-find-key" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>array_find_key</refname>
+  <refpurpose>Returns the key of the first element satisfying a callback function</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>mixed</type><methodname>array_find_key</methodname>
+   <methodparam><type>array</type><parameter>array</parameter></methodparam>
+   <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   <function>array_find_key</function> returns the key of the first element of an
+   &array; for which the given <parameter>callback</parameter> returns &true;.
+   If no matching element is found the function returns &null;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>array</parameter></term>
+    <listitem>
+     <simpara>
+      The &array; that should be searched.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>callback</parameter></term>
+    <listitem>
+     <para>
+      The callback function to call to check each element, which must be
+      <methodsynopsis>
+       <type>bool</type><methodname><replaceable>callback</replaceable></methodname>
+       <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
+       <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
+      </methodsynopsis>
+      If this function returns &true;, the key is returned from
+      <function>array_find_key</function> and the callback will not be called
+      for further elements.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   The function returns the key of the first element for which the
+   <parameter>callback</parameter> returns &true;. If no matching element is
+   found the function returns &null;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><function>array_find_key</function> example</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$array = [
+    'a' => 'dog',
+    'b' => 'cat',
+    'c' => 'cow',
+    'd' => 'duck',
+    'e' => 'goose',
+    'f' => 'elephant'
+];
+
+// Find the first animal with a name longer than 4 characters.
+var_dump(array_find_key($array, function (string $value) {
+    return strlen($value) > 4;
+}));
+
+// Find the first animal whose name begins with f.
+var_dump(array_find_key($array, function (string $value) {
+    return str_starts_with($value, 'f');
+}));
+
+// Find the first animal where the array key is the first symbol of the animal.
+var_dump(array_find_key($array, function (string $value, $key) {
+   return $value[0] === $key;
+}));
+
+// Find the first animal where the array key matching a RegEx.
+var_dump(array_find_key($array, function ($value, $key) {
+   return preg_match('/^([a-f])$/', $key);
+}));
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+string(1) "e"
+NULL
+string(1) "c"
+string(1) "a"
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>array_find</function></member>
+   <member><function>array_all</function></member>
+   <member><function>array_any</function></member>
+   <member><function>array_filter</function></member>
+   <member><function>array_reduce</function></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/array/functions/array-find.xml
+++ b/reference/array/functions/array-find.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="function.array-find" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>array_find</refname>
-  <refpurpose>Returns the first element satisfying a callback function</refpurpose>
+  <refpurpose>コールバック関数を満たす最初の要素を返す</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -16,9 +16,9 @@
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   <function>array_find</function> returns the value of the first element of an
-   &array; for which the given <parameter>callback</parameter> returns &true;.
-   If no matching element is found the function returns &null;.
+   <function>array_find</function> は、指定された
+   <parameter>callback</parameter> が &true; を返す &array; の最初の要素を返します。
+   見つからない場合 &null; を返します。
   </simpara>
  </refsect1>
 
@@ -29,7 +29,7 @@
     <term><parameter>array</parameter></term>
     <listitem>
      <simpara>
-      The &array; that should be searched.
+      検索する &array;。
      </simpara>
     </listitem>
    </varlistentry>
@@ -37,15 +37,15 @@
     <term><parameter>callback</parameter></term>
     <listitem>
      <para>
-      The callback function to call to check each element, which must be
+      各要素を調べるコールバック関数。シグネチャは次の通りです:
       <methodsynopsis>
        <type>bool</type><methodname><replaceable>callback</replaceable></methodname>
        <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
        <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
       </methodsynopsis>
-      If this function returns &true;, the value is returned from
-      <function>array_find</function> and the callback will not be called for
-      further elements.
+      この関数が &true; を返すと、
+      その要素が <function>array_find</function> から返され、
+      以降の要素に対してはコールバックは呼び出されません。
      </para>
     </listitem>
    </varlistentry>
@@ -55,16 +55,16 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   The function returns the value of the first element for which the
-   <parameter>callback</parameter> returns &true;. If no matching element is
-   found the function returns &null;.
+   <parameter>callback</parameter> が &true; を返す最初の要素を返します。
+   一致する要素が見つからない場合、
+   &null; を返します。
   </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title><function>array_find</function> example</title>
+   <title><function>array_find</function> の例</title>
    <programlisting role="php">
 <![CDATA[
 <?php
@@ -77,22 +77,22 @@ $array = [
     'f' => 'elephant'
 ];
 
-// Find the first animal with a name longer than 4 characters.
+// 名前が4文字より長い最初の動物を探します。
 var_dump(array_find($array, function (string $value) {
     return strlen($value) > 4;
 }));
 
-// Find the first animal whose name begins with f.
+// 名前がfで始まる最初の動物を探します。
 var_dump(array_find($array, function (string $value) {
     return str_starts_with($value, 'f');
 }));
 
-// Find the first animal where the array key is the first symbol of the animal.
+// キーが動物の名前の最初の文字と一致する最初の動物を探します。
 var_dump(array_find($array, function (string $value, $key) {
    return $value[0] === $key;
 }));
 
-// Find the first animal where the array key matching a RegEx.
+// キーが正規表現にマッチする最初の動物を探します。
 var_dump(array_find($array, function ($value, $key) {
    return preg_match('/^([a-f])$/', $key);
 }));

--- a/reference/array/functions/array-find.xml
+++ b/reference/array/functions/array-find.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 596c11440dc232b8ed1836d7e3afe2ed5b225a7b Maintainer: KentarouTakeda Status: ready -->
+<!-- CREDITS: KentarouTakeda -->
+<refentry xml:id="function.array-find" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>array_find</refname>
+  <refpurpose>Returns the first element satisfying a callback function</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>mixed</type><methodname>array_find</methodname>
+   <methodparam><type>array</type><parameter>array</parameter></methodparam>
+   <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   <function>array_find</function> returns the value of the first element of an
+   &array; for which the given <parameter>callback</parameter> returns &true;.
+   If no matching element is found the function returns &null;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>array</parameter></term>
+    <listitem>
+     <simpara>
+      The &array; that should be searched.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>callback</parameter></term>
+    <listitem>
+     <para>
+      The callback function to call to check each element, which must be
+      <methodsynopsis>
+       <type>bool</type><methodname><replaceable>callback</replaceable></methodname>
+       <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
+       <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
+      </methodsynopsis>
+      If this function returns &true;, the value is returned from
+      <function>array_find</function> and the callback will not be called for
+      further elements.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   The function returns the value of the first element for which the
+   <parameter>callback</parameter> returns &true;. If no matching element is
+   found the function returns &null;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><function>array_find</function> example</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$array = [
+    'a' => 'dog',
+    'b' => 'cat',
+    'c' => 'cow',
+    'd' => 'duck',
+    'e' => 'goose',
+    'f' => 'elephant'
+];
+
+// Find the first animal with a name longer than 4 characters.
+var_dump(array_find($array, function (string $value) {
+    return strlen($value) > 4;
+}));
+
+// Find the first animal whose name begins with f.
+var_dump(array_find($array, function (string $value) {
+    return str_starts_with($value, 'f');
+}));
+
+// Find the first animal where the array key is the first symbol of the animal.
+var_dump(array_find($array, function (string $value, $key) {
+   return $value[0] === $key;
+}));
+
+// Find the first animal where the array key matching a RegEx.
+var_dump(array_find($array, function ($value, $key) {
+   return preg_match('/^([a-f])$/', $key);
+}));
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+string(5) "goose"
+NULL
+string(3) "cow"
+string(3) "dog"
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>array_find_key</function></member>
+   <member><function>array_all</function></member>
+   <member><function>array_any</function></member>
+   <member><function>array_filter</function></member>
+   <member><function>array_reduce</function></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
翻訳元: php/doc-en#3465

コミットを2つに分割しました。前半で英語版のコピー、次のコミットでその翻訳、という順序にしています。

これにより、後半のコミットでは、オリジナルと日本語版との対訳という形で Change Set を見ることができます。