### PR TITLE
[PHP 8.4] DOMNode::DOCUMENT_*定数とDOMNode::compareDocumentPositionに関する翻訳

### DIFF
--- a/reference/dom/domnode.xml
+++ b/reference/dom/domnode.xml
@@ -25,6 +25,50 @@
      <classname>DOMNode</classname>
     </ooclass>
 
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="domnode.constants.document-position-disconnected">DOMNode::DOCUMENT_POSITION_DISCONNECTED</varname>
+     <initializer>1</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="domnode.constants.document-position-preceding">DOMNode::DOCUMENT_POSITION_PRECEDING</varname>
+     <initializer>2</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="domnode.constants.document-position-following">DOMNode::DOCUMENT_POSITION_FOLLOWING</varname>
+     <initializer>4</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="domnode.constants.document-position-contains">DOMNode::DOCUMENT_POSITION_CONTAINS</varname>
+     <initializer>8</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="domnode.constants.document-position-contained-by">DOMNode::DOCUMENT_POSITION_CONTAINED_BY</varname>
+     <initializer>16</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="domnode.constants.document-position-implementation-specific">DOMNode::DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC</varname>
+     <initializer>32</initializer>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>public</modifier>
@@ -139,6 +183,74 @@
    </classsynopsis>
 <!-- }}} -->
  
