### PR TITLE
[PHP 8.4] 「Deprecatedアトリビュート」の翻訳

### DIFF
--- a/language/predefined/attributes.xml
+++ b/language/predefined/attributes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: fe11910e25e7eba44959bd347ba946ffc4d56934 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: e890e4a7f97a9ea85e60a38443e7c8eb7ae9383f Maintainer: mumumu Status: ready -->
 <part xml:id="reserved.attributes" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>定義済みのアトリビュート</title>
 
@@ -12,6 +12,7 @@
 
  &language.predefined.attributes.attribute;
  &language.predefined.attributes.allowdynamicproperties;
+ &language.predefined.attributes.deprecated;
  &language.predefined.attributes.override;
  &language.predefined.attributes.returntypewillchange;
  &language.predefined.attributes.sensitiveparameter;

--- a/language/predefined/attributes/deprecated.xml
+++ b/language/predefined/attributes/deprecated.xml
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: e890e4a7f97a9ea85e60a38443e7c8eb7ae9383f Maintainer: KentarouTakeda Status: ready -->
+<!-- CREDITS: KentarouTakeda -->
+<reference xml:id="class.deprecated" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>The Deprecated attribute</title>
+ <titleabbrev>Deprecated</titleabbrev>
+
+ <partintro>
+
+  <section xml:id="deprecated.intro">
+   &reftitle.intro;
+   <simpara>
+    This attribute is used to mark functionality as deprecated.
+    Using deprecated functionality will cause an <constant>E_USER_DEPRECATED</constant> error to be emitted.
+   </simpara>
+  </section>
+
+  <section xml:id="deprecated.synopsis">
+   &reftitle.classsynopsis;
+
+   <classsynopsis class="class">
+    <ooclass>
+     <modifier>final</modifier>
+     <classname>Deprecated</classname>
+    </ooclass>
+
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>string</type><type>null</type></type>
+     <varname linkend="deprecated.props.message">message</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type class="union"><type>string</type><type>null</type></type>
+     <varname linkend="deprecated.props.since">since</varname>
+    </fieldsynopsis>
+
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.deprecated')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Deprecated'])">
+     <xi:fallback/>
+    </xi:include>
+   </classsynopsis>
+  </section>
+
+  <section xml:id="deprecated.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="deprecated.props.message">
+     <term><varname>message</varname></term>
+     <listitem>
+      <para>
+       An optional message explaining the reason for the deprecation and possible replacement functionality.
+       Will be included in the emitted deprecation message.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="deprecated.props.since">
+     <term><varname>since</varname></term>
+     <listitem>
+       <para>
+        An optional string indicating since when the functionality is deprecated.
+        The contents are not validated by PHP and may contain a version number,
+        a date or any other value that is considered appropriate.
+        Will be included in the emitted deprecation message.
+       </para>
+       <para>
+        Functionality that is part of PHP will use Major.Minor as the <varname>since</varname> value,
+        for example <literal>'8.4'</literal>.
+       </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+
+  <section>
+   &reftitle.examples;
+   <informalexample>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+#[\Deprecated(message: "use safe_replacement() instead", since: "1.5")]
+function unsafe_function()
+{
+   echo "This is unsafe", PHP_EOL;
+}
+
+unsafe_function();
+
+?>
+]]>
+    </programlisting>
+    &example.outputs.84.similar;
+    <screen>
+<![CDATA[
+Deprecated: Function unsafe_function() is deprecated since 1.5, use safe_replacement() instead in example.php on line 9
+This is unsafe
+]]>
+    </screen>
+   </informalexample>
+  </section>
+
+  <section xml:id="deprecated.seealso">
+   &reftitle.seealso;
+   <simplelist>
+    <member><link linkend="language.attributes">Attributes overview</link></member>
+    <member><methodname>ReflectionFunctionAbstract::isDeprecated</methodname></member>
+    <member><methodname>ReflectionClassConstant::isDeprecated</methodname></member>
+    <member><constant>E_USER_DEPRECATED</constant></member>
+   </simplelist>
+  </section>
+
+ </partintro>
+
+ &language.predefined.attributes.deprecated.construct;
+
+</reference>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/language/predefined/attributes/deprecated.xml
+++ b/language/predefined/attributes/deprecated.xml
@@ -3,7 +3,7 @@
 <!-- EN-Revision: e890e4a7f97a9ea85e60a38443e7c8eb7ae9383f Maintainer: KentarouTakeda Status: ready -->
 <!-- CREDITS: KentarouTakeda -->
 <reference xml:id="class.deprecated" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
