### PR TITLE
`&Alias;` の記述順が英語と日本語で入れ替わっていない箇所を全て修正

### DIFF
--- a/reference/datetime/constants.xml
+++ b/reference/datetime/constants.xml
@@ -195,7 +195,7 @@
    <listitem>
     <simpara>
      RSS (例: <literal>Mon, 15 Aug 2005 15:52:01 +0000</literal>).
-     &Alias; <constant>DATE_RFC1123</constant>.
+     <constant>DATE_RFC1123</constant> &Alias;.
     </simpara>
    </listitem>
   </varlistentry>
@@ -205,7 +205,7 @@
    <listitem>
     <simpara>
      World Wide Web Consortium (例: <literal>2005-08-15T15:52:01+00:00</literal>).
-     &Alias; <constant>DATE_RFC3339</constant>.
+     <constant>DATE_RFC3339</constant> &Alias;.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/enchant/functions/enchant-dict-add-to-personal.xml
+++ b/reference/enchant/functions/enchant-dict-add-to-personal.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="function.enchant-dict-add-to-personal" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>enchant_dict_add_to_personal</refname>
-  <refpurpose>&Alias; <function>enchant_dict_add</function></refpurpose>
+  <refpurpose><function>enchant_dict_add</function> &Alias;</refpurpose>
  </refnamediv>
 
  <refsynopsisdiv>

--- a/reference/enchant/functions/enchant-dict-is-in-session.xml
+++ b/reference/enchant/functions/enchant-dict-is-in-session.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="function.enchant-dict-is-in-session" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>enchant_dict_is_in_session</refname>
-  <refpurpose>&Alias; <function>enchant_dict_is_added</function></refpurpose>
+  <refpurpose><function>enchant_dict_is_added</function> &Alias;</refpurpose>
  </refnamediv>
 
  <refsynopsisdiv>

--- a/reference/exif/functions/read-exif-data.xml
+++ b/reference/exif/functions/read-exif-data.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="function.read-exif-data" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>read_exif_data</refname>
-  <refpurpose>&Alias; <function>exif_read_data</function></refpurpose>
+  <refpurpose><function>exif_read_data</function> &Alias;</refpurpose>
  </refnamediv>
 
  <refsynopsisdiv>

--- a/reference/gettext/functions/-.xml
+++ b/reference/gettext/functions/-.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="function.-" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>_</refname>
-  <refpurpose>&Alias; <function>gettext</function></refpurpose>
+  <refpurpose><function>gettext</function> &Alias;</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/ldap/constants.xml
+++ b/reference/ldap/constants.xml
@@ -1037,7 +1037,7 @@
    </term>
    <listitem>
     <simpara>
-     &Alias; <constant>LDAP_OPT_X_TLS_DEMAND</constant>.
+     <constant>LDAP_OPT_X_TLS_DEMAND</constant> &Alias;
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/ldap/functions/ldap-modify.xml
+++ b/reference/ldap/functions/ldap-modify.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="function.ldap-modify" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ldap_modify</refname>
-  <refpurpose>&Alias; <function>ldap_mod_replace</function></refpurpose>
+  <refpurpose><function>ldap_mod_replace</function> &Alias;</refpurpose>
  </refnamediv>
  
  <refsect1 role="description">

--- a/reference/oci8/ocilob/saveFile.xml
+++ b/reference/oci8/ocilob/saveFile.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="ocilob.savefile" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>OCILob::saveFile</refname>
-  <refpurpose>&Alias; <function>OCILob::import</function></refpurpose>
+  <refpurpose><function>OCILob::import</function> &Alias;</refpurpose>
  </refnamediv>
  
  <refsect1 role="description">

--- a/reference/oci8/ocilob/writeToFile.xml
+++ b/reference/oci8/ocilob/writeToFile.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="ocilob.writetofile" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>OCILob::writeToFile</refname>
-  <refpurpose>&Alias; <function>OCILob::export</function></refpurpose>
+  <refpurpose><function>OCILob::export</function> &Alias;</refpurpose>
  </refnamediv>
  
  <refsect1 role="description">

--- a/reference/oci8/oldaliases/ocicollappend.xml
+++ b/reference/oci8/oldaliases/ocicollappend.xml
@@ -4,12 +4,12 @@
 <refentry xml:id="function.ocicollappend" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ocicollappend</refname>
-  <refpurpose>&Alias; <function>OCICollection::append</function></refpurpose>
+  <refpurpose><function>OCICollection::append</function> &Alias;</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
-  <para>&Alias; <function>OCICollection::append</function></para>
+  <para><function>OCICollection::append</function> &Alias;</para>
   &warn.deprecated.alias-5-4-0;
  </refsect1>
 