+  </section>
+
+  <section xml:id="domnode.constants">
+   &reftitle.constants;
+   <variablelist>
+    <varlistentry xml:id="domnode.constants.document-position-disconnected">
+     <term>
+      <constant>DOMNode::DOCUMENT_POSITION_DISCONNECTED</constant>
+     </term>
+     <listitem>
+      <simpara>
+       Set when the other node and reference node are not in the same tree.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="domnode.constants.document-position-preceding">
+     <term>
+      <constant>DOMNode::DOCUMENT_POSITION_PRECEDING</constant>
+     </term>
+     <listitem>
+      <simpara>
+       Set when the other node precedes the reference node.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="domnode.constants.document-position-following">
+     <term>
+      <constant>DOMNode::DOCUMENT_POSITION_FOLLOWING</constant>
+     </term>
+     <listitem>
+      <simpara>
+       Set when the other node follows the reference node.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="domnode.constants.document-position-contains">
+     <term>
+      <constant>DOMNode::DOCUMENT_POSITION_CONTAINS</constant>
+     </term>
+     <listitem>
+      <simpara>
+       Set when the other node is an ancestor of the reference node.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="domnode.constants.document-position-contained-by">
+     <term>
+      <constant>DOMNode::DOCUMENT_POSITION_CONTAINED_BY</constant>
+     </term>
+     <listitem>
+      <simpara>
+       Set when the other node is a descendant of the reference node.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="domnode.constants.document-position-implementation-specific">
+     <term>
+      <constant>DOMNode::DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC</constant>
+     </term>
+     <listitem>
+      <simpara>
+       Set when the result depends on implementation-specific behaviour and
+       may not be portable.
+       This may happen with disconnected nodes or with attribute nodes.
+      </simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
   </section>
  
 <!-- {{{ DOMNode properties -->

--- a/reference/dom/domnode.xml
+++ b/reference/dom/domnode.xml
@@ -194,7 +194,7 @@
      </term>
      <listitem>
       <simpara>
-       他のノードと参照ノードが同じツリー内にない場合に設定されます。
+       もう一方のノードと参照ノードが同じツリー内にない場合に設定されます。
       </simpara>
      </listitem>
     </varlistentry>
@@ -204,7 +204,7 @@
      </term>
      <listitem>
       <simpara>
-       他のノードが参照ノードより前にある場合に設定されます。
+       もう一方のノードが参照ノードより前にある場合に設定されます。
       </simpara>
      </listitem>
     </varlistentry>
@@ -214,7 +214,7 @@
      </term>
      <listitem>
       <simpara>
-       他のノードが参照ノードの後に続く場合に設定されます。
+       もう一方のノードが参照ノードの後に続く場合に設定されます。
       </simpara>
      </listitem>
     </varlistentry>
@@ -224,7 +224,7 @@
      </term>
      <listitem>
       <simpara>
-       他のノードが参照ノードの祖先である場合に設定されます。
+       もう一方のノードが参照ノードの祖先である場合に設定されます。
       </simpara>
      </listitem>
     </varlistentry>
@@ -234,7 +234,7 @@
      </term>
      <listitem>
       <simpara>
-       他のノードが参照ノードの子孫である場合に設定されます。
+       もう一方のノードが参照ノードの子孫である場合に設定されます。
       </simpara>
      </listitem>
     </varlistentry>

--- a/reference/dom/domnode.xml
+++ b/reference/dom/domnode.xml
@@ -194,7 +194,7 @@
      </term>
      <listitem>
       <simpara>
-       Set when the other node and reference node are not in the same tree.
+       他のノードと参照ノードが同じツリー内にない場合に設定されます。
       </simpara>
      </listitem>
     </varlistentry>
@@ -204,7 +204,7 @@
      </term>
      <listitem>
       <simpara>
-       Set when the other node precedes the reference node.
+       他のノードが参照ノードより前にある場合に設定されます。
       </simpara>
      </listitem>
     </varlistentry>
@@ -214,7 +214,7 @@
      </term>
      <listitem>
       <simpara>
-       Set when the other node follows the reference node.
+       他のノードが参照ノードの後に続く場合に設定されます。
       </simpara>
      </listitem>
     </varlistentry>
@@ -224,7 +224,7 @@
      </term>
      <listitem>
       <simpara>
-       Set when the other node is an ancestor of the reference node.
+       他のノードが参照ノードの祖先である場合に設定されます。
       </simpara>
      </listitem>
     </varlistentry>
@@ -234,7 +234,7 @@
      </term>
      <listitem>
       <simpara>
-       Set when the other node is a descendant of the reference node.
+       他のノードが参照ノードの子孫である場合に設定されます。
       </simpara>
      </listitem>
     </varlistentry>
@@ -244,9 +244,8 @@
      </term>
      <listitem>
       <simpara>
-       Set when the result depends on implementation-specific behaviour and
-       may not be portable.
-       This may happen with disconnected nodes or with attribute nodes.
+       結果が実装依存の動作に基づいており、移植性がない場合に設定されます。
+       これは、同じツリー内にないノードや属性ノードの場合に発生する可能性があります。
       </simpara>
      </listitem>
     </varlistentry>

--- a/reference/dom/domnode.xml
+++ b/reference/dom/domnode.xml
@@ -251,7 +251,7 @@
     </varlistentry>
    </variablelist>
   </section>
- 
+
 <!-- {{{ DOMNode properties -->
   <section xml:id="domnode.props">
    &reftitle.properties;

--- a/reference/dom/domnode.xml
+++ b/reference/dom/domnode.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 89ae180a851621c308f0ea4604ff2e919aa57a7f Maintainer: takagi Status: ready -->
-<!-- Credits: mumumu -->
+<!-- EN-Revision: 4b6c8a5a9469b5c02585618d5a6e0774ca37530f Maintainer: takagi Status: ready -->
+<!-- Credits: mumumu,jdkfx -->
 <reference xml:id="class.domnode" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>DOMNode クラス</title>
  <titleabbrev>DOMNode</titleabbrev>

--- a/reference/dom/domnode.xml
+++ b/reference/dom/domnode.xml
@@ -293,6 +293,31 @@
      </thead>
      <tbody>
       <row>
+       <entry>8.4.0</entry>
+       <entry>
+        <methodname>DOMNode::compareDocumentPosition</methodname> メソッドが追加されました。
+       </entry>
+      </row>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        以下の定数が新たに追加されました。
+        <constant>DOMNode::DOCUMENT_POSITION_DISCONNECTED</constant>、
+        <constant>DOMNode::DOCUMENT_POSITION_PRECEDING</constant>、
+        <constant>DOMNode::DOCUMENT_POSITION_FOLLOWING</constant>、
+        <constant>DOMNode::DOCUMENT_POSITION_CONTAINS</constant>、
+        <constant>DOMNode::DOCUMENT_POSITION_CONTAINED_BY</constant>、および
+        <constant>DOMNode::DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC</constant>。
+       </entry>
+      </row>
+      <row>
+       <entry>8.3.0</entry>
+       <entry>
+        <methodname>DOMNode::contains</methodname> と、
+        <methodname>DOMNode::isEqualNode</methodname> というメソッドが追加されました。
+       </entry>
+      </row>
+      <row>
        <entry>8.3.0</entry>
        <entry>
         プロパティ <property>DOMNode::$parentElement</property> と

--- a/reference/dom/domnode/compareDocumentPosition.xml
+++ b/reference/dom/domnode/compareDocumentPosition.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: f1516b33abc82b59d0b8a52b973d64f4857939cc Maintainer: jdkfx Status: ready -->
+<!-- CREDITS: jdkfx -->
 <refentry xml:id="domnode.comparedocumentposition" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>DOMNode::compareDocumentPosition</refname>

--- a/reference/dom/domnode/compareDocumentPosition.xml
+++ b/reference/dom/domnode/compareDocumentPosition.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="domnode.comparedocumentposition" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>DOMNode::compareDocumentPosition</refname>
-  <refpurpose>Compares the position of two nodes</refpurpose>
+  <refpurpose>2つのノードの位置を比較します。</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,7 +15,7 @@
    <methodparam><type>DOMNode</type><parameter>other</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Compares the position of the other node relative to this node.
+   このノードに対するもう一方のノードの位置を比較します。
   </simpara>
  </refsect1>
 
@@ -26,7 +26,7 @@
     <term><parameter>other</parameter></term>
     <listitem>
      <para>
-      The node for which the position should be compared for, relative to this node.
+      このノードに対して、位置を比較すべきノード。
      </para>
     </listitem>
    </varlistentry>
@@ -36,15 +36,14 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   A bitmask of the <constant>DOMNode::DOCUMENT_POSITION_<replaceable>*</replaceable></constant>
-   constants.
+   <constant>DOMNode::DOCUMENT_POSITION_<replaceable>*</replaceable></constant> 定数のビットマスク。
   </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title><methodname>DOMNode::compareDocumentPosition</methodname> example</title>
+   <title><methodname>DOMNode::compareDocumentPosition</methodname> の例</title>
    <programlisting role="php">
 <![CDATA[
 <?php
@@ -67,8 +66,8 @@ var_dump($child2->compareDocumentPosition($child1));
    &example.outputs;
    <screen>
 <![CDATA[
-int(20) // This is DOMNode::DOCUMENT_POSITION_CONTAINED_BY | DOMNode::DOCUMENT_POSITION_FOLLOWING
-int(2)  // This is DOMNode::DOCUMENT_POSITION_PRECEDING
+int(20) // DOMNode::DOCUMENT_POSITION_CONTAINED_BY | DOMNode::DOCUMENT_POSITION_FOLLOWING 定数
+int(2)  // DOMNode::DOCUMENT_POSITION_PRECEDING 定数
 ]]>
    </screen>
   </example>

--- a/reference/dom/domnode/compareDocumentPosition.xml
+++ b/reference/dom/domnode/compareDocumentPosition.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="domnode.comparedocumentposition" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>DOMNode::compareDocumentPosition</refname>
+  <refpurpose>Compares the position of two nodes</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="DOMNode">
+   <modifier>public</modifier> <type>int</type><methodname>DOMNode::compareDocumentPosition</methodname>
+   <methodparam><type>DOMNode</type><parameter>other</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Compares the position of the other node relative to this node.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>other</parameter></term>
+    <listitem>
+     <para>
+      The node for which the position should be compared for, relative to this node.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   A bitmask of the <constant>DOMNode::DOCUMENT_POSITION_<replaceable>*</replaceable></constant>
+   constants.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><methodname>DOMNode::compareDocumentPosition</methodname> example</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$xml = <<<XML
+<root>
+    <child1/>
+    <child2/>
+</root>
+XML;
+$dom = new DOMDocument();
+$dom->loadXML($xml);
+$root = $dom->documentElement;
+$child1 = $root->firstElementChild;
+$child2 = $child1->nextElementSibling;
+var_dump($root->compareDocumentPosition($child1));
+var_dump($child2->compareDocumentPosition($child1));
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+int(20) // This is DOMNode::DOCUMENT_POSITION_CONTAINED_BY | DOMNode::DOCUMENT_POSITION_FOLLOWING
+int(2)  // This is DOMNode::DOCUMENT_POSITION_PRECEDING
+]]>
+   </screen>
+  </example>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/dom/domnode/compareDocumentPosition.xml
+++ b/reference/dom/domnode/compareDocumentPosition.xml
@@ -53,11 +53,14 @@ $xml = <<<XML
     <child2/>
 </root>
 XML;
+
 $dom = new DOMDocument();
 $dom->loadXML($xml);
+
 $root = $dom->documentElement;
 $child1 = $root->firstElementChild;
 $child2 = $child1->nextElementSibling;
+
 var_dump($root->compareDocumentPosition($child1));
 var_dump($child2->compareDocumentPosition($child1));
 ?>


### PR DESCRIPTION
内容が似ているので、以下の2点を取り込み

- [x] ドキュメント追加 https://github.com/php/doc-en/pull/4081
- [x] 変更履歴追加 https://github.com/php/doc-en/pull/4121