### PR TITLE
[PHP 8.4] Function return type changesの翻訳

### DIFF
--- a/reference/misc/functions/highlight-string.xml
+++ b/reference/misc/functions/highlight-string.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 443d81b33e6537a000cc235c2a11748ba8d56232 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: ba50f222e7108287fb6eb11265c2b28efe0cc0ce Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi -->
 <refentry xml:id="function.highlight-string" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -11,7 +11,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type class="union"><type>string</type><type>bool</type></type><methodname>highlight_string</methodname>
+   <type class="union"><type>string</type><type>true</type></type><methodname>highlight_string</methodname>
    <methodparam><type>string</type><parameter>string</parameter></methodparam>
    <methodparam choice="opt"><type>bool</type><parameter>return</parameter><initializer>&false;</initializer></methodparam>
   </methodsynopsis>
@@ -51,8 +51,7 @@
   <para>
    <parameter>return</parameter> が &true; の場合は、
    ハイライトされたコードを文字列として返し、表示しません。
-   それ以外の場合は、成功した場合に &true;、
-   失敗した場合に &false; を返します。
+   それ以外の場合は、&true; を返します。
   </para>
  </refsect1>
 
@@ -68,6 +67,13 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        戻り値の型が、<type class="union"><type>string</type><type>bool</type></type> から
+        <type class="union"><type>string</type><type>true</type></type> に変更されました。
+       </entry>
+      </row>
       <row>
        <entry>8.3.0</entry>
        <entry>

--- a/reference/network/functions/long2ip.xml
+++ b/reference/network/functions/long2ip.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d715365c098db000eaf7dcd987ee6093f6e83091 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 2537e56cce341e1c14cf2f0e49e5378700f84897 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi,mumumu -->
 <refentry xml:id="function.long2ip" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -39,8 +39,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   インターネットの IP アドレスを表す文字列を返します。
-   &return.falseforfailure;
+   インターネットの IP アドレスを表す<type>文字列</type>を返します。
   </para>
  </refsect1>
 
@@ -55,6 +54,12 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       戻り値の型が、<type class="union"><type>string</type><type>false</type></type> から <type>string</type> に変更されました。
+      </entry>
+     </row>
      <row>
       <entry>7.1.0</entry>
       <entry>

--- a/reference/var/functions/print-r.xml
+++ b/reference/var/functions/print-r.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ccc438a27bae31d71fe2ca7dc095360db5bc1af6 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 649598d5e2965b2565f7724cdb4fd4f094d4c81e Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: shimooka -->
 <refentry xml:id="function.print-r" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,7 +13,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type class="union"><type>string</type><type>bool</type></type><methodname>print_r</methodname>
+   <type class="union"><type>string</type><type>true</type></type><methodname>print_r</methodname>
    <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
    <methodparam choice="opt"><type>bool</type><parameter>return</parameter><initializer>&false;</initializer></methodparam>
   </methodsynopsis>
@@ -67,6 +67,31 @@
   <para>
    <parameter>return</parameter> パラメータが &true; の場合は、
    この関数は <type>string</type> を返します。それ以外の場合の戻り値は &true; です。
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        戻り値の型が、<type class="union"><type>string</type><type>bool</type></type> から
+        <type class="union"><type>string</type><type>true</type></type> に変更されました。
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </para>
  </refsect1>
 

--- a/reference/xsl/xsltprocessor/setparameter.xml
+++ b/reference/xsl/xsltprocessor/setparameter.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 03817004058a9d8d847626ce6582342dd2645e48 Maintainer: takagi Status: ready -->
-<!-- Credits: mumumu -->
+<!-- EN-Revision: 68e72e60ba0b318e21bb8b4a87abba35adb891c8 Maintainer: takagi Status: ready -->
+<!-- Credits: mumumu,t2aking -->
 <refentry xml:id="xsltprocessor.setparameter" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>XSLTProcessor::setParameter</refname>
@@ -72,6 +72,13 @@
   </para>
  </refsect1>
 
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   引数のいずれかにヌルバイトが含まれている場合、<exceptionname>ValueError</exceptionname>例外が発生します。
+  </simpara>
+ </refsect1>
+
  <refsect1 role="changelog">
   &reftitle.changelog;
   <informaltable>
@@ -83,6 +90,12 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       引数のいずれかにヌルバイトが含まれている場合、<exceptionname>ValueError</exceptionname>例外が発生するようになりました。
+      </entry>
+     </row>
      <row>
       <entry>8.4.0</entry>
       <entry>


### PR DESCRIPTION
refs #150 

php/doc-en#4083 を取り込みました。

- `reference/network/functions/long2ip.xml` の戻り値の説明は原文に合わせて `<type>文字列</type>` とタグを追加したが、原文と違ってリンクにはならない
- 他のファイルでも同様なので、そのような仕様と解釈した