### PR TITLE
[PHP 8.4] mysqli拡張モジュール

### DIFF
--- a/reference/mysqli/constants.xml
+++ b/reference/mysqli/constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 6d3ade3a588d629e52a948ceb36bea814e47a4f3 Maintainer: takagi Status: working -->
+<!-- EN-Revision: 8fb5db5a5eea9940e1cb5ea599817da36d3f36dd Maintainer: takagi Status: working -->
 <!-- CREDITS: hirokawa,mumumu -->
 <appendix xml:id="mysqli.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
@@ -281,6 +281,7 @@
       the copy approach can reduce the overall memory usage
       because PHP variables holding results may be released earlier.
       Available with <literal>mysqlnd</literal> only.
+      Deprecated as of PHP 8.4.0.
      </simpara>
     </listitem>
    </varlistentry>
@@ -812,6 +813,17 @@
      </para>
     </listitem>
    </varlistentry>
+   <varlistentry xml:id="constant.mysqli-type-vector">
+    <term>
+     <constant>MYSQLI_TYPE_VECTOR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <para>
+      Field is defined as <literal>VECTOR</literal>.
+     </para>
+    </listitem>
+   </varlistentry>
    <varlistentry xml:id="constant.mysqli-need-data">
     <term><constant>MYSQLI_NEED_DATA</constant></term>
     <listitem>
@@ -849,6 +861,7 @@
     </term>
     <listitem>
      <para>
+      Removed as of PHP 8.4.0.
      </para>
     </listitem>
    </varlistentry>
@@ -879,6 +892,7 @@
     </term>
     <listitem>
      <para>
+      Removed as of PHP 8.4.0.
      </para>
     </listitem>
    </varlistentry>
@@ -899,6 +913,7 @@
     </term>
     <listitem>
      <para>
+      Removed as of PHP 8.4.0.
      </para>
     </listitem>
    </varlistentry>
@@ -1006,6 +1021,7 @@
     <listitem>
      <para>
       権限テーブルをリフレッシュします。
+      Deprecated as of PHP 8.4.0.
      </para>
     </listitem>
    </varlistentry>
@@ -1018,6 +1034,7 @@
      <para>
       ログをフラッシュします。<acronym>SQL</acronym> 文
       <literal>FLUSH LOGS</literal> を実行するのと同じです。
+      Deprecated as of PHP 8.4.0.
      </para>
     </listitem>
    </varlistentry>
@@ -1030,6 +1047,7 @@
      <para>
       テーブルキャッシュをフラッシュします。<acronym>SQL</acronym> 文
       <literal>FLUSH TABLES</literal> を実行するのと同じです。
+      Deprecated as of PHP 8.4.0.
      </para>
     </listitem>
    </varlistentry>
@@ -1042,6 +1060,7 @@
      <para>
       ホストキャッシュをフラッシュします。<acronym>SQL</acronym> 文
       <literal>FLUSH HOSTS</literal> を実行するのと同じです。
+      Deprecated as of PHP 8.4.0.
      </para>
     </listitem>
    </varlistentry>
@@ -1053,7 +1072,7 @@
     <listitem>
      <para>
       <constant>MYSQLI_REFRESH_SLAVE</constant> のエイリアスです。
-      PHP 8.1.0 以降で利用可能です。
+      PHP 8.1.0 以降で利用可能です。Deprecated as of PHP 8.4.0.
      </para>
     </listitem>
    </varlistentry>
@@ -1066,6 +1085,7 @@
      <para>
       状態変数をリセットします。<acronym>SQL</acronym> 文
       <literal>FLUSH STATUS</literal> を実行するのと同じです。
+      Deprecated as of PHP 8.4.0.
      </para>
     </listitem>
    </varlistentry>
@@ -1077,6 +1097,7 @@
     <listitem>
      <para>
       スレッドキャッシュをフラッシュします。
+      Deprecated as of PHP 8.4.0.
      </para>
     </listitem>
    </varlistentry>
@@ -1091,6 +1112,7 @@
       マスタサーバーの情報をリセットしてスレーブを再起動します。
       <acronym>SQL</acronym> 文
       <literal>RESET SLAVE</literal> を実行するのと同じです。
+      Deprecated as of PHP 8.4.0.
      </para>
     </listitem>
    </varlistentry>
@@ -1105,6 +1127,7 @@
       バイナリログインデックスにあるバイナリログファイルを削除してインデックスファイルを切り詰めます。
       <acronym>SQL</acronym> 文
       <literal>RESET MASTER</literal> を実行するのと同じです。
+      Deprecated as of PHP 8.4.0.
      </para>
     </listitem>
    </varlistentry>
@@ -1117,6 +1140,7 @@
     <listitem>
      <simpara>
       Closes and reopens the backup log files.
