### PR TITLE
[PHP 8.3] opcache.preload_user is not required when run as rootを翻訳

### DIFF
--- a/reference/opcache/ini.xml
+++ b/reference/opcache/ini.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 0b7ba7f50bfefd540fefd257425a1a60718c6b75 Maintainer: satoruyoshida Status: ready -->
+<!-- EN-Revision: 33437fb390b792266f4bdae7a0797808a6d7b9d4 Maintainer: satoruyoshida Status: ready -->
 <!-- CREDITS: mumumu -->
 <sect1 xml:id="opcache.configuration" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.runtime;
@@ -954,6 +954,8 @@
       セキュリティ上の理由からデフォルトでは禁止されています。
       但し、このディレクティブに明示的に <literal>root</literal>
       を指定した場合は許可されます。
+      PHP 8.3.0 以降では、&cli.sapi; や <link linkend="book.phpdbg">phpdbg SAPI</link> から root で実行した場合、
+      root ユーザでの事前ロードを許可するために、このディレクティブを指定する必要はありません。 
      </para>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
php/doc-en#4231 を取り込みました。

#228 にて積み残したものになります。
