### PR TITLE
chore: マルチバイト関連の新規作成ページの原文リビジョンとクレジットを追加

### DIFF
--- a/reference/intl/grapheme/grapheme-str-split.xml
+++ b/reference/intl/grapheme/grapheme-str-split.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
+<!-- EN-Revision: 1b36e583dcc11bb7897f1e11f82020315c1afaaf Maintainer: youkidearitai Status: ready -->
+<!-- Credits: youkidearitai -->
+
 <refentry xml:id="function.grapheme-str-split" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>grapheme_str_split</refname>

--- a/reference/mbstring/functions/mb-lcfirst.xml
+++ b/reference/mbstring/functions/mb-lcfirst.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: d0e23f48165c79327727e3a51b8277104975e3ad Maintainer: youkidearitai Status: ready -->
+<!-- Credits: youkidearitai -->
+
 <refentry xml:id="function.mb-lcfirst" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mb_lcfirst</refname>

--- a/reference/mbstring/functions/mb-ltrim.xml
+++ b/reference/mbstring/functions/mb-ltrim.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: d0e23f48165c79327727e3a51b8277104975e3ad Maintainer: youkidearitai Status: ready -->
+<!-- Credits: youkidearitai -->
+
 <refentry xml:id="function.mb-ltrim" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mb_ltrim</refname>

--- a/reference/mbstring/functions/mb-rtrim.xml
+++ b/reference/mbstring/functions/mb-rtrim.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: d0e23f48165c79327727e3a51b8277104975e3ad Maintainer: youkidearitai Status: ready -->
+<!-- Credits: youkidearitai -->
+
 <refentry xml:id="function.mb-rtrim" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mb_rtrim</refname>

--- a/reference/mbstring/functions/mb-trim.xml
+++ b/reference/mbstring/functions/mb-trim.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: d0e23f48165c79327727e3a51b8277104975e3ad Maintainer: youkidearitai Status: ready -->
+<!-- Credits: youkidearitai -->
+
 <refentry xml:id="function.mb-trim" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mb_trim</refname>

--- a/reference/mbstring/functions/mb-ucfirst.xml
+++ b/reference/mbstring/functions/mb-ucfirst.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: d0e23f48165c79327727e3a51b8277104975e3ad Maintainer: youkidearitai Status: ready -->
+<!-- Credits: youkidearitai -->
+
 <refentry xml:id="function.mb-ucfirst" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>mb_ucfirst</refname>

--- a/translation.xml
+++ b/translation.xml
@@ -30,6 +30,7 @@
    <person name="Takashi Iwamoto" email="-" nick="iwamot" vcs="no" />
    <person name="Kenta Usami" email="tadsan@zonu.me" nick="zonuexe" vcs="no" />
    <person name="Kentaro Takeda" email="takeda@youmind.jp" nick="KentarouTakeda" vcs="yes" />
+   <person name="Yuya Hamada" email="youkidearitai@gmail.com" nick="youkidearitai" vcs="yes" />
   </translators>
 
   <work-in-progress>


### PR DESCRIPTION
PHP 8.4に向けてマルチバイト関連で新たに作成されたページへ:

* 英語版リビジョン番号を追加
* 各ページのクレジットに翻訳者を追加
* `translation.xml` へ翻訳者として新規追加

以上の対応を行いました。

---

@youkidearitai

各ファイルの冒頭に `EN-Revision` として翻訳元（doc-en）のリビジョン番号を明記しておくことで、どのファイルが上流で更新されたか一覧で表示できるようになります。

![revcheck](https://github.com/user-attachments/assets/77e6b58d-af03-456f-9704-e6cafc175277)

この追記を行ったのですが、その際に翻訳者のクレジットも明記する必要があります。てきめんさんのGitHubアカウント等を、php-src等での公開情報を参考に記載させて頂いたのですが問題ないでしょうか？ 確認をお願いします。

