### PR TITLE
[PHP 8.4] xml,xsl関連機能の翻訳

### DIFF
--- a/reference/libxml/constants.xml
+++ b/reference/libxml/constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 8f6fd5c55ab10709a4ff8daf6140dea422c1363c Maintainer: takagi Status: ready -->
+<!-- EN-Revision: eae558e584a4e5f70e5d85b5cebc59e296399924 Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa,mumumu -->
 <appendix xml:id="libxml.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
@@ -48,6 +48,12 @@
     <simpara>
      デフォルトのDTD属性
     </simpara>
+    <caution>
+     <simpara>
+      DTD属性の読み込みを有効にすると、外部エンティティの取得が可能になります。
+      これを防ぐために <constant>LIBXML_NO_XXE</constant> 定数を使用できます(PHP 8.4.0 以降、Libxml &gt;= 2.13.0 でのみ利用可能です)。
+     </simpara>
+    </caution>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.libxml-dtdload">
@@ -59,6 +65,12 @@
     <simpara>
      外部サブセットをロードする
     </simpara>
+    <caution>
+     <simpara>
+      外部サブセットの読み込みを有効にすると、外部エンティティの取得が可能になります。
+      これを防ぐために <constant>LIBXML_NO_XXE</constant> 定数を使用できます(PHP 8.4.0 以降、Libxml &gt;= 2.13.0 でのみ利用可能です)。
+     </simpara>
+    </caution>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.libxml-dtdvalid">
@@ -73,6 +85,7 @@
     <caution>
      <simpara>
       DTD の検証を有効にすると、XML外部エンティティ参照攻撃(XXE) を容易にしてしまうかもしれません。
+      これを防ぐために <constant>LIBXML_NO_XXE</constant> 定数を使用できます(PHP 8.4.0 以降、Libxml &gt;= 2.13.0 でのみ利用可能です)。
      </simpara>
     </caution>
    </listitem>
@@ -228,6 +241,22 @@
     </note>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.libxml-no-xxe">
+   <term>
+    <constant>LIBXML_NO_XXE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     エンティティ置換を行う際、XML外部エンティティ参照(XXE)を無効にします
+    </simpara>
+    <note>
+     <para>
+      PHP 8.4.0 以降、Libxml &gt;= 2.13.0 の場合のみ有効
+     </para>
+    </note>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.libxml-nsclean">
    <term>
     <constant>LIBXML_NSCLEAN</constant>
@@ -270,6 +299,22 @@
     <note>
      <para>
       PHP &gt;= 5.4.0 でのみ有効
+     </para>
+    </note>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.libxml-recover">
+   <term>
+    <constant>LIBXML_RECOVER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     ドキュメントをパースする際、リカバリモードを有効にする。
+    </simpara>
+    <note>
+     <para>
+      PHP 8.4.0 以降でのみ有効
      </para>
     </note>
    </listitem>

--- a/reference/libxml/functions/libxml-disable-entity-loader.xml
+++ b/reference/libxml/functions/libxml-disable-entity-loader.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: f3b5475eebc9a79088559e506d90cd648404bf33 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: eae558e584a4e5f70e5d85b5cebc59e296399924 Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 
 <refentry xml:id="function.libxml-disable-entity-loader" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -23,11 +23,15 @@
    外部エンティティ読み込み機能の有効/無効を切り替えます。
    外部エンティティの読み込みを無効にすると、
    XML文書を読み込む際に問題が起こる可能性があることに注意して下さい。
-   しかし、libxml 2.9.0 以降では、エンティティの置換はデフォルトで無効になっているため、
-   <constant>LIBXML_NOENT</constant> を使って内部エンティティの参照を解決する必要がない限り、
+  </para>
+  <para>
+   libxml 2.9.0 以降では、エンティティの置換はデフォルトで無効になっているため、<constant>LIBXML_NOENT</constant>,
+   <constant>LIBXML_DTDVALID</constant>, or <constant>LIBXML_DTDLOAD</constant>.
+   を使って内部エンティティの参照を解決する必要がない限り、
    外部エンティティの読み込みを無効にする必要はありません。
    一般的には、外部エンティティの読み込みを抑制するのであれば、
    <function>libxml_set_external_entity_loader</function> を使うことが望ましいです。
