### PR TITLE
Fix typos in string.xml

### DIFF
--- a/language/types/string.xml
+++ b/language/types/string.xml
@@ -871,7 +871,7 @@ Object value: string.
     <note>
      <simpara>
       配列のキーについては、クォートを外さなければなりません。
-      よって、単純な記法ではキーを定数として参照できません。
+      よって、単純な記法では定数をキーとして参照できません。
       <link linkend="language.types.string.parsing.advanced">高度な</link>
       記法を使ってください。
      </simpara>
@@ -925,8 +925,7 @@ Changing the character at index -3 to o gives strong.
      式は文字列の外部に現れるものと同じやり方で書くことができ、
      <literal>{</literal> と <literal>}</literal> で囲みます。
      <literal>{</literal> はエスケープできないので、
-     この記法は <literal>$</literal>
-     記号のすぐ後に <literal>{</literal>
+     この記法は <literal>{</literal> のすぐ後に <literal>$</literal>
      が続く場合にのみ認識されます。
      <literal>{$</literal> を使いたい場合は
      <literal>{\$</literal> と書くようにしてください。
@@ -1039,7 +1038,7 @@ echo "C:\\folder\\{$great}.txt";
 
    <warning>
     <simpara>
-     範囲外のオフセットに書き込んだ場合は、空いた部分に空白文字が埋められます。
+     範囲外のオフセットに書き込んだ場合は、その地点までが空白文字で埋められます。
      整数型以外の型は整数型に変換されます。
      無効なオフセット形式を指定した場合は <constant>E_WARNING</constant> を発行します。
      文字列を代入した場合は最初の文字だけを使用します。
@@ -1203,7 +1202,7 @@ bool(false)
    関数を使って変数を文字列へ変換することができます。
    文字列型を必要とする式のスコープにおいて、文字列への変換は自動的に行われます。
    <function>echo</function> や <function>print</function> 関数を使うとき、
-   あるいは可変変数を文字列を比較するときにこの自動変換が行われます。
+   あるいは変数を文字列と比較するときにこの自動変換が行われます。
    マニュアルの<link linkend="language.types">型</link> と
    <link linkend="language.types.type-juggling">型の相互変換</link>
    の項を読むとわかりやすいでしょう。


### PR DESCRIPTION
1. キーを定数として → 定数をキーとして（元の表現でも一応伝わるが）
原文：
> The array key must be unquoted, and it is therefore not possible to refer to a constant as a key with the basic syntax.
2. \\$記号のすぐ後に{ → {のすぐ後に\\$（ついでに「記号」を消して表記を統一）
原文：
> Since { can not be escaped, this syntax will only be recognised when the $ immediately follows the {.
3. 空いた部分に → その地点までが（これはタイポではなく表現の修正）
原文：
> Writing to an out of range offset pads the string with spaces.
4. 可変変数を文字列を → 変数を文字列と
原文：
> This happens when using the echo or print functions, or when a variable is compared to a string.