--- a/reference/oci8/oldaliases/ocicollassign.xml
+++ b/reference/oci8/oldaliases/ocicollassign.xml
@@ -4,12 +4,12 @@
 <refentry xml:id="function.ocicollassign" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ocicollassign</refname>
-  <refpurpose>&Alias; <function>OCICollection::assign</function></refpurpose>
+  <refpurpose><function>OCICollection::assign</function> &Alias;</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
-  <para>&Alias; <function>OCICollection::assign</function></para>
+  <para><function>OCICollection::assign</function> &Alias;</para>
   &warn.deprecated.alias-5-4-0;
  </refsect1>
 

--- a/reference/oci8/oldaliases/ocicollassignelem.xml
+++ b/reference/oci8/oldaliases/ocicollassignelem.xml
@@ -4,12 +4,12 @@
 <refentry xml:id="function.ocicollassignelem" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ocicollassignelem</refname>
-  <refpurpose>&Alias; <function>OCICollection::assignElem</function></refpurpose>
+  <refpurpose><function>OCICollection::assignElem</function> &Alias;</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
-  <para>&Alias; <function>OCICollection::assignElem</function></para>
+  <para><function>OCICollection::assignElem</function> &Alias;</para>
   &warn.deprecated.alias-5-4-0;
  </refsect1>
 

--- a/reference/oci8/oldaliases/ocicollgetelem.xml
+++ b/reference/oci8/oldaliases/ocicollgetelem.xml
@@ -4,12 +4,12 @@
 <refentry xml:id="function.ocicollgetelem" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ocicollgetelem</refname>
-  <refpurpose>&Alias; <function>OCICollection::getElem</function></refpurpose>
+  <refpurpose><function>OCICollection::getElem</function> &Alias;</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
-  <para>&Alias; <function>OCICollection::getElem</function></para>
+  <para><function>OCICollection::getElem</function> &Alias;</para>
   &warn.deprecated.alias-5-4-0;
  </refsect1>
 

--- a/reference/oci8/oldaliases/ocicollmax.xml
+++ b/reference/oci8/oldaliases/ocicollmax.xml
@@ -4,12 +4,12 @@
 <refentry xml:id="function.ocicollmax" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ocicollmax</refname>
-  <refpurpose>&Alias; <function>OCICollection::max</function></refpurpose>
+  <refpurpose><function>OCICollection::max</function> &Alias;</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
-  <para>&Alias; <function>OCICollection::max</function></para>
+  <para><function>OCICollection::max</function> &Alias;</para>
   &warn.deprecated.alias-5-4-0;
  </refsect1>
 

--- a/reference/oci8/oldaliases/ocicollsize.xml
+++ b/reference/oci8/oldaliases/ocicollsize.xml
@@ -4,12 +4,12 @@
 <refentry xml:id="function.ocicollsize" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ocicollsize</refname>
-  <refpurpose>&Alias; <function>OCICollection::size</function></refpurpose>
+  <refpurpose><function>OCICollection::size</function> &Alias;</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
-  <para>&Alias; <function>OCICollection::size</function></para>
+  <para><function>OCICollection::size</function> &Alias;</para>
   &warn.deprecated.alias-5-4-0;
  </refsect1>
 

--- a/reference/oci8/oldaliases/ocicolltrim.xml
+++ b/reference/oci8/oldaliases/ocicolltrim.xml
@@ -4,12 +4,12 @@
 <refentry xml:id="function.ocicolltrim" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ocicolltrim</refname>
-  <refpurpose>&Alias; <function>OCICollection::trim</function></refpurpose>
+  <refpurpose><function>OCICollection::trim</function> &Alias;</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
-  <para>&Alias; <function>OCICollection::trim</function></para>
+  <para><function>OCICollection::trim</function> &Alias;</para>
   &warn.deprecated.alias-5-4-0;
  </refsect1>
 

--- a/reference/oci8/oldaliases/ocifreecollection.xml
+++ b/reference/oci8/oldaliases/ocifreecollection.xml
@@ -4,12 +4,12 @@
 <refentry xml:id="function.ocifreecollection" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ocifreecollection</refname>
-  <refpurpose>&Alias; <function>OCICollection::free</function></refpurpose>
+  <refpurpose><function>OCICollection::free</function> &Alias;</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
-  <para>&Alias; <function>OCICollection::free</function></para>
+  <para><function>OCICollection::free</function> &Alias;</para>
   &warn.deprecated.alias-5-4-0;
  </refsect1>
 

--- a/reference/pdo_pgsql/pdo_overloaded/pgsqlCopyToArray.xml
+++ b/reference/pdo_pgsql/pdo_overloaded/pgsqlCopyToArray.xml
@@ -5,7 +5,7 @@
  <refnamediv>
   <refname>PDO::pgsqlCopyToArray</refname>
   <refpurpose>
