### PR TITLE
[PHP 8.4] Mention PHP_HISTFILE env var の翻訳

### DIFF
--- a/features/commandline.xml
+++ b/features/commandline.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: eee245cdbd89dc2fd908285f588e3b9e055924e5 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4b4292baf79bb650763e8230dbb254ee59d5ce80 Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa,shimooka,mumumu -->
 <chapter xml:id="features.commandline" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>PHP をコマンドラインから使用する</title>
@@ -1510,10 +1510,12 @@ php > $foo[TAB]ThisIsAReallyLongVariableName
    </programlisting>
   </example>
 
-  <para>
+  <simpara>
    対話シェル上では操作履歴が保存され、上矢印キーと下矢印キーで履歴にアクセスすることができます。
    履歴の保存先は <filename>~/.php_history</filename> ファイルです。
-  </para>
+   PHP 8.4.0 以降では、環境変数 <envar>PHP_HISTFILE</envar> を使って
+   履歴ファイルのパスを設定できます。
+  </simpara>
 
   <para>
    &cli.sapi; では、二つの


### PR DESCRIPTION
ref: #150 

以下の英語版の更新を取り込み、翻訳しました。

* https://github.com/php/doc-en/pull/4262

こちらの文言の追加です。

> ```
> As of PHP 8.4.0, the path to the history file can be set using the
> <envar>PHP_HISTFILE</envar> environment variable.
> ```