- <title>The Deprecated attribute</title>
+ <title>Deprecated クラス</title>
  <titleabbrev>Deprecated</titleabbrev>
 
  <partintro>
@@ -11,8 +11,8 @@
   <section xml:id="deprecated.intro">
    &reftitle.intro;
    <simpara>
-    This attribute is used to mark functionality as deprecated.
-    Using deprecated functionality will cause an <constant>E_USER_DEPRECATED</constant> error to be emitted.
+    このアトリビュートは、機能を非推奨としてマークします。
+    マークされた機能を使用すると、<constant>E_USER_DEPRECATED</constant> エラーが発生します。
    </simpara>
   </section>
 
@@ -53,8 +53,8 @@
      <term><varname>message</varname></term>
      <listitem>
       <para>
-       An optional message explaining the reason for the deprecation and possible replacement functionality.
-       Will be included in the emitted deprecation message.
+       非推奨となった理由と可能なら代替機能を説明する追加のメッセージ。
+       発生する非推奨エラーのメッセージに含まれます。
       </para>
      </listitem>
     </varlistentry>
@@ -62,14 +62,14 @@
      <term><varname>since</varname></term>
      <listitem>
        <para>
-        An optional string indicating since when the functionality is deprecated.
-        The contents are not validated by PHP and may contain a version number,
-        a date or any other value that is considered appropriate.
-        Will be included in the emitted deprecation message.
+        機能がいつから非推奨になったかを示す追加の文字列。
+        内容は PHP によって検証されず、バージョン番号、日付、
+        または適切と考えられる他の値を含むことができます。
+        発生する非推奨エラーのメッセージに含まれます。
        </para>
        <para>
-        Functionality that is part of PHP will use Major.Minor as the <varname>since</varname> value,
-        for example <literal>'8.4'</literal>.
+        PHP 自体の機能は、<varname>since</varname> の値として Major.Minor を利用します。
+        例えば <literal>'8.4'</literal> です。
        </para>
      </listitem>
     </varlistentry>
@@ -107,7 +107,7 @@ This is unsafe
   <section xml:id="deprecated.seealso">
    &reftitle.seealso;
    <simplelist>
-    <member><link linkend="language.attributes">Attributes overview</link></member>
+    <member><link linkend="language.attributes">アトリビュートの概要</link></member>
     <member><methodname>ReflectionFunctionAbstract::isDeprecated</methodname></member>
     <member><methodname>ReflectionClassConstant::isDeprecated</methodname></member>
     <member><constant>E_USER_DEPRECATED</constant></member>

--- a/language/predefined/attributes/deprecated/construct.xml
+++ b/language/predefined/attributes/deprecated/construct.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="deprecated.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Deprecated::__construct</refname>
-  <refpurpose>Construct a new Deprecated attribute instance</refpurpose>
+  <refpurpose>新しい Deprecated のインスタンスを作成する</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -16,7 +16,7 @@
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>since</parameter><initializer>&null;</initializer></methodparam>
   </constructorsynopsis>
   <simpara>
-   Constructs a new <classname>Deprecated</classname> instance.
+   新しい <classname>Deprecated</classname> のインスタンスを作成します。
   </simpara>
  </refsect1>
 
@@ -27,7 +27,7 @@
     <term><parameter>message</parameter></term>
     <listitem>
      <para>
-      The value of the <property linkend="deprecated.props.message">message</property> property.
+      <property linkend="deprecated.props.message">message</property> プロパティの値。
      </para>
     </listitem>
    </varlistentry>