+   <constant>LIBXML_NO_XXE</constant> 定数を使ってこれを防ぐこともできます (PHP 8.4.0 以降、Libxml &gt;= 2.13.0 でのみ利用可能)。
   </para>
  </refsect1>
 
@@ -102,7 +106,9 @@
    <simplelist>
     <member><function>libxml_use_internal_errors</function></member>
     <member><function>libxml_set_external_entity_loader</function></member>
-    <member><link linkend="libxml.constants"><constant>LIBXML_NOENT</constant> 定数</link></member>
+    <member>The <constant>LIBXML_NOENT</constant> 定数</member>
+    <member>The <constant>LIBXML_DTDVALID</constant> 定数</member>
+    <member>The <constant>LIBXML_NO_XXE</constant> 定数</member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/libxml/functions/libxml-set-streams-context.xml
+++ b/reference/libxml/functions/libxml-set-streams-context.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: f90df97fa5ebfa6e7fcace04976900d6700467cc Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 81bc2b5f454f893206009e0e931a72c85a86ac63 Maintainer: hirokawa Status: ready -->
 <refentry xml:id="function.libxml-set-streams-context" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>libxml_set_streams_context</refname>
@@ -41,6 +41,39 @@
   <para>
    &return.void;
   </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   非ストリームリソースが <parameter>context</parameter> に渡された場合、
+   <classname>TypeError</classname> をスローします。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       <function>libxml_set_streams_context</function> は、
+       <parameter>context</parameter> に非ストリームリソースが渡された場合、
+       コンテキストが実際に使用されたときではなく、その場で
+       <exceptionname>TypeError</exceptionname> をスローするようになりました。
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/libxml/setup.xml
+++ b/reference/libxml/setup.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 48ce43fe79fa0c9f31f187ea8ec995b4cb13037e Maintainer: takagi Status: ready -->
+<!-- EN-Revision: b8cefce03356afc96a205de76dac5c9770e78a9d Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa -->
 
 <chapter xml:id="libxml.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -10,8 +10,8 @@
  <section xml:id="libxml.requirements">
   &reftitle.required;
   <para>
-   この拡張モジュールは、PHP 8.0 以降では <link xlink:href="&url.libxml;">libxml</link> &gt;=
-   2.9.0 が必要です。PHP 8.0 より前のバージョンでは、libxml &gt;= 2.6.0 が必要です。
+   この拡張モジュールは、PHP 8.4.0 以降では <link xlink:href="&url.libxml;">libxml</link> &gt;=
+   2.9.4 が、PHP 8.4.0 より前のバージョンでは、libxml &gt;= 2.9.0 が、PHP 8.0.0 より前のバージョンでは libxml &gt;= 2.6.0 が必要です。
   </para>
  </section>
  <!-- }}} -->

--- a/reference/simplexml/functions/simplexml-import-dom.xml
+++ b/reference/simplexml/functions/simplexml-import-dom.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d715365c098db000eaf7dcd987ee6093f6e83091 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 62514381ff35348ffc4061b691132e36adf96210 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: shimooka -->
 <refentry xml:id="function.simplexml-import-dom" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>simplexml_import_dom</refname>
-  <refpurpose>DOM ノードから <literal>SimpleXMLElement</literal> オブジェクトを取得する</refpurpose>
+  <refpurpose>XML または HTML ノードから <literal>SimpleXMLElement</literal> オブジェクトを取得する</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -54,6 +54,38 @@
    <type>SimpleXMLElement</type> を返します。
    失敗時に &null; を返します。
   </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   非XMLまたは非HTMLの<parameter>node</parameter>が渡された場合、
