### PR TITLE
[PHP 8.4] SIGCKPTとSIGCKPTEXITの翻訳

### DIFF
--- a/reference/pcntl/constants.xml
+++ b/reference/pcntl/constants.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 3535c3901f9e31d75d2ef3c47b9f835c79f3757a Maintainer: hirokawa Status: ready -->
-<!-- CREDITS: takagi -->
+<!-- EN-Revision: 71fa455c5670ea4a3a3a0c60e34d906d1061a6c8 Maintainer: hirokawa Status: ready -->
+<!-- CREDITS: takagi,jdkfx -->
 <appendix xml:id="pcntl.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
  <para>
@@ -37,6 +37,36 @@
   <varlistentry xml:id="constant.wcontinued">
    <term>
     <constant>WCONTINUED</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.wexited">
+   <term>
+    <constant>WEXITED</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.wstopped">
+   <term>
+    <constant>WSTOPPED</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.wnowait">
+   <term>
+    <constant>WNOWAIT</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -1590,6 +1620,98 @@
    </term>
    <listitem>
     <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+ </variablelist>
+ <variablelist xml:id="pcntl.constants.waitid">
+ <title><literal>waitid</literal> (<literal>idtype</literal>) の最初の引数</title>
+  <varlistentry xml:id="constant.p-all">
+   <term>
+    <constant>P_ALL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     任意の子プロセスを選択します。
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.p-pid">
+   <term>
+    <constant>P_PID</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     プロセスIDで選択します。
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.p-pgid">
+   <term>
+    <constant>P_PGID</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     プロセスグループIDで選択します。
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.p-pidfd">
+   <term>
+    <constant>P_PIDFD</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     プロセスIDファイルディスクリプタで選択します。
+     この機能は Linux 専用で、 Linux カーネル 5.4 以降でサポートされています。
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.p-uid">
+   <term>
+    <constant>P_UID</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     実効ユーザーIDで選択します。この機能は NetBSD および FreeBSD でのみ使用できます。
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.p-gid">
+   <term>
+    <constant>P_GID</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     実効グループIDで選択します。この機能は NetBSD および FreeBSD でのみ使用できます。
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.p-sid">
+   <term>
+    <constant>P_SID</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     セッションIDで選択します。この機能は NetBSD および FreeBSD でのみ使用できます。
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.p-jailid">
+   <term>
+    <constant>P_JAILID</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     ジェイル識別子で選択します。この機能は FreeBSD 専用です。
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/pcntl/constants.xml
+++ b/reference/pcntl/constants.xml
@@ -530,6 +530,30 @@
     </simpara>
    </listitem>
   </varlistentry>
+    <varlistentry xml:id="constant.sigckpt">
+   <term>
+    <constant>SIGCKPT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     チェックポイントを作成または復元するための定数です。
+     この機能は PHP 8.4.0 以降で使用可能で、 DragonFlyBSD のみでサポートされています。
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.sigckptexit">
+   <term>
+    <constant>SIGCKPTEXIT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     チェックポイントを作成または復元し、その後プロセスを終了するための定数です。
+     この機能は PHP 8.4.0 以降で使用可能で、 DragonFlyBSD のみでサポートされています。
+    </simpara>
+   </listitem>
+  </varlistentry>
  </variablelist>
 
  <variablelist xml:id="pcntl.constants.si">

--- a/reference/pcntl/functions/pcntl-get-last-error.xml
+++ b/reference/pcntl/functions/pcntl-get-last-error.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: b608b323883ac77489a31f8a1aa406e17c202bcb Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4ac5624be0dc8484a333514b605150e73cad06b8 Maintainer: takagi Status: ready -->
 
 <refentry xml:id="function.pcntl-get-last-error" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,11 +15,9 @@
    <void />
   </methodsynopsis>
   <para>
-
+   直前に失敗した pcntl 関数によって設定されたエラー番号 (<literal>errno</literal>) を取得します。
+   エラー番号に関連付けられたシステムエラーメッセージは、 <function>pcntl_strerror</function> を使用して確認できます。
   </para>
-
-  &warn.undocumented.func;
-
  </refsect1>
 
  <refsect1 role="parameters">
@@ -30,8 +28,36 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   エラーコードを返します。
+   直前に失敗した pcntl 関数によって設定されたエラー番号 (<literal>errno</literal>) を返します。エラーが発生していない場合は、 0 を返します。
   </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><function>pcntl_get_last_error</function> の例</title>
+   <para>
+    この例では、存在しない子プロセスを待機しようと試みた後、対応するエラーメッセージを出力します。
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$pid = pcntl_wait($status);
+if ($pid === -1) {
+    $errno = pcntl_get_last_error();
+    $message = pcntl_strerror($errno);
+    fwrite(STDERR, 'pcntl_wait がエラー番号' . $errno
+           . 'で失敗しました: ' . $message . PHP_EOL);
+}
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+pcntl_wait がエラー番号 10 で失敗しました: 子プロセスが存在しません
+]]>
+   </screen>
+  </example>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/pcntl/functions/pcntl-get-last-error.xml
+++ b/reference/pcntl/functions/pcntl-get-last-error.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4ac5624be0dc8484a333514b605150e73cad06b8 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: b608b323883ac77489a31f8a1aa406e17c202bcb Maintainer: takagi Status: ready -->
 
 <refentry xml:id="function.pcntl-get-last-error" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,9 +15,11 @@
    <void />
   </methodsynopsis>
   <para>
-   直前に失敗した pcntl 関数によって設定されたエラー番号 (<literal>errno</literal>) を取得します。
-   エラー番号に関連付けられたシステムエラーメッセージは、 <function>pcntl_strerror</function> を使用して確認できます。
+
   </para>
+
+  &warn.undocumented.func;
+
  </refsect1>
 
  <refsect1 role="parameters">
@@ -28,36 +30,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   直前に失敗した pcntl 関数によって設定されたエラー番号 (<literal>errno</literal>) を返します。エラーが発生していない場合は、 0 を返します。
+   エラーコードを返します。
   </para>
- </refsect1>
-
- <refsect1 role="examples">
-  &reftitle.examples;
-  <example>
-   <title><function>pcntl_get_last_error</function> の例</title>
-   <para>
-    この例では、存在しない子プロセスを待機しようと試みた後、対応するエラーメッセージを出力します。
-   </para>
-   <programlisting role="php">
-<![CDATA[
-<?php
-$pid = pcntl_wait($status);
-if ($pid === -1) {
-    $errno = pcntl_get_last_error();
-    $message = pcntl_strerror($errno);
-    fwrite(STDERR, 'pcntl_wait がエラー番号' . $errno
-           . 'で失敗しました: ' . $message . PHP_EOL);
-}
-]]>
-   </programlisting>
-   &example.outputs.similar;
-   <screen>
-<![CDATA[
-pcntl_wait がエラー番号 10 で失敗しました: 子プロセスが存在しません
-]]>
-   </screen>
-  </example>
  </refsect1>
 
  <refsect1 role="seealso">


### PR DESCRIPTION
以下を取り込み
https://github.com/php/doc-en/pull/4073

また、`reference/pcntl/constants.xml`の翻訳が追いついていない部分を取り込んでいる