+      Deprecated as of PHP 8.4.0.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/mysqli/constants.xml
+++ b/reference/mysqli/constants.xml
@@ -263,7 +263,6 @@
      </para>
     </listitem>
    </varlistentry>
-   <!-- to be translated -->
    <varlistentry xml:id="constant.mysqli-store-result-copy_data">
     <term>
      <constant>MYSQLI_STORE_RESULT_COPY_DATA</constant>
@@ -271,17 +270,17 @@
     </term>
     <listitem>
      <simpara>
-      As of PHP 8.1, this constants no longer has any effect.
-      Before PHP 8.1, this constant is used to copy results
-      from the internal <literal>mysqlnd</literal> buffer
-      into the PHP variables fetched.
-      By default, <literal>mysqlnd</literal> will use a reference logic
-      to avoid copying and duplicating results held in memory.
-      For certain result sets, for example, result sets with many small rows,
-      the copy approach can reduce the overall memory usage
-      because PHP variables holding results may be released earlier.
-      Available with <literal>mysqlnd</literal> only.
-      Deprecated as of PHP 8.4.0.
+      PHP 8.1 以降、この定数はもはや意味をなしません。
+      PHP 8.1 より前は、
+      <literal>mysqlnd</literal> の内部バッファに格納されたフェッチ結果を
+      PHP 変数へコピーするために使用されていました。
+      デフォルトでは <literal>mysqlnd</literal>  は、メモリ内の結果を
+      重複させないようにコピーではなく参照ロジックを使用します。
+      しかし、特定の結果セット、たとえば多数の小さな行を持つ結果セットでは、
+      PHP 変数を個別で早期に解放できるコピー方式の方が
+      全体的なメモリ使用量を削減る可能性があります。
+      <literal>mysqlnd</literal> のみで利用可能です。
+      PHP 8.4.0 で非推奨となりました。
      </simpara>
     </listitem>
    </varlistentry>
@@ -820,7 +819,7 @@
     </term>
     <listitem>
      <para>
-      Field is defined as <literal>VECTOR</literal>.
+      フィールドは <literal>VECTOR</literal> と定義されています。
      </para>
     </listitem>
    </varlistentry>
@@ -861,7 +860,7 @@
     </term>
     <listitem>
      <para>
-      Removed as of PHP 8.4.0.
+      PHP 8.4.0 で削除されました。
      </para>
     </listitem>
    </varlistentry>
@@ -892,7 +891,7 @@
     </term>
     <listitem>
      <para>
-      Removed as of PHP 8.4.0.
+      PHP 8.4.0 で削除されました。
      </para>
     </listitem>
    </varlistentry>
@@ -913,7 +912,7 @@
     </term>
     <listitem>
      <para>
-      Removed as of PHP 8.4.0.
+      PHP 8.4.0 で削除されました。
      </para>
     </listitem>
    </varlistentry>
@@ -1021,7 +1020,7 @@
     <listitem>
      <para>
       権限テーブルをリフレッシュします。
-      Deprecated as of PHP 8.4.0.
+      PHP 8.4.0 で非推奨となりました。
      </para>
     </listitem>
    </varlistentry>
@@ -1034,7 +1033,7 @@
      <para>
       ログをフラッシュします。<acronym>SQL</acronym> 文
       <literal>FLUSH LOGS</literal> を実行するのと同じです。
-      Deprecated as of PHP 8.4.0.
+      PHP 8.4.0 で非推奨となりました。
      </para>
     </listitem>
    </varlistentry>
@@ -1047,7 +1046,7 @@
      <para>
       テーブルキャッシュをフラッシュします。<acronym>SQL</acronym> 文
       <literal>FLUSH TABLES</literal> を実行するのと同じです。
-      Deprecated as of PHP 8.4.0.
+      PHP 8.4.0 で非推奨となりました。
      </para>
     </listitem>
    </varlistentry>
@@ -1060,7 +1059,7 @@
      <para>
       ホストキャッシュをフラッシュします。<acronym>SQL</acronym> 文
       <literal>FLUSH HOSTS</literal> を実行するのと同じです。
-      Deprecated as of PHP 8.4.0.
+      PHP 8.4.0 で非推奨となりました。
      </para>
     </listitem>
    </varlistentry>
@@ -1072,7 +1071,7 @@
     <listitem>
      <para>
       <constant>MYSQLI_REFRESH_SLAVE</constant> のエイリアスです。
-      PHP 8.1.0 以降で利用可能です。Deprecated as of PHP 8.4.0.
+      PHP 8.1.0 以降で利用可能です。PHP 8.4.0 で非推奨となりました。
      </para>
     </listitem>
    </varlistentry>
@@ -1085,7 +1084,7 @@
      <para>
       状態変数をリセットします。<acronym>SQL</acronym> 文
       <literal>FLUSH STATUS</literal> を実行するのと同じです。