@@ -35,7 +35,7 @@
     <term><parameter>since</parameter></term>
     <listitem>
      <para>
-      The value of the <property linkend="deprecated.props.since">since</property> property.
+      <property linkend="deprecated.props.since">since</property> プロパティの値。
      </para>
     </listitem>
    </varlistentry>

--- a/language/predefined/attributes/deprecated/construct.xml
+++ b/language/predefined/attributes/deprecated/construct.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: e890e4a7f97a9ea85e60a38443e7c8eb7ae9383f Maintainer: KentarouTakeda Status: ready -->
+<!-- CREDITS: KentarouTakeda -->
+<refentry xml:id="deprecated.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Deprecated::__construct</refname>
+  <refpurpose>Construct a new Deprecated attribute instance</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <constructorsynopsis role="Deprecated">
+   <modifier>public</modifier> <methodname>Deprecated::__construct</methodname>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>message</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>since</parameter><initializer>&null;</initializer></methodparam>
+  </constructorsynopsis>
+  <simpara>
+   Constructs a new <classname>Deprecated</classname> instance.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>message</parameter></term>
+    <listitem>
+     <para>
+      The value of the <property linkend="deprecated.props.message">message</property> property.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>since</parameter></term>
+    <listitem>
+     <para>
+      The value of the <property linkend="deprecated.props.since">since</property> property.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/reflection/reflectionclassconstant/isdeprecated.xml
+++ b/reference/reflection/reflectionclassconstant/isdeprecated.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 7de265dc47277aaf9b3c9f29d9691364aa0350ca Maintainer: KentarouTakeda Status: ready -->
+<!-- CREDITS: KentarouTakeda -->
+<refentry xml:id="reflectionclassconstant.isdeprecated" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ReflectionClassConstant::isDeprecated</refname>
+  <refpurpose>Checks if deprecated</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="ReflectionClassConstant">
+   <modifier>public</modifier> <type>bool</type><methodname>ReflectionClassConstant::isDeprecated</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Checks whether the class constant is deprecated.
+  </simpara>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &true; if it's deprecated, otherwise &false;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>
+    <methodname>ReflectionClassConstant::isDeprecated</methodname> example
+   </title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+class Basket {
+    #[\Deprecated(message: 'use Basket::APPLE instead')]
+    public const APLE = 'apple';
+
+    public const APPLE = 'apple';
+}
+$classConstant = new ReflectionClassConstant('Basket', 'APLE');
+var_dump($classConstant->isDeprecated());
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+bool(true)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><classname>Deprecated</classname></member>
+   <member><methodname>ReflectionClassConstant::getDocComment</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/reflection/reflectionclassconstant/isdeprecated.xml
+++ b/reference/reflection/reflectionclassconstant/isdeprecated.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="reflectionclassconstant.isdeprecated" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ReflectionClassConstant::isDeprecated</refname>
-  <refpurpose>Checks if deprecated</refpurpose>
+  <refpurpose>クラス定数が非推奨かどうかを調べる</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,7 +15,7 @@
    <void/>
   </methodsynopsis>
   <simpara>
-   Checks whether the class constant is deprecated.
+   クラス定数が非推奨かどうかを調べます。
   </simpara>
 
  </refsect1>
@@ -28,7 +28,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   &true; if it's deprecated, otherwise &false;
+   クラス定数が非推奨なら &true; を、そうでなければ &false; を返します。
   </simpara>
  </refsect1>
 
@@ -36,7 +36,7 @@
   &reftitle.examples;
   <example>
    <title>
-    <methodname>ReflectionClassConstant::isDeprecated</methodname> example
+    <methodname>ReflectionClassConstant::isDeprecated</methodname> の例
    </title>
    <programlisting role="php">
 <![CDATA[


### PR DESCRIPTION
翻訳元:
*  php/doc-en#3894
*  php/doc-en#3895

コミットを2つに分割しました。前半で英語版のコピー、次のコミットでその翻訳、という順序にしています。

これにより、後半のコミットでは、オリジナルと日本語版との対訳という形で Change Set を見ることができます。