### PR TITLE
`<type>型名</type>` を `<type>typeName</type>` に修正

### DIFF
--- a/appendices/about.xml
+++ b/appendices/about.xml
@@ -189,7 +189,7 @@ int strlen ( string $string )
         <entry>
          strlen() 関数の最初の（この場合は唯一の）引数が
          <parameter>string</parameter>という名前であり
-         それは<type>文字列</type>である
+         それは文字列(<type>string</type>)である
         </entry>
        </row>
        <row>

--- a/appendices/comparisons.xml
+++ b/appendices/comparisons.xml
@@ -15,10 +15,10 @@
  </para>
  <para>
   この表を活用する前に、型とその意味について理解しておく必要があります。
-  例えば、<literal>"42"</literal>は<type>文字列</type>ですが
-  <literal>42</literal>は<type>整数</type>です。
-  &false;は<type>bool</type>ですが<literal>"false"</literal>は
-  <type>文字列</type>です。
+  例えば、<literal>"42"</literal>は <type>string</type> ですが
+  <literal>42</literal>は <type>int</type> です。
+  &false; は <type>bool</type> ですが <literal>"false"</literal> は
+  <type>string</type> です。
  </para>
  <note>
   <para>

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -2249,7 +2249,7 @@ NULL フィールドに PHPの &null; 値を設定します。</simpara></note>'
 
 <!ENTITY mysql.linkid-noreopen.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>link_identifier</parameter></term><listitem><para>MySQL 接続。指定されない場合、<function>mysql_connect</function> により直近にオープンされたリンクが指定されたと仮定されます。接続が見つからない、または、確立できない場合、<constant>E_WARNING</constant> レベルのエラーが生成されます。</para></listitem></varlistentry>'>
 
-<!ENTITY mysql.result.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>result</parameter></term><listitem><para>評価された結果 <type>リソース</type>。この結果は、<function>mysql_query</function> のコールにより得られたものです。</para></listitem></varlistentry>'>
+<!ENTITY mysql.result.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>result</parameter></term><listitem><para>評価された結果を示す <type>resource</type>。この結果は、<function>mysql_query</function> のコールにより得られたものです。</para></listitem></varlistentry>'>
 
 <!ENTITY mysql.field-offset.req.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>field_offset</parameter></term><listitem><para>数値フィールドオフセット。<parameter>field_offset</parameter> は <literal>0</literal> から始まります。<parameter>field_offset</parameter> が存在しない場合、<constant>E_WARNING</constant> レベルのエラーが発行されます。</para></listitem></varlistentry>'>
 

--- a/language/types/array.xml
+++ b/language/types/array.xml
@@ -30,11 +30,11 @@
    <title><function>array</function> で指定</title>
 
    <para>
-    <type>配列</type> は、言語に組み込まれた
+    配列(<type>array</type>)は、言語に組み込まれた
     <function>array</function> で作成することが可能です。この構造は、
     特定の数のカンマで区切られた
-    <literal><replaceable>キー</replaceable> =&gt; <replaceable
-    >値</replaceable></literal> の組を引数とします。
+    <literal><replaceable>key</replaceable> =&gt; <replaceable
+    >value</replaceable></literal> の組を引数とします。
    </para>
 
    <synopsis>
