### PR TITLE
fix: タイプ名羅列の区切り文字を揃える

### DIFF
--- a/reference/var/functions/print-r.xml
+++ b/reference/var/functions/print-r.xml
@@ -59,7 +59,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   <type>string</type>、<type>int</type>,
+   <type>string</type>、<type>int</type>、
    <type>float</type> を指定した場合はその値が出力されます。
    <type>array</type> を指定した場合、キーと要素を表す形式で値が
    表示されます。<type>object</type> に関しても同様の表示形式となります。


### PR DESCRIPTION
タイプ名を羅列する句点文字を揃えました。

- 同ファイルの説明で「、」が使用されていたため（タイプ名ではありませんが）こちらに合わせる
- 他では、「,」と「、」の違いに加えて「または」、「あるいは」、「いずれか」とさまざま使用されている
- よって、句点文字を修正するのみで留めた
