### PR TITLE
PHP 8.4: stream_context_set_option() 2 param deprecation の翻訳

### DIFF
--- a/reference/stream/functions/stream-context-set-option.xml
+++ b/reference/stream/functions/stream-context-set-option.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: f7b3a3a469091c4015c224356de4824eb99b9232 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: d5859815063bb6d3a0953c773920ce7425cf912e Maintainer: hirokawa Status: ready -->
 <refentry xml:id="function.stream-context-set-option" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>stream_context_set_option</refname>
@@ -16,11 +16,15 @@
    <methodparam><type>string</type><parameter>option</parameter></methodparam>
    <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
   </methodsynopsis>
+  <para>
+   以下のシグネチャは、PHP 8.4.0 以降で非推奨となりました。
+   代わりに <function>stream_context_set_options</function> を使用してください。
    <methodsynopsis>
     <type>bool</type><methodname>stream_context_set_option</methodname>
     <methodparam><type>resource</type><parameter>stream_or_context</parameter></methodparam>
     <methodparam><type>array</type><parameter>options</parameter></methodparam>
    </methodsynopsis>
+  </para>
   <simpara>
     指定されたストリームまたはコンテキストのオプションを設定します。
     <parameter>value</parameter> の内容が
@@ -97,8 +101,30 @@
   </para>
  </refsect1><!-- }}} -->
 
-</refentry>
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       2 引数のシグネチャは非推奨となりました。
+       代わりに <function>stream_context_set_options</function> を使用してください。
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
 
+</refentry>
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml


### PR DESCRIPTION
refs #150 

php/doc-en#4106 を取り込みました。

EN-Revision

- `f7b3a3a469091c4015c224356de4824eb99b9232` → `d5859815063bb6d3a0953c773920ce7425cf912e`
- 間に php/doc-en#979 があるがスペルミスの修正のみのため取り込み不要 