-      Deprecated as of PHP 8.4.0.
+      PHP 8.4.0 で非推奨となりました。
      </para>
     </listitem>
    </varlistentry>
@@ -1097,7 +1096,7 @@
     <listitem>
      <para>
       スレッドキャッシュをフラッシュします。
-      Deprecated as of PHP 8.4.0.
+      PHP 8.4.0 で非推奨となりました。
      </para>
     </listitem>
    </varlistentry>
@@ -1112,7 +1111,7 @@
       マスタサーバーの情報をリセットしてスレーブを再起動します。
       <acronym>SQL</acronym> 文
       <literal>RESET SLAVE</literal> を実行するのと同じです。
-      Deprecated as of PHP 8.4.0.
+      PHP 8.4.0 で非推奨となりました。
      </para>
     </listitem>
    </varlistentry>
@@ -1127,7 +1126,7 @@
       バイナリログインデックスにあるバイナリログファイルを削除してインデックスファイルを切り詰めます。
       <acronym>SQL</acronym> 文
       <literal>RESET MASTER</literal> を実行するのと同じです。
-      Deprecated as of PHP 8.4.0.
+      PHP 8.4.0 で非推奨となりました。
      </para>
     </listitem>
    </varlistentry>
@@ -1140,7 +1139,7 @@
     <listitem>
      <simpara>
       Closes and reopens the backup log files.
-      Deprecated as of PHP 8.4.0.
+      PHP 8.4.0 で非推奨となりました。
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/mysqli/mysqli/kill.xml
+++ b/reference/mysqli/mysqli/kill.xml
@@ -73,9 +73,9 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Both <methodname>mysqli::kill</methodname> and
-       <function>mysqli_kill</function> are now deprecated. Use the
-       <literal>KILL</literal> SQL command instead.
+       <methodname>mysqli::kill</methodname> と
+       <function>mysqli_kill</function> は非推奨となりました。代わりに
+       <literal>KILL</literal> SQL コマンドを使用してください。
       </entry>
      </row>
     </tbody>

--- a/reference/mysqli/mysqli/kill.xml
+++ b/reference/mysqli/mysqli/kill.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 63b99082ef83eade08151f8cb528246fded81db9 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 7ce9e1661da0479fe49641e3da2c2761cf029d5c Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="mysqli.kill" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -8,6 +8,10 @@
   <refname>mysqli_kill</refname>
   <refpurpose>サーバーに MySQL スレッドの停止を問い合わせる</refpurpose>
  </refnamediv>
+
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-4-0;
+ </refsynopsisdiv>
 
  <refsect1 role="description">
   &reftitle.description;
@@ -53,6 +57,30 @@
  <refsect1 role="errors">
   &reftitle.errors;
   &mysqli.conditionalexception;
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Both <methodname>mysqli::kill</methodname> and
+       <function>mysqli_kill</function> are now deprecated. Use the
+       <literal>KILL</literal> SQL command instead.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mysqli/mysqli/ping.xml
+++ b/reference/mysqli/mysqli/ping.xml
@@ -78,10 +78,10 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Both <methodname>mysqli::ping</methodname> and
-       <function>mysqli_ping</function> are now deprecated.
-       The <literal>reconnect</literal> feature has not been available
-       as of PHP 8.2.0, making this function obsolete.
+       <methodname>mysqli::ping</methodname> と
+       <function>mysqli_ping</function> は非推奨となりました。
+       <literal>reconnect</literal> 機能は
+       PHP 8.2.0 で廃止されたため、この関数はもはや必要ありません。
       </entry>
      </row>
     </tbody>

--- a/reference/mysqli/mysqli/ping.xml
+++ b/reference/mysqli/mysqli/ping.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 63b99082ef83eade08151f8cb528246fded81db9 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 7ce9e1661da0479fe49641e3da2c2761cf029d5c Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="mysqli.ping" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -8,6 +8,10 @@
   <refname>mysqli_ping</refname>
   <refpurpose>サーバーとの接続をチェックし、もし切断されている場合は再接続を試みる</refpurpose>
  </refnamediv>
+
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-4-0;
+ </refsynopsisdiv>
 
  <refsect1 role="description">
   &reftitle.description;
@@ -58,6 +62,31 @@
  <refsect1 role="errors">
   &reftitle.errors;
   &mysqli.conditionalexception;
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Both <methodname>mysqli::ping</methodname> and
+       <function>mysqli_ping</function> are now deprecated.
+       The <literal>reconnect</literal> feature has not been available
+       as of PHP 8.2.0, making this function obsolete.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mysqli/mysqli/refresh.xml
+++ b/reference/mysqli/mysqli/refresh.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 035c126c0393fe154bac46e2c3c489ebadce48a5 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 7ce9e1661da0479fe49641e3da2c2761cf029d5c Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="mysqli.refresh" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -8,6 +8,10 @@
   <refname>mysqli_refresh</refname>
   <refpurpose>リフレッシュする</refpurpose>
  </refnamediv>
