### PR TITLE
Fix mistranslation in preg-match.xml

### DIFF
--- a/reference/pcre/functions/preg-match.xml
+++ b/reference/pcre/functions/preg-match.xml
@@ -66,11 +66,10 @@
          <listitem>
           <para>
            このフラグを設定した場合、各マッチに対応する文字列のオフセットも(バイト単位で)返されます。
-           これは、<parameter>matches</parameter> の値を配列に変更することに注意してください。
-           その配列のすべての要素は、
-           オフセット <literal>0</literal> で一致した文字列、
-           およびその文字列のオフセット <literal>1</literal> での
-           <parameter>subject</parameter> へのオフセットからなります。
+           これは、<parameter>matches</parameter> の値を配列の配列に変更することに注意してください。
+           配列のすべての要素が、オフセット <literal>0</literal> に、一致した文字列、
+           オフセット <literal>1</literal> に、<parameter>subject</parameter> 内でのその文字列のオフセット
+           からなる配列になります。
            <informalexample>
             <programlisting role="php">
 <![CDATA[


### PR DESCRIPTION
matchesは元から配列なので「配列に変更」は不適切で、後半も誤訳していたのでそれらを修正。
原文：
> Note that this changes the value of matches into an array where every element is an array consisting of the matched string at offset 0 and its string offset into subject at offset 1.
> https://www.php.net/manual/en/function.preg-match.php