+   <classname>TypeError</classname>をスローします。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       この関数は、非XMLまたは非HTMLの<parameter>node</parameter>が渡された場合、
+       <classname>ValueError</classname> ではなく
+       <classname>TypeError</classname> をスローするようになりました。
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/xml/constants.xml
+++ b/reference/xml/constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 5e9500ddad6dbc2f1b01d7da8b53379c8b7c386c Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 9acfa18973f304f8f2d531f28dd12b12c2b84f8b Maintainer: takagi Status: ready -->
 <appendix xml:id="xml.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
  &extension.constants;
@@ -255,6 +255,19 @@
    <listitem>
     <simpara>
      
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.xml-option-parse-huge">
+   <term>
+    <constant>XML_OPTION_PARSE_HUGE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     PHP 8.4.0 以降で利用可能です。
+     libxml2 &lt; 2.7.0 を利用している場合(例えは PHP 7.x)、
+     このオプションはデフォルトで有効となり、無効化できません。
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/xml/functions/xml-parser-get-option.xml
+++ b/reference/xml/functions/xml-parser-get-option.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9fb00a4cf8563ea56d53cb1f72e2856b68899646 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 9acfa18973f304f8f2d531f28dd12b12c2b84f8b Maintainer: hirokawa Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="function.xml-parser-get-option" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -37,6 +37,7 @@
      <listitem>
       <simpara>
        取得するオプション。<constant>XML_OPTION_CASE_FOLDING</constant>,
+       <constant>XML_OPTION_PARSE_HUGE</constant>,
        <constant>XML_OPTION_SKIP_TAGSTART</constant>, <constant>XML_OPTION_SKIP_WHITE</constant>
        あるいは <constant>XML_OPTION_TARGET_ENCODING</constant> が使用可能です。
        詳細は <function>xml_parser_set_option</function> を参照ください。

--- a/reference/xml/functions/xml-parser-set-option.xml
+++ b/reference/xml/functions/xml-parser-set-option.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9fb00a4cf8563ea56d53cb1f72e2856b68899646 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 9acfa18973f304f8f2d531f28dd12b12c2b84f8b Maintainer: hirokawa Status: ready -->
 <refentry xml:id="function.xml-parser-set-option" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>xml_parser_set_option</refname>
@@ -57,6 +57,16 @@
            <entry>
             XMLパーサの<link linkend="xml.case-folding">大文字変換
             </link> を有効にするかどうかを制御する。デフォルトで有効。
+           </entry>
+          </row>
+          <row>
+           <entry><constant>XML_OPTION_PARSE_HUGE</constant></entry>
+           <entry>bool</entry>
+           <entry>
+            10 MB を超えるドキュメントの解析を許可する。
+            この設定は DoS 攻撃に繋がる可能性があるため、
+            ドキュメントサイズに制限を設けている場合にのみ有効にすべきです。
+            libxml2 を使用している場合のみ利用可能です。
            </entry>
           </row>
           <row>
@@ -136,6 +146,12 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       <constant>XML_OPTION_PARSE_HUGE</constant> が追加されました。
+      </entry>
+     </row>
      <row>
       <entry>8.3.0</entry>
       <entry>

--- a/reference/xml/functions/xml-set-character-data-handler.xml
+++ b/reference/xml/functions/xml-set-character-data-handler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 5a14f904d231d294e2e5b4fb5d2fc4d2fd9eddee Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 9cd8eb0f11edb4e59fd22f723137bbb91d6ab64f Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa -->
 <refentry xml:id="function.xml-set-character-data-handler" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -76,7 +76,8 @@
      </row>
     </thead>
     <tbody>
-      &xml.changelog.parser-param;
+     &xml.changelog.handler-param;
+     &xml.changelog.parser-param;
     </tbody>
    </tgroup>
   </informaltable>