+
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-4-0;
+ </refsynopsisdiv>
  
  <refsect1 role="description">
   &reftitle.description;
@@ -54,6 +58,30 @@
   <para>
    リフレッシュに成功した場合に &true;、それ以外の場合に &false; を返します。
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Both <methodname>mysqli::refresh</methodname> and
+       <function>mysqli_refresh</function> are now deprecated.
+       Use <literal>FLUSH</literal> SQL commands instead.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mysqli/mysqli/refresh.xml
+++ b/reference/mysqli/mysqli/refresh.xml
@@ -74,9 +74,9 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Both <methodname>mysqli::refresh</methodname> and
-       <function>mysqli_refresh</function> are now deprecated.
-       Use <literal>FLUSH</literal> SQL commands instead.
+       <methodname>mysqli::refresh</methodname> と
+       <function>mysqli_refresh</function> は非推奨となりました。代わりに
+       <literal>FLUSH</literal> SQL コマンドを使用してください。
       </entry>
      </row>
     </tbody>

--- a/reference/mysqli/mysqli/store-result.xml
+++ b/reference/mysqli/mysqli/store-result.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 90953eddaa06c6c83faf0dea76c241dfafeaa2a1 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 699e596aaba256f7c3c81be8bb309e12fbd03ef4 Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="mysqli.store-result" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -97,6 +97,29 @@
  <refsect1 role="errors">
   &reftitle.errors;
   &mysqli.conditionalexception;
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Passing the <parameter>mode</parameter> parameter is now deprecated.
+       The parameter has had no effect as of PHP 8.1.0.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mysqli/mysqli/store-result.xml
+++ b/reference/mysqli/mysqli/store-result.xml
@@ -113,8 +113,8 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Passing the <parameter>mode</parameter> parameter is now deprecated.
-       The parameter has had no effect as of PHP 8.1.0.
+       <parameter>mode</parameter> パラメータの指定は非推奨となりました。
+       PHP 8.1 以降では、このパラメータを指定しても意味はありません。
       </entry>
      </row>
     </tbody>

--- a/reference/mysqli/mysqli/thread-id.xml
+++ b/reference/mysqli/mysqli/thread-id.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 7e5d0d1bb69180c9de1992edf9613215c975fa57 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 1afd3581fea176162adacef6dd692dfc114410f3 Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="mysqli.thread-id" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/mysqli/mysqli_stmt/attr-set.xml
+++ b/reference/mysqli/mysqli_stmt/attr-set.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 61374bbe228e8e9c55a24aba59a1e2bb2a871148 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4683a073bf428da8cd06a9bc428a131292c42ba3 Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 
 <refentry xml:id="mysqli-stmt.attr-set" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -71,6 +71,7 @@
             カーソルの使用時にサーバーからいちどに取得する行数。
             <parameter>value</parameter> に指定できる値の範囲は
             1 から unsigned long の最大値までで、デフォルトは 1 です。
+            Removed as of PHP 8.4.0.
            </entry>
           </row>
          </tbody>

--- a/reference/mysqli/mysqli_stmt/attr-set.xml
+++ b/reference/mysqli/mysqli_stmt/attr-set.xml
@@ -71,7 +71,7 @@
             カーソルの使用時にサーバーからいちどに取得する行数。
             <parameter>value</parameter> に指定できる値の範囲は
             1 から unsigned long の最大値までで、デフォルトは 1 です。
-            Removed as of PHP 8.4.0.
+            PHP 8.4.0 で削除されました。
            </entry>
           </row>
          </tbody>


### PR DESCRIPTION
翻訳元:
* php/doc-en#3847
  * reference/mysqli/mysqli/ping.xml
  * reference/mysqli/mysqli/thread-id.xml
* php/doc-en#3848
  * reference/mysqli/mysqli/refresh.xml
* php/doc-en#3850
  * reference/mysqli/mysqli/store-result.xml
* php/doc-en#3958
  * ~~language-snippets.ent~~: will be resolved with #161
  * reference/mysqli/mysqli/kill.xml
  * reference/mysqli/mysqli/ping.xml
  * reference/mysqli/mysqli/refresh.xml
* php/doc-en#3959
  * reference/mysqli/constants.xml
* php/doc-en#3960
  * reference/mysqli/constants.xml
  * reference/mysqli/mysqli_stmt/aaaaattr-set.xml
* php/doc-en#4065
  * reference/mysqli/constants.xml

コミットを2つに分割しました。前半で英語版のコピー、次のコミットでその翻訳、という順序にしています。

これにより、後半のコミットでは、オリジナルと日本語版との対訳という形で Change Set を見ることができま