-   &Alias; <methodname>Pdo\Pgsql::copyToArray</methodname>
+   <methodname>Pdo\Pgsql::copyToArray</methodname> &Alias;
   </refpurpose>
  </refnamediv>
  <refsect1 role="description">

--- a/reference/pdo_pgsql/pdo_overloaded/pgsqlCopyToFile.xml
+++ b/reference/pdo_pgsql/pdo_overloaded/pgsqlCopyToFile.xml
@@ -5,7 +5,7 @@
  <refnamediv>
   <refname>PDO::pgsqlCopyToFile</refname>
   <refpurpose>
-   &Alias; <methodname>Pdo\Pgsql::copyToFile</methodname>
+   <methodname>Pdo\Pgsql::copyToFile</methodname> &Alias;
   </refpurpose>
  </refnamediv>
  <refsect1 role="description">

--- a/reference/pdo_pgsql/pdo_overloaded/pgsqlGetPid.xml
+++ b/reference/pdo_pgsql/pdo_overloaded/pgsqlGetPid.xml
@@ -5,7 +5,7 @@
  <refnamediv>
   <refname>PDO::pgsqlGetPid</refname>
   <refpurpose>
-   &Alias; <methodname>Pdo\Pgsql::getPid</methodname>
+   <methodname>Pdo\Pgsql::getPid</methodname> &Alias;
   </refpurpose>
  </refnamediv>
  <refsect1 role="description">

--- a/reference/reflection/reflectionclass/isiterateable.xml
+++ b/reference/reflection/reflectionclass/isiterateable.xml
@@ -6,12 +6,12 @@
 <refentry xml:id="reflectionclass.isiterateable" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ReflectionClass::isIterateable</refname>
-  <refpurpose>&Alias; <methodname>ReflectionClass::isIterable</methodname></refpurpose>
+  <refpurpose><methodname>ReflectionClass::isIterable</methodname> &Alias;</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
-  <para>&Alias; <methodname>ReflectionClass::isIterable</methodname></para>
+  <para><methodname>ReflectionClass::isIterable</methodname> &Alias;</para>
   <para>
    PHP 7.2.0 以降は、スペルミスがある <methodname>RefectionClass::isIterateable</methodname>
    の代わりに、 <methodname>ReflectionClass::isIterable</methodname>  を使うのが好ましいです。

--- a/reference/stream/constants.xml
+++ b/reference/stream/constants.xml
@@ -429,7 +429,7 @@
    </term>
    <listitem>
     <simpara>
-     &Alias; <constant>STREAM_CRYPTO_METHOD_SSLv3_SERVER</constant>.
+     <constant>STREAM_CRYPTO_METHOD_SSLv3_SERVER</constant> &Alias;
     </simpara>
    </listitem>
   </varlistentry>
@@ -440,7 +440,7 @@
    </term>
    <listitem>
     <simpara>
-     &Alias; <constant>STREAM_CRYPTO_METHOD_TLSv1_0_SERVER</constant>.
+     <constant>STREAM_CRYPTO_METHOD_TLSv1_0_SERVER</constant> &Alias;
     </simpara>
    </listitem>
   </varlistentry>
@@ -451,7 +451,7 @@
    </term>
    <listitem>
     <simpara>
-     &Alias; <constant>STREAM_CRYPTO_METHOD_TLSv1_1_SERVER</constant>.
+     <constant>STREAM_CRYPTO_METHOD_TLSv1_1_SERVER</constant> &Alias;
     </simpara>
    </listitem>
   </varlistentry>
@@ -462,7 +462,7 @@
    </term>
    <listitem>
     <simpara>
-     &Alias; <constant>STREAM_CRYPTO_METHOD_TLSv1_2_SERVER</constant>.
+     <constant>STREAM_CRYPTO_METHOD_TLSv1_2_SERVER</constant> &Alias;
     </simpara>
    </listitem>
   </varlistentry>
@@ -473,7 +473,7 @@
    </term>
    <listitem>
     <simpara>
-     &Alias; <constant>STREAM_CRYPTO_METHOD_TLSv1_3_SERVER</constant>.
+     <constant>STREAM_CRYPTO_METHOD_TLSv1_3_SERVER</constant> &Alias;
     </simpara>
    </listitem>
   </varlistentry>


### PR DESCRIPTION
## 参照の定義

* en:
  ```xml
  <!ENTITY Alias "Alias of">
  ```
* ja:
  ```xml
  <!ENTITY Alias "のエイリアス">
  ```

## 修正内容

以上の定義のため `&Alias;` は原文では前置されるが日本語訳では後置に直す必要がある。`&Alias; ` と末尾にホワイトスペースを入れて検索し特定した対象を全て修正。この検索条件でヒットしない箇所で要修正が残っている可能性あり。
