### PR TITLE
Update documentation of opcache.interned_strings_buffer の翻訳

### DIFF
--- a/reference/opcache/ini.xml
+++ b/reference/opcache/ini.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 7bdf6028aa9304cea1369e128b8b8e425faec032 Maintainer: satoruyoshida Status: ready -->
+<!-- EN-Revision: 0b7ba7f50bfefd540fefd257425a1a60718c6b75 Maintainer: satoruyoshida Status: ready -->
 <!-- CREDITS: mumumu -->
 <sect1 xml:id="opcache.configuration" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.runtime;
@@ -423,7 +423,15 @@
     <listitem>
      <para>
       インターン化 (intern) された文字列を格納するために使用されるメモリ量。（ MB 単位）
+      最大値は、64bit アーキテクチャでは 32767 であり、
+      32bit アーキテクチャでは 4095 です。
      </para>
+     <note>
+      <simpara>
+       PHP 8.4.0 より前のバージョンの最大値は、
+       すべてのアーキテクチャで 4095 MB でした。
+      </simpara>
+     </note>
     </listitem>
    </varlistentry>
    <varlistentry xml:id="ini.opcache.max-accelerated-files">


### PR DESCRIPTION
refs #150 

php/doc-en#4061 を取り込みました。

↑以降さらに修正（php/doc-en#4231）が入っていますが、PHP8.3に関するプルリクなので別で対応します。
