### PR TITLE
[PHP 8.4] fix php/doc-en#3936 ([PHP 8.4] Add new constants and tokens from the tokenizer)

### DIFF
--- a/appendices/tokens.xml
+++ b/appendices/tokens.xml
@@ -707,7 +707,7 @@ defined('T_FN') || define('T_FN', 10001);
      <entry><constant>T_PRIVATE_SET</constant></entry>
      <entry>private(set)</entry>
      <entry>
-      property hooks (available as of PHP 8.4.0)
+      プロパティフック (PHP 8.4.0 以降で利用可能)
      </entry>
     </row>
     <row xml:id="constant.t-protected">
@@ -721,7 +721,7 @@ defined('T_FN') || define('T_FN', 10001);
      <entry><constant>T_PROTECTED_SET</constant></entry>
      <entry>protected(set)</entry>
      <entry>
-      property hooks (available as of PHP 8.4.0)
+      プロパティフック (PHP 8.4.0 以降で利用可能)
      </entry>
     </row>
     <row xml:id="constant.t-public">
@@ -735,7 +735,7 @@ defined('T_FN') || define('T_FN', 10001);
      <entry><constant>T_PUBLIC_SET</constant></entry>
      <entry>public(set)</entry>
      <entry>
-      property hooks (available as of PHP 8.4.0)
+      プロパティフック (PHP 8.4.0 以降で利用可能)
      </entry>
     </row>
     <row xml:id="constant.t-readonly">

--- a/appendices/tokens.xml
+++ b/appendices/tokens.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 270a871223343be9280a3e8a133a5467a3e82908 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 8a6397d39aefd23c61d64aa4e9af919772541e2a Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi,mumumu -->
 
 <appendix xml:id="tokens" xmlns="http://docbook.org/ns/docbook">
@@ -703,6 +703,13 @@ defined('T_FN') || define('T_FN', 10001);
       <link linkend="language.oop5">クラスとオブジェクト</link>
      </entry>
     </row>
+    <row xml:id="constant.t-private-set">
+     <entry><constant>T_PRIVATE_SET</constant></entry>
+     <entry>private(set)</entry>
+     <entry>
+      property hooks (available as of PHP 8.4.0)
+     </entry>
+    </row>
     <row xml:id="constant.t-protected">
      <entry><constant>T_PROTECTED</constant></entry>
      <entry>protected</entry>
@@ -710,11 +717,25 @@ defined('T_FN') || define('T_FN', 10001);
       <link linkend="language.oop5">クラスとオブジェクト</link>
      </entry>
     </row>
+    <row xml:id="constant.t-protected-set">
+     <entry><constant>T_PROTECTED_SET</constant></entry>
+     <entry>protected(set)</entry>
+     <entry>
+      property hooks (available as of PHP 8.4.0)
+     </entry>
+    </row>
     <row xml:id="constant.t-public">
      <entry><constant>T_PUBLIC</constant></entry>
      <entry>public</entry>
      <entry>
       <link linkend="language.oop5">クラスとオブジェクト</link>
+     </entry>
+    </row>
+    <row xml:id="constant.t-public-set">
+     <entry><constant>T_PUBLIC_SET</constant></entry>
+     <entry>public(set)</entry>
+     <entry>
+      property hooks (available as of PHP 8.4.0)
      </entry>
     </row>
     <row xml:id="constant.t-readonly">


### PR DESCRIPTION
## Issue
* 元ネタ: php/doc-en#3936
* ref: #150
* page: PHP Manual > 付録 > パーサトークンの一覧

## Refs
* ターゲットとしているPRには `appendices/migration84/constants.xml` の変更も含まれているが、jaへは ↓で反映済み

https://github.com/php/doc-ja/blob/c378f9b639ec106b5431e2ca39c1adbb6febb751/appendices/migration84/constants.xml#L292-L305

---
追加されたのは、Property Hooksに伴って追加された3つのトークン
![image](https://github.com/user-attachments/assets/a1b6d534-0d7d-426f-aa47-80dee31d481e)
