### PR TITLE
PHP 8.4: Document SplObjectStorage::seek() の翻訳

### DIFF
--- a/reference/spl/arrayiterator/seek.xml
+++ b/reference/spl/arrayiterator/seek.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d51166ca16fda8e766849505b84f9306ef443f71 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 434557c58ba28213b97f39bc7ca1e59dc8f6cae9 Maintainer: takagi Status: ready -->
 <!-- CREDITS: shimooka -->
 <refentry xml:id="arrayiterator.seek" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -15,7 +15,9 @@
    <methodparam><type>int</type><parameter>offset</parameter></methodparam>
   </methodsynopsis>
 
-  &warn.undocumented.func;
+  <simpara>
+   イテレータ内の指定した位置に移動します。
+  </simpara>
  </refsect1>
  
  <refsect1 role="parameters">
@@ -39,6 +41,14 @@
   <para>
    &return.void;
   </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   <parameter>offset</parameter> に移動できない場合は、
+   <classname>OutOfBoundsException</classname> をスローします。
+  </simpara>
  </refsect1>
 
 </refentry>

--- a/reference/spl/seekableiterator/seek.xml
+++ b/reference/spl/seekableiterator/seek.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d51166ca16fda8e766849505b84f9306ef443f71 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 434557c58ba28213b97f39bc7ca1e59dc8f6cae9 Maintainer: takagi Status: ready -->
 <refentry xml:id="seekableiterator.seek" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SeekableIterator::seek</refname>
@@ -44,10 +44,10 @@
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    <parameter>offset</parameter> に移動できない場合、
    <classname>OutOfBoundsException</classname> をスローするよう実装しなければなりません。
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/spl/seekableiterator/seek.xml
+++ b/reference/spl/seekableiterator/seek.xml
@@ -1,51 +1,51 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 <!-- EN-Revision: d51166ca16fda8e766849505b84f9306ef443f71 Maintainer: takagi Status: ready -->
-    <refentry xml:id="seekableiterator.seek" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
-     <refnamediv>
-      <refname>SeekableIterator::seek</refname>
-      <refpurpose>位置を移動する</refpurpose>
-     </refnamediv>
+<refentry xml:id="seekableiterator.seek" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>SeekableIterator::seek</refname>
+  <refpurpose>位置を移動する</refpurpose>
+ </refnamediv>
 
-     <refsect1 role="description">
-      &reftitle.description;
-      <methodsynopsis role="SeekableIterator">
-       <modifier>public</modifier> <type>void</type><methodname>SeekableIterator::seek</methodname>
-       <methodparam><type>int</type><parameter>offset</parameter></methodparam>
-      </methodsynopsis>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="SeekableIterator">
+   <modifier>public</modifier> <type>void</type><methodname>SeekableIterator::seek</methodname>
+   <methodparam><type>int</type><parameter>offset</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   イテレータ内の指定した位置に移動します。
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>offset</parameter></term>
+     <listitem>
       <para>
-       イテレータ内の指定した位置に移動します。
+       移動先の位置。
       </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
 
-     </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
 
-     <refsect1 role="parameters">
-      &reftitle.parameters;
-      <para>
-       <variablelist>
-        <varlistentry>
-         <term><parameter>offset</parameter></term>
-         <listitem>
-          <para>
-           移動先の位置。
-          </para>
-         </listitem>
-        </varlistentry>
-       </variablelist>
-      </para>
-     </refsect1>
-
-     <refsect1 role="returnvalues">
-      &reftitle.returnvalues;
-      <para>
-       &return.void;
-      </para>
-     </refsect1>
-
-     <refsect1 role="errors">
-      &reftitle.errors;
-      <para>
-       <parameter>offset</parameter> に移動できない場合、
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   <parameter>offset</parameter> に移動できない場合、
    <classname>OutOfBoundsException</classname> をスローするよう実装しなければなりません。
   </para>
  </refsect1>

--- a/reference/spl/splobjectstorage/seek.xml
+++ b/reference/spl/splobjectstorage/seek.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 434557c58ba28213b97f39bc7ca1e59dc8f6cae9 Maintainer: siwa32 Status: ready -->
+<!-- CREDITS: siwa32 -->
+<refentry xml:id="splobjectstorage.seek" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>SplObjectStorage::seek</refname>
+  <refpurpose>位置を移動する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="SplObjectStorage">
+   <modifier>public</modifier> <type>void</type><methodname>SplObjectStorage::seek</methodname>
+   <methodparam><type>int</type><parameter>offset</parameter></methodparam>
+  </methodsynopsis>
+
+  <simpara>
+   イテレータ内の指定した位置に移動します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>offset</parameter></term>
+    <listitem>
+     <simpara>
+      移動先の位置。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.void;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   <parameter>offset</parameter> に移動できない場合は、
+   <classname>OutOfBoundsException</classname> をスローします。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="splobjectstorage.seek.example.basic">
+   <title><methodname>SplObjectStorage::seek</methodname> の例</title>
+   <simpara>
+    イテレータの 2 番目の位置に移動します。
+   </simpara>
+   <programlisting role="php">
+<![CDATA[
+<?php
+class Test {
+    public function __construct(public string $marker) {}
+}
+
+$a = new Test("a");
+$b = new Test("b");
+$c = new Test("c");
+
+$storage = new SplObjectStorage();
+$storage[$a] = "first";
+$storage[$b] = "second";
+$storage[$c] = "third";
+
+$storage->seek(2);
+var_dump($storage->key());
+var_dump($storage->current());
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+int(2)
+object(Test)#3 (1) {
+  ["marker"]=>
+  string(1) "c"
+}
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><classname>SeekableIterator</classname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
refs #150 

php/doc-en#4048 を取り込みました。

- `seekableiterator/seek.xml` はインデントが崩れていたため合わせて修正
- `SplObjectStorage::seek` は `SeekableIterator::seek` を参考に翻訳