### PR TITLE
pattern.syntax.xml: extra spaces have been removed and... を取り込み

### DIFF
--- a/reference/pcre/pattern.syntax.xml
+++ b/reference/pcre/pattern.syntax.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 <!-- splitted from ./ja/functions/pcre.xml, last change in rev 1.1 -->
-<!-- EN-Revision: 587830d5d261802148a160a59059dd8d76385fd2 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 77fe733a1ba9c961424adcb7c9af00c1f5443a77 Maintainer: takagi Status: ready -->
 <!-- Credits: haruki,hirokawa,mumumu -->
 <chapter xml:id="reference.pcre.pattern.syntax" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>パターン構文</title>
@@ -1423,7 +1423,7 @@
 
       <literal>(a(?i)b)c</literal>
 
-      は、abc および aBc にマッチし、他の文字列にはマッチしません
+      は、"abc" および "aBc" にマッチし、他の文字列にはマッチしません
       （<link linkend="reference.pcre.pattern.modifiers">PCRE_CASELESS</link> 
       が設定されていないと仮定）。このように、パターンの各場所に
       異なった設定を行うようなオプション指定が可能です。


### PR DESCRIPTION
refs: https://github.com/php/doc-en/pull/3275

こちらの英語版 PR の変更を取り込みました。XML 上での連続した空白の除去と改行の挿入がほとんどで、テキストへの変更点は以下リンク先強調部分のクォート挿入のみです。

https://github.com/php/doc-en/pull/3275/files?diff=unified&w=1#diff-f4d370b049b74c4b90bd2841403e305f5d8396e364003aa00368934ad4a88948L1390-R1393

上記リンクのように空白の差分表示を無効化した状態で確認をおこないました。