### PR TITLE
PHP 8.4: Single underscore as class name is deprecated の翻訳

### DIFF
--- a/language/oop5/basic.xml
+++ b/language/oop5/basic.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 1d92bcca7524c50fc41056ea4c04e1032eb9e055 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 2f85d57a0b5a01b875cbca2b291f04389cf61ac2 Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa,mumumu,jdkfx -->
 
 <sect1 xml:id="language.oop5.basic" xmlns="http://docbook.org/ns/docbook">
@@ -16,6 +16,8 @@
    <para>
     クラス名には、PHP の<link linkend="reserved">予約語</link>
     以外でラベルとして有効なあらゆる名前を使用することができます。
+    PHP 8.4.0 以降では、アンダースコア (<literal>_</literal>)
+    1文字のみのクラス名は非推奨となりました。
     有効なクラス名は、先頭が文字あるいはアンダースコアで始まり、
     その後に任意の数の文字/数字/アンダースコアが続くものです。
     正規表現で表すと、


### PR DESCRIPTION
refs #150 

php/doc-en#4099 を取り込みました