--- a/reference/xml/functions/xml-set-default-handler.xml
+++ b/reference/xml/functions/xml-set-default-handler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 5a14f904d231d294e2e5b4fb5d2fc4d2fd9eddee Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 9cd8eb0f11edb4e59fd22f723137bbb91d6ab64f Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa -->
 <refentry xml:id="function.xml-set-default-handler" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -76,7 +76,8 @@
      </row>
     </thead>
     <tbody>
-      &xml.changelog.parser-param;
+     &xml.changelog.handler-param;
+     &xml.changelog.parser-param;
     </tbody>
    </tgroup>
   </informaltable>

--- a/reference/xml/functions/xml-set-element-handler.xml
+++ b/reference/xml/functions/xml-set-element-handler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 5a14f904d231d294e2e5b4fb5d2fc4d2fd9eddee Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 9cd8eb0f11edb4e59fd22f723137bbb91d6ab64f Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa,mumumu -->
 <refentry xml:id="function.xml-set-element-handler" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -124,7 +124,8 @@
      </row>
     </thead>
     <tbody>
-      &xml.changelog.parser-param;
+     &xml.changelog.handler-param;
+     &xml.changelog.parser-param;
     </tbody>
    </tgroup>
   </informaltable>

--- a/reference/xml/functions/xml-set-end-namespace-decl-handler.xml
+++ b/reference/xml/functions/xml-set-end-namespace-decl-handler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 5a14f904d231d294e2e5b4fb5d2fc4d2fd9eddee Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 9cd8eb0f11edb4e59fd22f723137bbb91d6ab64f Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id='function.xml-set-end-namespace-decl-handler'>
  <refnamediv>
@@ -81,7 +81,8 @@
      </row>
     </thead>
     <tbody>
-      &xml.changelog.parser-param;
+     &xml.changelog.handler-param;
+     &xml.changelog.parser-param;
     </tbody>
    </tgroup>
   </informaltable>

--- a/reference/xml/functions/xml-set-external-entity-ref-handler.xml
+++ b/reference/xml/functions/xml-set-external-entity-ref-handler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 5a14f904d231d294e2e5b4fb5d2fc4d2fd9eddee Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 9cd8eb0f11edb4e59fd22f723137bbb91d6ab64f Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa,mumumu -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.xml-set-external-entity-ref-handler">
  <refnamediv>
@@ -113,32 +113,8 @@
      </row>
     </thead>
     <tbody>
-      &xml.changelog.parser-param;
-     <row>
-      <entry>7.3.0</entry>
-      <entry>
-       拡張モジュールが libxml を使ってビルドされた場合には、コールバック
-       <parameter>handler</parameter>
-       の戻り値が無視されることはなくなりました。
-       このバージョン以前はコールバックの戻り値が無視され、パースが止まりませんでした。 
-      </entry>
-     </row>
-    </tbody>
-   </tgroup>
-  </informaltable>
- </refsect1>
-
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <informaltable>
-   <tgroup cols="2">
-    <thead>
-     <row>
-      <entry>&Version;</entry>
-      <entry>&Description;</entry>
-     </row>
-    </thead>
-    <tbody>
+     &xml.changelog.handler-param;
+     &xml.changelog.parser-param;
      <row>
       <entry>7.3.0</entry>
       <entry>

--- a/reference/xml/functions/xml-set-notation-decl-handler.xml
+++ b/reference/xml/functions/xml-set-notation-decl-handler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 5a14f904d231d294e2e5b4fb5d2fc4d2fd9eddee Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 9cd8eb0f11edb4e59fd22f723137bbb91d6ab64f Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa -->
 <refentry xml:id="function.xml-set-notation-decl-handler" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -117,7 +117,8 @@
      </row>
     </thead>
     <tbody>
-      &xml.changelog.parser-param;
+     &xml.changelog.handler-param;
+     &xml.changelog.parser-param;
     </tbody>
    </tgroup>
   </informaltable>

