### PR TITLE
[PHP 8.4] fix php/doc-en#4122 (PHP 8.4: Flushing headers without a body will now succeed)

### DIFF
--- a/reference/outcontrol/functions/flush.xml
+++ b/reference/outcontrol/functions/flush.xml
@@ -56,6 +56,28 @@
    &return.void;
   </para>
  </refsect1>
+ 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Flushing headers without a body will now succeed in FastCGI.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/outcontrol/functions/flush.xml
+++ b/reference/outcontrol/functions/flush.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 91ab4f5f898023b0eed0e642e1482ac11f749d20 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: bac9d6a54fae363b3cc337bda924a76ff47e8851 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: shimooka -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.flush">
  <refnamediv>

--- a/reference/outcontrol/functions/flush.xml
+++ b/reference/outcontrol/functions/flush.xml
@@ -71,7 +71,7 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Flushing headers without a body will now succeed in FastCGI.
+       FastCGI 利用時に、本文なしでヘッダをフラッシュできるようになりました。
       </entry>
      </row>
     </tbody>


### PR DESCRIPTION
## Issue
元ネタ: php/doc-en#4122
ref: #150

該当ファイルの最新コミットが、このマージコミットになっているので
そのまま4122のFile Changedとの対応をとればOK

![image](https://github.com/user-attachments/assets/2671ff29-1df9-4767-a47b-cc0549277aa9)

翻訳の内容は、 appendices/migration84/other-changes.xml を参照(尊重)しています
https://github.com/php/doc-ja/blob/c378f9b639ec106b5431e2ca39c1adbb6febb751/appendices/migration84/other-changes.xml#L90-L96

オリジナル(en)でも、

- migration: _Flushing headers without a body will now succeed._
- reference: _Flushing headers without a body will now succeed in FastCGI._

となっているので、「殆どそのまま持ってくる」のが無難そうだと判断しました。

## Refs
- php-src: https://github.com/php/php-src/pull/12785
- 関連箇所: https://github.com/php/doc-en/commit/56b4b1960e07355f889ef6e4e3b75ebdc59507b9#diff-2e8a3e9ff34b4aa3187b4c564923caadce112c875124e93dd3e0115901d7172cL301
    - parent commit: https://github.com/php/doc-en/commit/d64e811eac61a5c7c744312d8bc6e2244de81488

## Preview
![image](https://github.com/user-attachments/assets/26ee9915-8b1a-4ebb-b2fc-09f5ec12d361)