### PR TITLE
[PHP 8.4] Document DOMImplementation::createDocument()の翻訳

### DIFF
--- a/reference/dom/domimplementation/createdocument.xml
+++ b/reference/dom/domimplementation/createdocument.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 765749a26b620538117fff4425fafb3ed5834b54 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 8c38327f130598e3680c3a33b6500af641b31f15 Maintainer: takagi Status: ready -->
 <refentry xml:id="domimplementation.createdocument" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>DOMImplementation::createDocument</refname>

--- a/reference/dom/domimplementation/createdocument.xml
+++ b/reference/dom/domimplementation/createdocument.xml
@@ -11,7 +11,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="DOMImplementation">
-   <modifier>public</modifier> <type class="union"><type>DOMDocument</type><type>false</type></type><methodname>DOMImplementation::createDocument</methodname>
+   <modifier>public</modifier> <type>DOMDocument</type><methodname>DOMImplementation::createDocument</methodname>
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>namespace</parameter><initializer>&null;</initializer></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>qualifiedName</parameter><initializer>""</initializer></methodparam>
    <methodparam choice="opt"><type class="union"><type>DOMDocumentType</type><type>null</type></type><parameter>doctype</parameter><initializer>&null;</initializer></methodparam>
@@ -56,7 +56,6 @@
   &reftitle.returnvalues;
   <para>
    新しい <classname>DOMDocument</classname> オブジェクトを返します。
-   エラーの場合は &false; を返します。
    <parameter>namespace</parameter>、<parameter>qualifiedName</parameter>
    および <parameter>doctype</parameter> が null の場合は、
    ドキュメント要素を含まない空の <classname>DOMDocument</classname>
@@ -101,6 +100,12 @@
       </row>
      </thead>
      <tbody>
+      <row>
+        <entry>8.4.0</entry>
+        <entry>
+          この関数の仮の戻り値の型が、<type>DOMDocument</type> になりました。
+        </entry>
+       </row>
       <row>
        <entry>8.0.3</entry>
        <entry>


### PR DESCRIPTION
refs https://github.com/php/doc-ja/issues/150
https://github.com/php/doc-en/pull/3901 の翻訳を担当します!

### 概要

該当ファイルの最新コミットがPRのマージコミットになっている事を確認した

https://github.com/php/doc-en/commits/master/reference/dom/domimplementation/createdocument.xml

<img width="1368" alt="image" src="https://github.com/user-attachments/assets/fff360fc-e696-4e4d-90e6-228267c87e06">

### 翻訳文章について

```php
    <row>
     <entry>8.4.0</entry>
     <entry>
      The function now has the tentative return type <type>DOMDocument</type>.
     </entry>
    </row>
```

`tentative`の翻訳を調べると、「仮の」や「暫定的」という意味があった。同じような英文を使っている関数を参考に調べたところ、「仮の」という意味で翻訳されているのを確認したので、こちらを参考に翻訳します。

- https://github.com/php/doc-en/blob/master/reference/dom/domdocument/loadxml.xml#L74
-https://github.com/php/doc-ja/blob/master/reference/dom/domdocument/loadxml.xml#L77

```php
    <row>
     <entry>8.4.0</entry>
     <entry>
      この関数の仮の戻り値の型が、<type>DOMDocument</type> になりました。
     </entry>
    </row>
```

### テスト

- [x] [jdkfx/phpdoc](https://github.com/jdkfx/phpdoc)のプレビューでcreatedocumentの翻訳が表示されている事を確認した

| 変更前 | 変更後 | 
| --- | --- |
| <img width="1416" alt="image" src="https://github.com/user-attachments/assets/f55e4d8e-3b0c-4243-a427-9c526a2fcd27"> |  <img width="1429" alt="image" src="https://github.com/user-attachments/assets/5754f076-165e-4189-8513-0a6422e76ea2">  | 


### このPRでやらなかった事 