### PR TITLE
[PHP 8.4] Sodium関数のタイポと翻訳漏れ対応

### DIFF
--- a/reference/sodium/functions/sodium-crypto-aead-aegis128l-decrypt.xml
+++ b/reference/sodium/functions/sodium-crypto-aead-aegis128l-decrypt.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="function.sodium-crypto-aead-aegis128l-decrypt" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>sodium_crypto_aead_aegis128l_decrypt</refname>
-  <refpurpose>AEGIS-128L を用いてメッセージを検証し、複合する</refpurpose>
+  <refpurpose>AEGIS-128L を用いてメッセージを検証し、復号する</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -17,7 +17,7 @@
    <methodparam><modifier role="attribute">#[\SensitiveParameter]</modifier><type>string</type><parameter>key</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   AEGIS-128L を用いてメッセージを検証し、複合します。
+   AEGIS-128L を用いてメッセージを検証し、復号します。
   </simpara>
  </refsect1>
 

--- a/reference/sodium/functions/sodium-crypto-aead-aegis128l-keygen.xml
+++ b/reference/sodium/functions/sodium-crypto-aead-aegis128l-keygen.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="function.sodium-crypto-aead-aegis128l-keygen" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>sodium_crypto_aead_aegis128l_keygen</refname>
-  <refpurpose>Generate a random AEGIS-128L key</refpurpose>
+  <refpurpose>ランダムな AEGIS-128L 暗号化キーを生成する</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;


### PR DESCRIPTION
- `複合` になってる箇所を `復号` に修正
- 一部翻訳漏れの対応

を行いました🙏