### PR TITLE
[PHP 8.4] 追加されたposixの定数を翻訳

### DIFF
--- a/reference/posix/constants.xml
+++ b/reference/posix/constants.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 61374bbe228e8e9c55a24aba59a1e2bb2a871148 Maintainer: takagi Status: ready -->
-<!-- Credits: mumumu -->
+<!-- EN-Revision: be0867e6488a28518529f31e9684d61741ac7dad Maintainer: takagi Status: ready -->
+<!-- Credits: mumumu,jdkfx -->
 <appendix xml:id="posix.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
  &extension.constants;
@@ -510,6 +510,18 @@
      </simpara>
     </listitem>
    </varlistentry>
+   <varlistentry xml:id="constant.posix-pc-symlink-max">
+    <term>
+     <constant>POSIX_PC_SYMLINK_MAX</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      シンボリックリンク内の最大バイト数。
+      PHP 8.3.0 以降で利用可能です。
+     </simpara>
+    </listitem>
+   </varlistentry>
   </variablelist>
  </section>
 
@@ -561,6 +573,30 @@
      <simpara>
       システムで現状アクティブなcpuの数。
       PHP 8.3.0 以降で利用可能です。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.posix-sc-child-max">
+    <term>
+     <constant>POSIX_SC_CHILD_MAX</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      1ユーザーあたりの同時プロセスの最大数。
+      PHP 8.4.0 以降で利用可能です。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.posix-sc-clk-tck">
+    <term>
+     <constant>POSIX_SC_CLK_TCK</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      1秒あたりの経過クロック数。
+      PHP 8.4.0 以降で利用可能です。
      </simpara>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
以下を取り込み

https://github.com/php/doc-en/pull/4072
https://github.com/php/doc-en/pull/4090
https://github.com/php/doc-en/pull/4091