@@ -83,8 +83,8 @@ $array = [
    </example>
    
    <para>
-    <varname>key</varname> は、<type>整数</type> または
-    <type>文字列</type>です。
+    <varname>key</varname> は、<type>int</type> または
+    <type>string</type>です。
     <replaceable>value</replaceable> には任意の型を指定できます。
    </para>
 
@@ -428,11 +428,11 @@ $secondElement = getArray()[1];
    </para>
    
    <synopsis>
-$arr[<replaceable>キー</replaceable>] = <replaceable>値</replaceable>;
-$arr[] = <replaceable>値</replaceable>;
-// <replaceable>キー</replaceable> は <type>文字列</type> または
-// <type>整数</type>のどちらかです。
-// <replaceable>値</replaceable> の型は、何でもかまいません。
+$arr[<replaceable>key</replaceable>] = <replaceable>value</replaceable>;
+$arr[] = <replaceable>value</replaceable>;
+// <replaceable>key</replaceable> は <type>string</type> または
+// <type>int</type>のどちらかです。
+// <replaceable>value</replaceable> の型は、何でもかまいません。
    </synopsis>
    
    <para>
@@ -993,7 +993,7 @@ $error_descriptions[8] = "This is just an informal notice";
 
     <note>
      <simpara>
-      二重引用符で括られた<type>文字列</type>の中では
+      二重引用符で括られた <type>string</type> の中では
       引用符で配列の添字を括らないことができ、このため、
       <literal>"$foo[bar]"</literal> は有効です。
       この理由の詳細については、上記の例や

--- a/reference/array/functions/array-combine.xml
+++ b/reference/array/functions/array-combine.xml
@@ -20,7 +20,7 @@
   <para>
    <parameter>keys</parameter> 配列の値をキーとして、また
    <parameter>values</parameter> 配列の値を対応する値として生成した
-   <type>配列</type> を作成します。
+   <type>array</type> を作成します。
   </para>
  </refsect1>
 

--- a/reference/dir/functions/closedir.xml
+++ b/reference/dir/functions/closedir.xml
@@ -33,7 +33,7 @@
      <listitem>
       <para>
        <function>opendir</function> が事前にオープンした
-       ディレクトリハンドル<type>リソース</type>。
+       ディレクトリハンドルを示す <type>resource</type>。
        ディレクトリハンドルを指定しなかった場合は、
        <function>opendir</function> が最後にオープンしたものを使用します。
       </para>

--- a/reference/dir/functions/readdir.xml
+++ b/reference/dir/functions/readdir.xml
@@ -30,7 +30,7 @@
      <listitem>
       <para>
        <function>opendir</function> が事前にオープンした
-       ディレクトリハンドル<type>リソース</type>。
+       ディレクトリハンドルを示す <type>resource</type>。
        ディレクトリハンドルを指定しなかった場合は、
        <function>opendir</function> が最後にオープンしたものを使用します。
       </para>

--- a/reference/dir/functions/rewinddir.xml
+++ b/reference/dir/functions/rewinddir.xml
@@ -30,7 +30,7 @@
      <listitem>
       <para>
        <function>opendir</function> が事前にオープンした
-       ディレクトリハンドル<type>リソース</type>。
+       ディレクトリハンドルを示す <type>resource</type>。
        ディレクトリハンドルを指定しなかった場合は、
        <function>opendir</function> が最後にオープンしたものを使用します。
       </para>

--- a/reference/exec/functions/proc-close.xml
+++ b/reference/exec/functions/proc-close.xml
@@ -35,7 +35,7 @@
      <term><parameter>process</parameter></term>
      <listitem>
       <para>
-       閉じられる <function>proc_open</function> <type>リソース</type>
+       閉じられる <function>proc_open</function> <type>resource</type>
       </para>
      </listitem>
     </varlistentry>

--- a/reference/exec/functions/proc-get-status.xml
+++ b/reference/exec/functions/proc-get-status.xml
@@ -29,7 +29,7 @@
      <term><parameter>process</parameter></term>
      <listitem>
       <para>
-       評価される <function>proc_open</function> <type>リソース</type>
+       評価される <function>proc_open</function> <type>resource</type>
       </para>
      </listitem>
     </varlistentry>
@@ -40,7 +40,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   集められた情報の <type>配列</type> を返します。
+   集められた情報を <type>array</type> として返します。
    返される配列は次のような要素を持ちます:
   </para>
   <para>

--- a/reference/filesystem/functions/file-put-contents.xml
+++ b/reference/filesystem/functions/file-put-contents.xml
@@ -44,11 +44,11 @@
      <term><parameter>data</parameter></term>
      <listitem>
       <para>
-       書き込むデータ。<type>文字列</type>, <type>配列</type>
-       もしくは <type>ストリーム</type> リソースのいずれかを指定可能です。
+       書き込むデータ。<type>string</type>, <type>array</type>
+       もしくは <type>stream</type> リソースのいずれかを指定可能です。
       </para>
       <para>
-       <parameter>data</parameter> が <type>ストリーム</type> リソースの場合は、
+       <parameter>data</parameter> が <type>stream</type> リソースの場合は、
        ストリームのバッファに残っている内容が指定したファイルにコピーされます。
        これは、<function>stream_copy_to_stream</function> の挙動と似ています。
       </para>

--- a/reference/info/functions/get-resources.xml
+++ b/reference/info/functions/get-resources.xml
@@ -14,7 +14,7 @@
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>type</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   現在アクティブなすべての<type>リソース</type>の配列を返します。 
+   現在アクティブなすべての <type>resource</type> の配列を返します。 
    オプションでリソース型によってフィルタリングされます。
   </para>
   <note>

--- a/reference/mbstring/functions/mb-ereg.xml
+++ b/reference/mbstring/functions/mb-ereg.xml
@@ -38,7 +38,7 @@
      <term><parameter>string</parameter></term>
      <listitem>
       <para>
-       検索<type>文字列</type>。
+       検索する <type>string</type>。
       </para>
      </listitem>
     </varlistentry>
@@ -99,7 +99,7 @@
       <entry>7.1.0</entry>
       <entry>
        マッチしなかった場合、<function>mb_ereg</function> は
-       <parameter>matches</parameter> を空の<type>配列</type>とするようになりました。
+       <parameter>matches</parameter> を空の<type>array</type>とするようになりました。
        これより前のバージョンでは <parameter>matches</parameter> を変更しませんでした。
       </entry>
      </row>

--- a/reference/network/functions/http-get-last-response-headers.xml
+++ b/reference/network/functions/http-get-last-response-headers.xml
@@ -16,7 +16,7 @@
   </methodsynopsis>
   <simpara>
    <link linkend="wrappers.http">HTTP ラッパー</link> を介して受け取った最後の <acronym>HTTP</acronym> レスポンスヘッダーを含む
-   <type>配列</type> を返します。
+   <type>array</type> を返します。
    レスポンスヘッダーがない場合は、 &null; を返します。
   </simpara>
  </refsect1>
@@ -30,7 +30,7 @@
   &reftitle.returnvalues;
   <simpara>
    <link linkend="wrappers.http">HTTP ラッパー</link> を使って受け取った <acronym>HTTP</acronym> ヘッダーを
-   インデックス付きの <type>配列</type> で返します。
+   インデックス付きの <type>array</type> で返します。
    ヘッダーがない場合は、 &null; を返します。
   </simpara>
  </refsect1>

--- a/reference/network/functions/long2ip.xml
+++ b/reference/network/functions/long2ip.xml
@@ -39,7 +39,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   インターネットの IP アドレスを表す<type>文字列</type>を返します。
+   インターネットの IP アドレスを <type>string</type> として返します。
   </para>
  </refsect1>
 

--- a/reference/pgsql/functions/pg-unescape-bytea.xml
+++ b/reference/pgsql/functions/pg-unescape-bytea.xml
@@ -49,7 +49,7 @@
      <listitem>
       <para>
        PHP のバイナリ文字列に変換される PostgreSQL の bytea データを含む
-       <type>文字列</type>。
+       <type>string</type>。
       </para>
      </listitem>
     </varlistentry>

--- a/reference/simplexml/examples.xml
+++ b/reference/simplexml/examples.xml
@@ -152,7 +152,7 @@ Mr. Coder played by El ActÓr
     <simpara>
      ここまでは、要素の名前と値を読む方法のみを扱って来ました。
      SimpleXML は要素の属性にアクセスすることも可能です。
-     要素の属性にアクセスする方法は、<type>配列</type> の要素に
+     要素の属性にアクセスする方法は、<type>array</type> の要素に
      アクセスするのと全く同じです。
     </simpara>
     <programlisting role="php">

--- a/reference/simplexml/simplexmlelement/xpath.xml
+++ b/reference/simplexml/simplexmlelement/xpath.xml
@@ -40,7 +40,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   SimpleXMLElement オブジェクトの<type>配列</type>を返します。
+   SimpleXMLElement オブジェクトの <type>array</type> を返します。
    エラーが発生した場合は &null; または &false; を返します。
   </para>
  </refsect1>

--- a/reference/var/functions/is-array.xml
+++ b/reference/var/functions/is-array.xml
@@ -35,7 +35,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   <parameter>value</parameter> が <type>配列型</type> の場合 &true;、
+   <parameter>value</parameter> が <type>array</type> の場合 &true;、
    そうでない場合 &false; を返します。
   </para>
  </refsect1>

--- a/reference/var/functions/var-export.xml
+++ b/reference/var/functions/var-export.xml
@@ -240,7 +240,7 @@ object(A)#2 (2) {
   &reftitle.notes;
   <note>
    <para>
-    <type>リソース型</type> の変数は、
+    <type>resource</type> 型の変数は、
     この関数ではエクスポートする事ができません。
    </para>
   </note>


### PR DESCRIPTION
多くの箇所にあった `<type>型名</type>` を `<type>typeName</type>` に修正し必要に応じて前後の訳を調整しました。

## 修正の概要

### en:

```xml
Returns the <type>string</type>.
```

> Returns the [string](#).


### ja: 修正前

```xml
<type>文字列</type>を返します。
```

> 文字列を返します。

### ja: 修正後

```xml
<type>string</type> を返します。
```

> [string](#) を返します。

## 方針

* `<type>` の使用有無は原文に準拠
* 原則すべての `<type>型名</type>` を `<type>typeName</type>` に修正
* 型それ自体の説明の際は括弧書きで補注
  * 例: 「配列」それ自体を説明する文章で唐突に *「[array](#) は、」* と書き出したりしない。
    冒頭のみ *「配列([array](#))は、」* と用語定義に相当する文。
* 必要に応じて訳の微調整
  * 例: *「ほげ文字列を返します」* => *「ほげを [string](#) として返します」*
  * 例: *「ふがリソースを返します」* => *「ふがを示す [resource](#) を返します」*

### その他

* 「配列」での `$arr[キー] = 値;` を `$arr[key] = value;` に修正
* それらに対応する文中のリテラル表記を `key`, `value` に修正