### PR TITLE
[PHP 8.4] DOMXPathの変更履歴の翻訳

### DIFF
--- a/reference/dom/domxpath.xml
+++ b/reference/dom/domxpath.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 0185cc34ca3528205e3bda346a4d907c28a57bc5 Maintainer: takagi Status: ready -->
 <!--
 Remove me once you perform substitutions
     domxpath
@@ -88,6 +88,13 @@ Remove me once you perform substitutions
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        以前は、 <classname>DOMXPath</classname> オブジェクトをクローンできましたが、返されるオブジェクトは使用できませんでした。
+        これはもはや可能ではなく、 <classname>DOMXPath</classname> オブジェクトをクローンすると、例外がスローされるようになりました。
+       </entry>
+      </row>
       <row>
        <entry>8.0.0</entry>
        <entry>


### PR DESCRIPTION
以下を取り込み
https://github.com/php/doc-en/pull/3925

また、以下の翻訳を参考にしました。
https://www.php.net/manual/ja/migration84.incompatible.php#migration84.incompatible.dom