### PR TITLE
[PHP 8.4] Update Closure::__debugInfo() changelog の取り込み

### DIFF
--- a/language/predefined/closure.xml
+++ b/language/predefined/closure.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: da5ebdf7e0b710ac4f20b53f7c09cf9fa1346d3e Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <reference xml:id="class.closure" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -53,6 +53,29 @@
    </classsynopsis>
 <!-- }}} -->
 
+  </section>
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        <methodname>Closure::__debugInfo</methodname> の出力に、
+        クロージャーの名前、行、ファイルを含むようになりました。
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>


### PR DESCRIPTION
refs #150 

https://github.com/php/doc-en/pull/4257
こちらを取り込みました。