--- a/reference/xml/functions/xml-set-object.xml
+++ b/reference/xml/functions/xml-set-object.xml
@@ -1,12 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 5a14f904d231d294e2e5b4fb5d2fc4d2fd9eddee Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 9cd8eb0f11edb4e59fd22f723137bbb91d6ab64f Maintainer: hirokawa Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="function.xml-set-object" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>xml_set_object</refname>
   <refpurpose>オブジェクト内部で XML パーサを使用する</refpurpose>
  </refnamediv>
+
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-4-0;
+ </refsynopsisdiv>
  
  <refsect1 role="description">
   &reftitle.description;
@@ -66,6 +70,13 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       この関数は非推奨になりました。
+       代わりに、<function>xml_set_</function> 関数に適切な <type>callable</type> を渡してください。
+      </entry>
+     </row>
       &xml.changelog.parser-param;
     </tbody>
    </tgroup>

--- a/reference/xml/functions/xml-set-processing-instruction-handler.xml
+++ b/reference/xml/functions/xml-set-processing-instruction-handler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 5a14f904d231d294e2e5b4fb5d2fc4d2fd9eddee Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 9cd8eb0f11edb4e59fd22f723137bbb91d6ab64f Maintainer: mumumu Status: ready -->
 <refentry xml:id="function.xml-set-processing-instruction-handler" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>xml_set_processing_instruction_handler</refname>
@@ -101,7 +101,8 @@ data
      </row>
     </thead>
     <tbody>
-      &xml.changelog.parser-param;
+     &xml.changelog.handler-param;
+     &xml.changelog.parser-param;
     </tbody>
    </tgroup>
   </informaltable>

--- a/reference/xml/functions/xml-set-start-namespace-decl-handler.xml
+++ b/reference/xml/functions/xml-set-start-namespace-decl-handler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 5a14f904d231d294e2e5b4fb5d2fc4d2fd9eddee Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 9cd8eb0f11edb4e59fd22f723137bbb91d6ab64f Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id='function.xml-set-start-namespace-decl-handler'>
  <refnamediv>
@@ -86,7 +86,8 @@
      </row>
     </thead>
     <tbody>
-      &xml.changelog.parser-param;
+     &xml.changelog.handler-param;
+     &xml.changelog.parser-param;
     </tbody>
    </tgroup>
   </informaltable>

--- a/reference/xml/functions/xml-set-unparsed-entity-decl-handler.xml
+++ b/reference/xml/functions/xml-set-unparsed-entity-decl-handler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 5a14f904d231d294e2e5b4fb5d2fc4d2fd9eddee Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 9cd8eb0f11edb4e59fd22f723137bbb91d6ab64f Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa -->
 <refentry xml:id="function.xml-set-unparsed-entity-decl-handler" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -129,7 +129,8 @@
      </row>
     </thead>
     <tbody>
-      &xml.changelog.parser-param;
+     &xml.changelog.handler-param;
+     &xml.changelog.parser-param;
     </tbody>
    </tgroup>
   </informaltable>

--- a/reference/xsl/xsltprocessor.xml
+++ b/reference/xsl/xsltprocessor.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 42432109c9926f3b475c415c9e892dd6a7ba06ec Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa,shimooka -->
 <reference xml:id="class.xsltprocessor" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>XSLTProcessor クラス</title>
@@ -27,6 +27,30 @@
      <classname>XSLTProcessor</classname>
     </ooclass>
 
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <type>bool</type>
+     <varname linkend="xsltprocessor.props.doxinclude">doXInclude</varname>
+     <initializer>&false;</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <type>bool</type>
+     <varname linkend="xsltprocessor.props.clonedocument">cloneDocument</varname>
+     <initializer>&false;</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <type>int</type>
+     <varname linkend="xsltprocessor.props.maxtemplatedepth">maxTemplateDepth</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <type>int</type>
+     <varname linkend="xsltprocessor.props.maxtemplatevars">maxTemplateVars</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.xsltprocessor')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='XSLTProcessor'])">
      <xi:fallback/>
