### PR TITLE
「定義済みの定数」全域インデントずれ修正・未追跡の未翻訳を反映

### DIFF
--- a/appendices/reserved.constants.core.xml
+++ b/appendices/reserved.constants.core.xml
@@ -2,801 +2,695 @@
 <!-- $Revision$ -->
 <!-- EN-Revision: b2fa00ca2e052f87785a7f8b296466edc4e55767 Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa,shimooka,mumumu -->
- <sect2 xml:id="reserved.constants.core" xmlns="http://docbook.org/ns/docbook">
-   <title>コアの定義済みの定数</title>
-   <simpara>
-    これらの定数は PHP のコアで定義済みの定数です。
-    PHP, Zend engine, SAPI モジュールも含みます。
-   </simpara>
-   <variablelist>
-    <varlistentry xml:id="constant.php-version">
-     <term>
-      <constant>PHP_VERSION</constant>
-      (<type>string</type>)
-     </term>
-     <listitem>
-      <simpara>
-       現在の PHP のバージョンを
-       "major.minor.release[extra]"
-       形式の文字列で表したもの。
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="constant.php-major-version">
-     <term>
-      <constant>PHP_MAJOR_VERSION</constant> 
-      (<type>int</type>)
-     </term>
-     <listitem>
-      <simpara>
-       現在の PHP のメジャーバージョンを整数値で表したもの
-       (たとえば、バージョンが "5.2.7-extra" の場合は int(5) となる)。
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="constant.php-minor-version">
-     <term>
-      <constant>PHP_MINOR_VERSION</constant> 
-      (<type>int</type>)
-     </term>
-     <listitem>
-      <simpara>
-       現在の PHP のマイナーバージョンを整数値で表したもの
-       (たとえば、バージョンが "5.2.7-extra" の場合は int(2) となる)。
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="constant.php-release-version">
-     <term>
-      <constant>PHP_RELEASE_VERSION</constant> 
-      (<type>int</type>)
-     </term>
-     <listitem>
-      <simpara>
-       現在の PHP のリリースバージョンを整数値で表したもの
-       (たとえば、バージョンが "5.2.7-extra" の場合は int(7) となる)。
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="constant.php-version-id">
-     <term>
-      <constant>PHP_VERSION_ID</constant> 
-      (<type>int</type>)
-     </term>
-     <listitem>
-      <simpara>
-       現在の PHP のバージョンを整数値で表したもの。バージョンを比較する際に有用
-       (たとえば、バージョンが "5.2.7-extra" の場合は int(50207) となる)。
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="constant.php-extra-version">
-     <term>
-      <constant>PHP_EXTRA_VERSION</constant> 
-      (<type>string</type>)
-     </term>
-     <listitem>
-      <simpara>
-       現在の PHP の追加バージョンを文字列で表したもの
-       (たとえば、バージョンが "5.2.7-extra" の場合は '-extra' となる)。
-       ディストリビューションのベンダーが、パッケージのバージョンを示すために使うことが多い。
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="constant.zend-thread-safe">
-     <term>
-      <constant>ZEND_THREAD_SAFE</constant>
-      (<type>bool</type>)
-     </term>
-     <listitem>
-      <simpara>
-       PHP の現状のビルドが、スレッドセーフ版であるかどうかを示す。
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="constant.zend-debug-build">
-     <term>
-      <constant>ZEND_DEBUG_BUILD</constant>
-      (<type>bool</type>)
-     </term>
-     <listitem>
-      <simpara>
-       PHP の現状のビルドが、デバッグビルド版であるかどうかを示す。
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="constant.php-zts">
-     <term>
-      <constant>PHP_ZTS</constant> 
-      (<type>bool</type>)
-      <constant>ZEND_THREAD_SAFE</constant> &Alias;
-     </term>
-     <listitem>
-      <simpara>
-       PHP の現状のビルドが、スレッドセーフ版であるかどうかを示す。
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="constant.php-debug">
-     <term>
-      <constant>PHP_DEBUG</constant>
-      (<type>bool</type>)
-      <constant>ZEND_DEBUG_BUILD</constant> &Alias;
-     </term>
-     <listitem>
-      <simpara>
-       PHP の現状のビルドが、デバッグビルド版であるかどうかを示す。
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="constant.debug-backtrace-provide-object">
-     <term>
-      <constant>DEBUG_BACKTRACE_PROVIDE_OBJECT</constant>
-      (<type>int</type>)
-     </term>
-     <listitem>
-      <simpara>
-       "object" のインデックスを収集します。
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="constant.debug-backtrace-ignore-args">
-     <term>
-      <constant>DEBUG_BACKTRACE_IGNORE_ARGS</constant>
-      (<type>int</type>)
-     </term>
-     <listitem>
-      <simpara>
-       スタックトレース中の関数の情報に、引数の情報を含めません。
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="constant.php-maxpathlen">
-     <term>
-      <constant>PHP_MAXPATHLEN</constant> 
-      (<type>int</type>)
-     </term>
-     <listitem>
-      <simpara>
-       この PHP がサポートする、ファイル名の長さ (パスを含む) の最大値。
-       PHP 5.3.0 以降で利用可能。
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="constant.php-os">
-     <term>
-      <constant>PHP_OS</constant>
-      (<type>string</type>)
-     </term>
-     <listitem>
-      <simpara>
-       PHP がビルドされた OS。
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="constant.php-os-family">
-     <term>
-      <constant>PHP_OS_FAMILY</constant> 
-      (<type>string</type>)
-     </term>
-     <listitem>
-      <simpara>
-       PHP がビルドされたオペレーティングシステムファミリー。
-       以下のうちひとつです。
-       <literal>'Windows'</literal>, <literal>'BSD'</literal>,
-       <literal>'Darwin'</literal>, <literal>'Solaris'</literal>,
-       <literal>'Linux'</literal> or <literal>'Unknown'</literal>.
-       PHP 7.2.0 以降で利用可能。
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="constant.php-sapi">
-     <term>
-      <constant>PHP_SAPI</constant> 
-      (<type>string</type>)
-     </term>
-     <listitem>
-      <simpara>
-       この PHP のサーバー API。
-       <function>php_sapi_name</function> も参照ください。
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="constant.php-eol">
-     <term>
-      <constant>PHP_EOL</constant>
-      (<type>string</type>)
-     </term>
-     <listitem>
-      <simpara>
-       このプラットフォームの行末文字。
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="constant.php-int-max">
-     <term>
-      <constant>PHP_INT_MAX</constant>
-      (<type>int</type>)
-     </term>
-     <listitem>
-      <simpara>
-       この PHP がサポートする整数型の最大値。32bit のシステムでは 通常は int(2147483647)。
-       64bit のシステムでは、int(9223372036854775807)。
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="constant.php-int-min">
-     <term>
-      <constant>PHP_INT_MIN</constant> 
-      (<type>int</type>)
-     </term>
-     <listitem>
-      <simpara>
-       この PHP がサポートする整数型の最小値。通常は、32ビットシステムなら int(-2147483648)、
-       64ビットシステムなら int(-9223372036854775808)。
-       通常は PHP_INT_MIN === ~PHP_INT_MAX となる。
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="constant.php-int-size">
-     <term>
-      <constant>PHP_INT_SIZE</constant>
-      (<type>int</type>)
-     </term>
-     <listitem>
-      <simpara>
-       この PHP ビルドにおける整数型のサイズ (バイト数)。
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="constant.php-float-dig">
-     <term>
-      <constant>PHP_FLOAT_DIG</constant> 
-      (<type>int</type>)
-     </term>
-     <listitem>
-      <simpara>
-       float への丸めやその逆操作の際に精度を維持できる数値の桁数。
-       PHP 7.2.0 以降で利用可能。
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="constant.php-float-epsilon">
-     <term>
-      <constant>PHP_FLOAT_EPSILON</constant> 
-      (<type>float</type>)
-     </term>
-     <listitem>
-      <simpara>
-       <literal>x + 1.0 != 1.0</literal> となる正の数 x のうちで、浮動小数点数値として表せる最小の数。
-       PHP 7.2.0 以降で利用可能。
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="constant.php-float-min">
-     <term>
-      <constant>PHP_FLOAT_MIN</constant> 
-      (<type>float</type>)
-     </term>
-     <listitem>
-      <simpara>
-       <emphasis>正</emphasis> の浮動小数点数値として表せる最小の数。
-       浮動小数点数値として表せる <emphasis>負の</emphasis> 最小値が必要なら、<literal>- PHP_FLOAT_MAX</literal> を使って下さい。
-       PHP 7.2.0 以降で利用可能。
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="constant.php-float-max">
-     <term>
-      <constant>PHP_FLOAT_MAX</constant> 
-      (<type>float</type>)
-     </term>
-     <listitem>
-      <simpara>
-       浮動小数点数値として表せる最大の数。
-       PHP 7.2.0 以降で利用可能。
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="constant.default-include-path">
-     <term>
-      <constant>DEFAULT_INCLUDE_PATH</constant>
-      (<type>string</type>)
-     </term>
-     <listitem>
-      <simpara>
+<sect2 xml:id="reserved.constants.core" xmlns="http://docbook.org/ns/docbook">
+ <title>コアの定義済みの定数</title>
+ <simpara>
+  これらの定数は PHP のコアで定義済みの定数です。
+  PHP, Zend engine, SAPI モジュールも含みます。
+ </simpara>
+ <variablelist>
+  <varlistentry xml:id="constant.php-version">
+   <term>
+    <constant>PHP_VERSION</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+     現在の PHP のバージョンを
+     "major.minor.release[extra]"
+     形式の文字列で表したもの。
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-major-version">
+   <term>
+    <constant>PHP_MAJOR_VERSION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     現在の PHP のメジャーバージョンを整数値で表したもの
+     (たとえば、バージョンが "5.2.7-extra" の場合は int(5) となる)。
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-minor-version">
+   <term>
+    <constant>PHP_MINOR_VERSION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     現在の PHP のマイナーバージョンを整数値で表したもの
+     (たとえば、バージョンが "5.2.7-extra" の場合は int(2) となる)。
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-release-version">
+   <term>
+    <constant>PHP_RELEASE_VERSION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     現在の PHP のリリースバージョンを整数値で表したもの
+     (たとえば、バージョンが "5.2.7-extra" の場合は int(7) となる)。
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-version-id">
+   <term>
+    <constant>PHP_VERSION_ID</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     現在の PHP のバージョンを整数値で表したもの。バージョンを比較する際に有用
+     (たとえば、バージョンが "5.2.7-extra" の場合は int(50207) となる)。
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-extra-version">
+   <term>
+    <constant>PHP_EXTRA_VERSION</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+     現在の PHP の追加バージョンを文字列で表したもの
+     (たとえば、バージョンが "5.2.7-extra" の場合は '-extra' となる)。
+     ディストリビューションのベンダーが、パッケージのバージョンを示すために使うことが多い。
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.zend-thread-safe">
+   <term>
+    <constant>ZEND_THREAD_SAFE</constant>
+    (<type>bool</type>)
+   </term>
+   <listitem>
+    <simpara>
+     PHP の現状のビルドが、スレッドセーフ版であるかどうかを示す。
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.zend-debug-build">
+   <term>
+    <constant>ZEND_DEBUG_BUILD</constant>
+    (<type>bool</type>)
+   </term>
+   <listitem>
+    <simpara>
+     PHP の現状のビルドが、デバッグビルド版であるかどうかを示す。
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-zts">
+   <term>
+    <constant>PHP_ZTS</constant>
+    (<type>bool</type>)
+    <constant>ZEND_THREAD_SAFE</constant> &Alias;
+   </term>
+   <listitem>
+    <simpara>
+     PHP の現状のビルドが、スレッドセーフ版であるかどうかを示す。
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-debug">
+   <term>
+    <constant>PHP_DEBUG</constant>
+    (<type>bool</type>)
+    <constant>ZEND_DEBUG_BUILD</constant> &Alias;
+   </term>
+   <listitem>
+    <simpara>
+     PHP の現状のビルドが、デバッグビルド版であるかどうかを示す。
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.debug-backtrace-provide-object">
+   <term>
+    <constant>DEBUG_BACKTRACE_PROVIDE_OBJECT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     "object" のインデックスを収集します。
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.debug-backtrace-ignore-args">
+   <term>
+    <constant>DEBUG_BACKTRACE_IGNORE_ARGS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     スタックトレース中の関数の情報に、引数の情報を含めません。
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-maxpathlen">
+   <term>
+    <constant>PHP_MAXPATHLEN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     この PHP がサポートする、ファイル名の長さ (パスを含む) の最大値。
+     PHP 5.3.0 以降で利用可能。
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-os">
+   <term>
+    <constant>PHP_OS</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+     PHP がビルドされた OS。
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-os-family">
+   <term>
+    <constant>PHP_OS_FAMILY</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+     PHP がビルドされたオペレーティングシステムファミリー。
+     以下のうちひとつです。
+     <literal>'Windows'</literal>, <literal>'BSD'</literal>,
+     <literal>'Darwin'</literal>, <literal>'Solaris'</literal>,
+     <literal>'Linux'</literal> or <literal>'Unknown'</literal>.
+     PHP 7.2.0 以降で利用可能。
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-sapi">
+   <term>
+    <constant>PHP_SAPI</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+     この PHP のサーバー API。
+     <function>php_sapi_name</function> も参照ください。
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-eol">
+   <term>
+    <constant>PHP_EOL</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+     このプラットフォームの行末文字。
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-int-max">
+   <term>
+    <constant>PHP_INT_MAX</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     この PHP がサポートする整数型の最大値。32bit のシステムでは 通常は int(2147483647)。
+     64bit のシステムでは、int(9223372036854775807)。
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-int-min">
+   <term>
+    <constant>PHP_INT_MIN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     この PHP がサポートする整数型の最小値。通常は、32ビットシステムなら int(-2147483648)、
+     64ビットシステムなら int(-9223372036854775808)。
+     通常は PHP_INT_MIN === ~PHP_INT_MAX となる。
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-int-size">
+   <term>
+    <constant>PHP_INT_SIZE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     この PHP ビルドにおける整数型のサイズ (バイト数)。
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-float-dig">
+   <term>
+    <constant>PHP_FLOAT_DIG</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     float への丸めやその逆操作の際に精度を維持できる数値の桁数。
+     PHP 7.2.0 以降で利用可能。
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-float-epsilon">
+   <term>
+    <constant>PHP_FLOAT_EPSILON</constant>
+    (<type>float</type>)
+   </term>
+   <listitem>
+    <simpara>
+     <literal>x + 1.0 != 1.0</literal> となる正の数 x のうちで、浮動小数点数値として表せる最小の数。
+     PHP 7.2.0 以降で利用可能。
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-float-min">
+   <term>
+    <constant>PHP_FLOAT_MIN</constant>
+    (<type>float</type>)
+   </term>
+   <listitem>
+    <simpara>
+     <emphasis>正</emphasis> の浮動小数点数値として表せる最小の数。
+     浮動小数点数値として表せる <emphasis>負の</emphasis> 最小値が必要なら、<literal>- PHP_FLOAT_MAX</literal> を使って下さい。
+     PHP 7.2.0 以降で利用可能。
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-float-max">
+   <term>
+    <constant>PHP_FLOAT_MAX</constant>
+    (<type>float</type>)
+   </term>
+   <listitem>
+    <simpara>
+     浮動小数点数値として表せる最大の数。
+     PHP 7.2.0 以降で利用可能。
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.default-include-path">
+   <term>
+    <constant>DEFAULT_INCLUDE_PATH</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
 
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="constant.pear-install-dir">
-     <term>
-      <constant>PEAR_INSTALL_DIR</constant>
-      (<type>string</type>)
-     </term>
-     <listitem>
-      <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.pear-install-dir">
+   <term>
+    <constant>PEAR_INSTALL_DIR</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
 
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="constant.pear-extension-dir">
-     <term>
-      <constant>PEAR_EXTENSION_DIR</constant>
-      (<type>string</type>)
-     </term>
-     <listitem>
-      <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.pear-extension-dir">
+   <term>
+    <constant>PEAR_EXTENSION_DIR</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
 
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="constant.php-extension-dir">
-     <term>
-      <constant>PHP_EXTENSION_DIR</constant>
-      (<type>string</type>)
-     </term>
-     <listitem>
-      <simpara>
-       動的にロード可能な拡張モジュールを探すデフォルトのディレクトリ。
-       (但し、<link linkend="ini.extension-dir">extension_dir</link> で上書きされた場合を除きます)
-       デフォルトは <constant>PHP_PREFIX</constant> です。
-       (Windows では、 <code>PHP_PREFIX . "\\ext"</code> です。)
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="constant.php-prefix">
-     <term>
-      <constant>PHP_PREFIX</constant> 
-      (<type>string</type>)
-     </term>
-     <listitem>
-      <simpara>
-       configure 時に設定された <option role="configure">--prefix</option> の値。
-       Windows の場合、configure 時に設定された
-       <option role="configure">--with-prefix</option> の値になります。
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="constant.php-bindir">
-     <term>
-      <constant>PHP_BINDIR</constant>
-      (<type>string</type>)
-     </term>
-     <listitem>
-      <simpara>
-       configure 時に設定された <option role="configure">--bindir</option> の値。
-       Windows の場合、configure 時に設定された
-       <option role="configure">--with-prefix</option> の値になります。
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="constant.php-sbindir">
-     <term>
-      <constant>PHP_SBINDIR</constant>
-      (<type>string</type>)
-     </term>
-     <listitem>
-      <simpara>
-       configure 時に設定された <option role="configure">--sbindir</option> の値。
-       PHP 8.4.0から、Windows の場合、configure 時に設定された
-       <option role="configure">--with-prefix</option> の値になります。
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="constant.php-binary">
-     <term>
-      <constant>PHP_BINARY</constant> 
-      (<type>string</type>)
-     </term>
-     <listitem>
-      <simpara>
-       スクリプト実行時の PHP バイナリのパス。
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="constant.php-mandir">
-     <term>
-      <constant>PHP_MANDIR</constant> 
-      (<type>string</type>)
-     </term>
-     <listitem>
-      <simpara>
-       man ページのインストール先。
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="constant.php-libdir">
-     <term>
-      <constant>PHP_LIBDIR</constant>
-      (<type>string</type>)
-     </term>
-     <listitem>
-      <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-extension-dir">
+   <term>
+    <constant>PHP_EXTENSION_DIR</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+     動的にロード可能な拡張モジュールを探すデフォルトのディレクトリ。
+     (但し、<link linkend="ini.extension-dir">extension_dir</link> で上書きされた場合を除きます)
+     デフォルトは <constant>PHP_PREFIX</constant> です。
+     (Windows では、 <code>PHP_PREFIX . "\\ext"</code> です。)
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-prefix">
+   <term>
+    <constant>PHP_PREFIX</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+     configure 時に設定された <option role="configure">--prefix</option> の値。
+     Windows の場合、configure 時に設定された
+     <option role="configure">--with-prefix</option> の値になります。
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-bindir">
+   <term>
+    <constant>PHP_BINDIR</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+     configure 時に設定された <option role="configure">--bindir</option> の値。
+     Windows の場合、configure 時に設定された
+     <option role="configure">--with-prefix</option> の値になります。
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-sbindir">
+   <term>
+    <constant>PHP_SBINDIR</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+     configure 時に設定された <option role="configure">--sbindir</option> の値。
+     PHP 8.4.0から、Windows の場合、configure 時に設定された
+     <option role="configure">--with-prefix</option> の値になります。
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-binary">
+   <term>
+    <constant>PHP_BINARY</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+     スクリプト実行時の PHP バイナリのパス。
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-mandir">
+   <term>
+    <constant>PHP_MANDIR</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+     man ページのインストール先。
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-libdir">
+   <term>
+    <constant>PHP_LIBDIR</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
 
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="constant.php-datadir">
-     <term>
-      <constant>PHP_DATADIR</constant>
-      (<type>string</type>)
-     </term>
-     <listitem>
-      <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-datadir">
+   <term>
+    <constant>PHP_DATADIR</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
 
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="constant.php-sysconfdir">
-     <term>
-      <constant>PHP_SYSCONFDIR</constant>
-      (<type>string</type>)
-     </term>
-     <listitem>
-      <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-sysconfdir">
+   <term>
+    <constant>PHP_SYSCONFDIR</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
 
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="constant.php-localstatedir">
-     <term>
-      <constant>PHP_LOCALSTATEDIR</constant>
-      (<type>string</type>)
-     </term>
-     <listitem>
-      <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-localstatedir">
+   <term>
+    <constant>PHP_LOCALSTATEDIR</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
 
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="constant.php-config-file-path">
-     <term>
-      <constant>PHP_CONFIG_FILE_PATH</constant>
-      (<type>string</type>)
-     </term>
-     <listitem>
-      <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-config-file-path">
+   <term>
+    <constant>PHP_CONFIG_FILE_PATH</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
 
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="constant.php-config-file-scan-dir">
-     <term>
-      <constant>PHP_CONFIG_FILE_SCAN_DIR</constant> 
-      (<type>string</type>)
-     </term>
-     <listitem>
-      <simpara>
-       
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="constant.php-shlib-suffix">
-     <term>
-      <constant>PHP_SHLIB_SUFFIX</constant> 
-      (<type>string</type>)
-     </term>
-     <listitem>
-      <simpara>
-       このプラットフォームの共有ライブラリの拡張子。"so" (多くの Unix 系 OS)
-       や "dll" (Windows) など。
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="constant.php-fd-setsize">
-     <term>
-      <constant>PHP_FD_SETSIZE</constant>
-      (<type>int</type>)
-     </term>
-     <listitem>
-      <simpara>
-       select システムコール用のファイルディスクリプタの最大数。
-       PHP 7.1.0 以降で使用可能です。
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>
-      <constant>E_ERROR</constant> 
-      (<type>int</type>)
-     </term>
-     <listitem>
-      <simpara>
-       <link linkend="errorfunc.constants">エラーを報告する定数</link>
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>
-      <constant>E_WARNING</constant> 
-      (<type>int</type>)
-     </term>
-     <listitem>
-      <simpara>
-       <link linkend="errorfunc.constants">エラーを報告する定数</link>
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>
-      <constant>E_PARSE</constant> 
-      (<type>int</type>)
-     </term>
-     <listitem>
-      <simpara>
-       <link linkend="errorfunc.constants">エラーを報告する定数</link>
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>
-      <constant>E_NOTICE</constant> 
-      (<type>int</type>)
-     </term>
-     <listitem>
-      <simpara>
-       <link linkend="errorfunc.constants">エラーを報告する定数</link>
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>
-      <constant>E_CORE_ERROR</constant> 
-      (<type>int</type>)
-     </term>
-     <listitem>
-      <simpara>
-       <link linkend="errorfunc.constants">エラーを報告する定数</link>
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>
-      <constant>E_CORE_WARNING</constant> 
-      (<type>int</type>)
-     </term>
-     <listitem>
-      <simpara>
-       <link linkend="errorfunc.constants">エラーを報告する定数</link>
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>
-      <constant>E_COMPILE_ERROR</constant> 
-      (<type>int</type>)
-     </term>
-     <listitem>
-      <simpara>
-       <link linkend="errorfunc.constants">エラーを報告する定数</link>
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>
-      <constant>E_COMPILE_WARNING</constant> 
-      (<type>int</type>)
-     </term>
-     <listitem>
-      <simpara>
-       <link linkend="errorfunc.constants">エラーを報告する定数</link>
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>
-      <constant>E_USER_ERROR</constant> 
-      (<type>int</type>)
-     </term>
-     <listitem>
-      <simpara>
-       <link linkend="errorfunc.constants">エラーを報告する定数</link>
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>
-      <constant>E_USER_WARNING</constant> 
-      (<type>int</type>)
-     </term>
-     <listitem>
-      <simpara>
-       <link linkend="errorfunc.constants">エラーを報告する定数</link>
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>
-      <constant>E_USER_NOTICE</constant> 
-      (<type>int</type>)
-     </term>
-     <listitem>
-      <simpara>
-       
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>
-      <constant>E_RECOVERABLE_ERROR</constant> 
-      (<type>int</type>)
-     </term>
-     <listitem>
-      <simpara>
-       <link linkend="errorfunc.constants">エラーを報告する定数</link>
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>
-      <constant>E_DEPRECATED</constant> 
-      (<type>int</type>)
-     </term>
-     <listitem>
-      <simpara>
-       <link linkend="errorfunc.constants">エラーを報告する定数</link>
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>
-      <constant>E_USER_DEPRECATED</constant> 
-      (<type>int</type>)
-     </term>
-     <listitem>
-      <simpara>
-       <link linkend="errorfunc.constants">エラーを報告する定数</link>
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>
-      <constant>E_ALL</constant>
-      (<type>int</type>)
-     </term>
-     <listitem>
-      <simpara>
-       <link linkend="errorfunc.constants">エラーを報告する定数</link>
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>
-      <constant>E_STRICT</constant>
-      (<type>int</type>)
-     </term>
-     <listitem>
-      <simpara>
-       <link linkend="errorfunc.constants">エラーを報告する定数</link>
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>
-      <constant>__COMPILER_HALT_OFFSET__</constant>
-      (<type>int</type>)
-     </term>
-     <listitem>
-      <simpara>
-      
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="constant.true">
-     <term>
-      &true;
-      (<type>bool</type>)
-     </term>
-     <listitem>
-      <simpara>
-       <link linkend="language.types.boolean">Booleans</link> も参照ください。
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="constant.false">
-     <term>
-      &false;
-      (<type>bool</type>)
-     </term>
-     <listitem>
-      <simpara>
-       <link linkend="language.types.boolean">Booleans</link> も参照ください。
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="constant.null">
-     <term>
-      &null;
-      (<type>null</type>)
-     </term>
-     <listitem>
-      <simpara>
-       <link linkend="language.types.null">Null</link> も参照ください。
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="constant.php-windows-event-ctrl-c">
-     <term>
-      <constant>PHP_WINDOWS_EVENT_CTRL_C</constant>
-      (<type>int</type>)
-     </term>
-     <listitem>
-      <simpara>
-       Windows の <literal>CTRL+C</literal> イベント。
-       PHP 7.4.0 から利用可能です。(Windows のみ)
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="constant.php-windows-event-ctrl-break">
-     <term>
-      <constant>PHP_WINDOWS_EVENT_CTRL_BREAK</constant>
-      (<type>int</type>)
-     </term>
-     <listitem>
-      <simpara>
-       Windows の <literal>CTRL+BREAK</literal> イベント。
-       PHP 7.4.0 から利用可能です。(Windows のみ)
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="constant.php-cli-process-title">
-     <term>
-      <constant>PHP_CLI_PROCESS_TITLE</constant>
-      (<type>bool</type>)
-     </term>
-     <listitem>
-      <simpara>
-       プロセスのタイトルを設定/取得できるかどうかを示します。
-       CLI SAPI でのみ利用可能です。
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="constant.stderr">
-     <term>
-      <constant>STDERR</constant>
-      (<type>resource</type>)
-     </term>
-     <listitem>
-      <simpara>
-       <literal>stderr</literal> に対して、
-       既にオープンされているストリーム。
-       CLI SAPI でのみ利用可能です。
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="constant.stdin">
-     <term>
-      <constant>STDIN</constant>
-      (<type>resource</type>)
-     </term>
-     <listitem>
-      <simpara>
-       <literal>stdin</literal> に対して、
-       既にオープンされているストリーム。
-       CLI SAPI でのみ利用可能です。
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="constant.stdout">
-     <term>
-      <constant>STDOUT</constant>
-      (<type>resource</type>)
-     </term>
-     <listitem>
-      <simpara>
-       <literal>stdout</literal> に対して、
-       既にオープンされているストリーム。
-       CLI SAPI でのみ利用可能です。
-      </simpara>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-   <para>
-    <link linkend="language.constants.magic">マジック定数</link> も参照ください。
-   </para>
- </sect2>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-config-file-scan-dir">
+   <term>
+    <constant>PHP_CONFIG_FILE_SCAN_DIR</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
 
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-shlib-suffix">
+   <term>
+    <constant>PHP_SHLIB_SUFFIX</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+     このプラットフォームの共有ライブラリの拡張子。"so" (多くの Unix 系 OS)
+     や "dll" (Windows) など。
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-fd-setsize">
+   <term>
+    <constant>PHP_FD_SETSIZE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     select システムコール用のファイルディスクリプタの最大数。
+     PHP 7.1.0 以降で使用可能です。
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry>
+   <term>
+    <constant>E_ERROR</constant>
+    (<type>int</type>)
+   </term>
+   <term>
+    <constant>E_WARNING</constant>
+    (<type>int</type>)
+   </term>
+   <term>
+    <constant>E_PARSE</constant>
+    (<type>int</type>)
+   </term>
+   <term>
+    <constant>E_NOTICE</constant>
+    (<type>int</type>)
+   </term>
+   <term>
+    <constant>E_CORE_ERROR</constant>
+    (<type>int</type>)
+   </term>
+   <term>
+    <constant>E_CORE_WARNING</constant>
+    (<type>int</type>)
+   </term>
+   <term>
+    <constant>E_COMPILE_ERROR</constant>
+    (<type>int</type>)
+   </term>
+   <term>
+    <constant>E_COMPILE_WARNING</constant>
+    (<type>int</type>)
+   </term>
+   <term>
+    <constant>E_USER_ERROR</constant>
+    (<type>int</type>)
+   </term>
+   <term>
+    <constant>E_USER_WARNING</constant>
+    (<type>int</type>)
+   </term>
+   <term>
+    <constant>E_USER_NOTICE</constant>
+    (<type>int</type>)
+   </term>
+   <term>
+    <constant>E_RECOVERABLE_ERROR</constant>
+    (<type>int</type>)
+   </term>
+   <term>
+    <constant>E_DEPRECATED</constant>
+    (<type>int</type>)
+   </term>
+   <term>
+    <constant>E_USER_DEPRECATED</constant>
+    (<type>int</type>)
+   </term>
+   <term>
+    <constant>E_ALL</constant>
+    (<type>int</type>)
+   </term>
+   <term>
+    <constant>E_STRICT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     <link linkend="errorfunc.constants">エラーを報告する定数</link>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry>
+   <term>
+    <constant>__COMPILER_HALT_OFFSET__</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.true">
+   <term>
+    &true;
+    (<type>bool</type>)
+   </term>
+   <listitem>
+    <simpara>
+     <link linkend="language.types.boolean">Booleans</link> も参照ください。
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.false">
+   <term>
+    &false;
+    (<type>bool</type>)
+   </term>
+   <listitem>
+    <simpara>
+     <link linkend="language.types.boolean">Booleans</link> も参照ください。
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.null">
+   <term>
+    &null;
+    (<type>null</type>)
+   </term>
+   <listitem>
+    <simpara>
+     <link linkend="language.types.null">Null</link> も参照ください。
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-windows-event-ctrl-c">
+   <term>
+    <constant>PHP_WINDOWS_EVENT_CTRL_C</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+      Windows の <literal>CTRL+C</literal> イベント。
+      PHP 7.4.0 から利用可能です。(Windows のみ)
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-windows-event-ctrl-break">
+   <term>
+    <constant>PHP_WINDOWS_EVENT_CTRL_BREAK</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Windows の <literal>CTRL+BREAK</literal> イベント。
+     PHP 7.4.0 から利用可能です。(Windows のみ)
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-cli-process-title">
+   <term>
+    <constant>PHP_CLI_PROCESS_TITLE</constant>
+    (<type>bool</type>)
+   </term>
+   <listitem>
+    <simpara>
+     プロセスのタイトルを設定/取得できるかどうかを示します。
+     CLI SAPI でのみ利用可能です。
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.stderr">
+   <term>
+    <constant>STDERR</constant>
+    (<type>resource</type>)
+   </term>
+   <listitem>
+    <simpara>
+     <literal>stderr</literal> に対して、
+     既にオープンされているストリーム。
+     CLI SAPI でのみ利用可能です。
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.stdin">
+   <term>
+    <constant>STDIN</constant>
+    (<type>resource</type>)
+   </term>
+   <listitem>
+    <simpara>
+     <literal>stdin</literal> に対して、
+     既にオープンされているストリーム。
+     CLI SAPI でのみ利用可能です。
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.stdout">
+   <term>
+    <constant>STDOUT</constant>
+    (<type>resource</type>)
+   </term>
+   <listitem>
+    <simpara>
+     <literal>stdout</literal> に対して、
+     既にオープンされているストリーム。
+     CLI SAPI でのみ利用可能です。
+    </simpara>
+   </listitem>
+  </varlistentry>
+ </variablelist>
+ <para>
+  <link linkend="language.constants.magic">マジック定数</link> も参照ください。
+ </para>
+</sect2>
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml


### PR DESCRIPTION
1. ファイル全域に渡りインデント崩れがあり全行で原文との差分
   原文を正としインデントを修正
2. `E_*` 定数の反映漏れ
   ![定義済定数修正](https://github.com/user-attachments/assets/c7fa9182-ea74-4ea7-b2f4-676548555a83)
