### PR TITLE
fix: `array_slice()` 誤訳の修正

### DIFF
--- a/reference/array/functions/array-slice.xml
+++ b/reference/array/functions/array-slice.xml
@@ -63,7 +63,7 @@
       </para>
       <para>
        <parameter>length</parameter>
-       が指定され、負の場合、配列の末尾から連続する複数の要素が返されます。
+       が指定され、負の場合、配列の末尾からその数だけ要素を取り除いた配列が返されます。
       </para>
       <para>
        省略された場合、<parameter>offset</parameter>


### PR DESCRIPTION
closes #176