### PR TITLE
Fix typo: 英語版のマニュアルにあった不定冠詞の削除忘れの修正

### DIFF
--- a/reference/exec/functions/proc-open.xml
+++ b/reference/exec/functions/proc-open.xml
@@ -242,7 +242,7 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>A <function>proc_open</function> の例</title>
+    <title><function>proc_open</function> の例</title>
     <programlisting role="php">
 <![CDATA[
 <?php


### PR DESCRIPTION
[英語版の proc_open の Example #1](https://www.php.net/manual/en/function.proc-open.php#example-3470) には、不定冠詞の「A」がついている。日本語版でも、この「A」が残っていたので削除した。