### PR TITLE
[CI/CD] Pull Requestごとの環境を GitHub Pages へとデプロイする GitHub Actions の追加

### DIFF
--- a/.github/workflows/branch-preview.yaml
+++ b/.github/workflows/branch-preview.yaml
@@ -27,12 +27,12 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: php/doc-en
-        path: doc-en
+        path: en
 
     - name: Checkout doc-ja
       uses: actions/checkout@v4
       with:
-        path: doc-ja
+        path: ja
 
     - name: Set up PHP
       uses: shivammathur/setup-php@v2

--- a/.github/workflows/branch-preview.yaml
+++ b/.github/workflows/branch-preview.yaml
@@ -64,6 +64,7 @@ jobs:
     permissions:
       pages: write
       id-token: write
+      pull-requests: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -73,3 +74,8 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+      - name: Comment URL to Pull Request
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          message: |
+            Deployed ${{ github.sha }} to ${{ steps.deployment.outputs.page_url }}/pr/${{ github.event.pull_request.number }}

--- a/.github/workflows/branch-preview.yaml
+++ b/.github/workflows/branch-preview.yaml
@@ -58,6 +58,7 @@ jobs:
       uses: actions/upload-pages-artifact@v3
       with:
         path: ./output/
+        retention-days: 7 # 1週間くらい残しておく
 
   deploy:
     permissions:

--- a/.github/workflows/branch-preview.yaml
+++ b/.github/workflows/branch-preview.yaml
@@ -47,11 +47,17 @@ jobs:
       run: |
         php phd/render.php --docbook doc-base/.manual.xml --package PHP --format xhtml
 
+    - name: Add Pull Request Path
+      run: |
+        PR_NUMBER=${{ github.event.pull_request.number }}
+        mkdir -p ./output/pr/$PR_NUMBER
+        mv ./output/php-chunked-xhtml/* ./output/pr/$PR_NUMBER/
+
     - name: Upload static files as artifact
       id: deployment
       uses: actions/upload-pages-artifact@v3
       with:
-        path: output/php-chunked-xhtml/
+        path: ./output/
 
   deploy:
     permissions:

--- a/.github/workflows/branch-preview.yaml
+++ b/.github/workflows/branch-preview.yaml
@@ -78,4 +78,4 @@ jobs:
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           message: |
-            Deployed ${{ github.event.pull_request.head.sha }} to ${{ steps.deployment.outputs.page_url }}/pr/${{ github.event.pull_request.number }}
+            Deployed ${{ github.event.pull_request.head.sha }} to ${{ steps.deployment.outputs.page_url }}pr/${{ github.event.pull_request.number }}

--- a/.github/workflows/branch-preview.yaml
+++ b/.github/workflows/branch-preview.yaml
@@ -1,0 +1,29 @@
+name: Deploy Pull Request to GitHub Pages
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout doc-ja
+        uses: actions/checkout@v4
+        with:
+          path: doc-ja
+
+      - name: Checkout phd
+        uses: actions/checkout@v4
+        with:
+          repository: phd/phd
+          path: phd
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+

--- a/.github/workflows/branch-preview.yaml
+++ b/.github/workflows/branch-preview.yaml
@@ -11,19 +11,39 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout doc-ja
-        uses: actions/checkout@v4
-        with:
-          path: doc-ja
+    - name: Checkout phd
+      uses: actions/checkout@v4
+      with:
+        repository: php/phd
+        path: phd
+    
+    - name: Checkout doc-base
+      uses: actions/checkout@v4
+      with:
+        repository: php/doc-base
+        path: doc-base
 
-      - name: Checkout phd
-        uses: actions/checkout@v4
-        with:
-          repository: phd/phd
-          path: phd
+    - name: Checkout doc-en
+      uses: actions/checkout@v4
+      with:
+        repository: php/doc-en
+        path: doc-en
 
-      - name: Set up PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.3'
+    - name: Checkout doc-ja
+      uses: actions/checkout@v4
+      with:
+        path: doc-ja
 
+    - name: Set up PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '8.3'
+
+    - name: Validate and build .manual.xml
+      run: |
+        php doc-base/configure.php --with-lang=ja
+
+    - name: Render xhtml
+      run: |
+        php phd/render.php --docbook doc-base/.manual.xml --package PHP --format xhtml
+        cat output/php-chunked-xhtml/index.html

--- a/.github/workflows/branch-preview.yaml
+++ b/.github/workflows/branch-preview.yaml
@@ -8,7 +8,7 @@ on:
       - reopened
 
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout phd
@@ -46,4 +46,23 @@ jobs:
     - name: Render xhtml
       run: |
         php phd/render.php --docbook doc-base/.manual.xml --package PHP --format xhtml
-        cat output/php-chunked-xhtml/index.html
+
+    - name: Upload static files as artifact
+      id: deployment
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: output/php-chunked-xhtml/
+
+  deploy:
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/branch-preview.yaml
+++ b/.github/workflows/branch-preview.yaml
@@ -78,4 +78,4 @@ jobs:
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           message: |
-            Deployed ${{ github.sha }} to ${{ steps.deployment.outputs.page_url }}/pr/${{ github.event.pull_request.number }}
+            Deployed ${{ github.event.pull_request.head.sha }} to ${{ steps.deployment.outputs.page_url }}/pr/${{ github.event.pull_request.number }}


### PR DESCRIPTION
> [!TIP]
> 実装にあたって https://github.com/jdkfx/phpdoc を参考にさせていただきました :tada: ありがとうございます 🙏🏻 

## 解決したい課題
- 翻訳作業のハードルを下げたい
  - ちょっとした編集をコミットした後に意図通り反映されているかの確認を楽にしたい

## 実施したこと
- Pull Requestが開かれた際に、環境をビルドしGitHubのArtifactsにアップロードし、その結果をGitHub Pagesにデプロイするようにした
- その上で、デプロイされたURLをPull Requestにコメントするようにした

以下のコメントが実際に私のfork上で投稿されたコメント(https://github.com/stefafafan/php-doc-ja/pull/1#issuecomment-2495985600) です:

![CleanShot 2024-11-24 at 22 04 19](https://github.com/user-attachments/assets/f5c216cc-5c19-4b44-bc01-871026505333)

## php/doc-ja に組み込むために必要な設定

デフォルトのGitHubのリポジトリ設定では動かないので、以下の2点の設定が必要です。

### `/settings/pages` から Source を GitHub Actions に変更する

デフォルトではDeploy from a branchになっているので、GitHub Actionsに変更する必要があります。

![CleanShot 2024-11-24 at 22 08 29](https://github.com/user-attachments/assets/65b73fe6-bfe5-41af-b5f9-bd28e9f72c3e)

### `/settings/environments/` の `github-pages` の Deployment branches and tags の制限を緩める

デフォルトの状態だと main (master) branch 以外からGitHub Pagesへのデプロイはできないので緩める必要があります

![CleanShot 2024-11-24 at 22 27 29@2x](https://github.com/user-attachments/assets/cafecdbd-4d1b-430f-b891-f7dd0091e3f0)

![CleanShot 2024-11-24 at 22 27 52@2x](https://github.com/user-attachments/assets/70a858ce-71b9-4902-9161-be683bc5fcde)