@@ -35,7 +59,76 @@
 <!-- }}} -->
  
   </section>
- 
+
+  <section xml:id="xsltprocessor.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="xsltprocessor.props.doxinclude">
+     <term><varname>doXInclude</varname></term>
+     <listitem>
+      <simpara>
+       xIncludeを実行するかどうか。
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="xsltprocessor.props.clonedocument">
+     <term><varname>cloneDocument</varname></term>
+     <listitem>
+      <simpara>
+       ドキュメントのクローンに対して変換を実行するかどうか。
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="xsltprocessor.props.maxtemplatedepth">
+     <term><varname>maxTemplateDepth</varname></term>
+     <listitem>
+      <simpara>
+       テンプレートの最大再帰深度。
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="xsltprocessor.props.maxtemplatevars">
+     <term><varname>maxTemplateVars</varname></term>
+     <listitem>
+      <simpara>
+       テンプレート内の変数の最大数。
+      </simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        プロパティ <varname linkend="xsltprocessor.props.doxinclude">doXInclude</varname>
+        および <varname linkend="xsltprocessor.props.clonedocument">cloneDocument</varname>
+        を明示的に設定できるようになりました。
+       </entry>
+      </row>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        プロパティ <varname linkend="xsltprocessor.props.maxtemplatedepth">maxTemplateDepth</varname>
+        と <varname linkend="xsltprocessor.props.maxtemplatevars">maxTemplateVars</varname>
+        が追加されました。
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
  </partintro>
  
  &reference.xsl.entities.xsltprocessor;

--- a/reference/xsl/xsltprocessor/setparameter.xml
+++ b/reference/xsl/xsltprocessor/setparameter.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 07e6a4aaa2d28b6218a362b05e573fb13267358d Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 03817004058a9d8d847626ce6582342dd2645e48 Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="xsltprocessor.setparameter" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -71,6 +71,30 @@
    &return.success;
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+      パラメータの値に、シングルクォートとダブルクォートを同時に含められるようになりました。
+      PHP 8.4.0 より前のバージョンでは、警告が発生していました。
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>


### PR DESCRIPTION
翻訳元: 

* php/doc-en#3899
  * reference/xml/constants.xml
  * reference/xml/functions/xml-parser-get-option.xml
  * reference/xml/functions/xml-parser-set-option.xml
* php/doc-en#3900
  * reference/libxml/constants.xml
* php/doc-en#3906
  * reference/simplexml/functions/simplexml-import-dom.xml
* php/doc-en#4036: *PHP 8.4 外の修正*
  * reference/libxml/constants.xml
  * reference/libxml/functions/libxml-disable-entity-loader.xml
* php/doc-en#4038
  * reference/xsl/xsltprocessor/setparameter.xml
* php/doc-en#4041
  * reference/xsl/xsltprocessor.xml
* php/doc-en#4051
  * reference/libxml/functions/libxml-set-streams-context.xml
  * reference/libxml/setup.xml
* php/doc-en#4067
  * ~~language-snippets.ent~~: closed via #161
  * reference/xml/functions/xml-set-character-data-handler.xml
  * reference/xml/functions/xml-set-default-handler.xml
  * reference/xml/functions/xml-set-element-handler.xml
  * reference/xml/functions/xml-set-end-namespace-decl-handler.xml
  * reference/xml/functions/xml-set-external-entity-ref-handler.xml
  * reference/xml/functions/xml-set-notation-decl-handler.xml
  * reference/xml/functions/xml-set-object.xml
  * reference/xml/functions/xml-set-processing-instruction-handler.xml
  * reference/xml/functions/xml-set-start-namespace-decl-handler.xml
  * reference/xml/functions/xml-set-unparsed-entity-decl-handler.xml
