### PR TITLE
[PHP 8.4] doc-en#4105とdoc-en#4109の翻訳

### DIFF
--- a/reference/sockets/functions/socket-create-listen.xml
+++ b/reference/sockets/functions/socket-create-listen.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e50e79746736dbdfbabe9bd3566793b3ddf38f58 Maintainer: hirokawa Status: ready -->
-<!-- CREDITS: takagi -->
+<!-- EN-Revision: 0e097419a847a077c7d8a74ebc5237ba9d8ddc90 Maintainer: hirokawa Status: ready -->
+<!-- CREDITS: takagi,jdkfx -->
 <refentry xml:id="function.socket-create-listen" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>socket_create_listen</refname>
@@ -76,6 +76,13 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       デフォルトの値は <constant>SOMAXCONN</constant> に設定されています。
+       以前のバージョンでは <literal>128</literal> でした。
+      </entry>
+     </row>
      <row>
       <entry>8.0.0</entry>
       <entry>

--- a/reference/zlib/setup.xml
+++ b/reference/zlib/setup.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: a0ae28d3bc85f927c22649ebd9a590b921534b7d Maintainer: takagi Status: ready -->
-<!-- CREDITS: hirokawa,mumumu -->
+<!-- EN-Revision: 6bb12514da39d010f2f0beb025dab9ec2459af51 Maintainer: takagi Status: ready -->
+<!-- CREDITS: hirokawa,mumumu,jdkfx -->
 
 <chapter xml:id="zlib.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.setup;
@@ -12,8 +12,8 @@
   <para>
    このモジュールは、Jean-loup Gailly および Mark Adler による
    <link xlink:href="&url.zlib;">zlib</link> の関数を使用します。
-   このモジュールを使用するには、
-   zlib &gt;= 1.2.0.4 を使用する必要があります。
+   PHP 8.4.0 以降のバージョンで、このモジュールを使用するために必要な zlib の最低バージョンは 1.2.11 です。
+   PHP 8.4.0 より前のバージョンで、このモジュールを使用するために必要な zlib の最低バージョンは 1.2.0.4 です。
   </para>
  </section>
  <!-- }}} -->


### PR DESCRIPTION
以下を取り込み
簡単なものなので二つ同時にやりました

https://github.com/php/doc-en/pull/4105
https://github.com/php/doc-en/pull/4109