### PR TITLE
[PHP 8.4] posix_isatty update を取り込み

### DIFF
--- a/reference/posix/functions/posix-isatty.xml
+++ b/reference/posix/functions/posix-isatty.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9c166423255b3d5e02f74232f2d05fd3b59d5d62 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 394815225713c1aad0007d80f2c3c3592d085084 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi,mumumu -->
 <refentry xml:id="function.posix-isatty" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -49,6 +49,13 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       渡されたファイル記述子やストリームが無効な場合、
+       errno (エラー番号) に <constant>EBADF</constant> を設定するようになりました。
+      </entry>
+     </row>
      <row>
       <entry>8.3.0</entry>
       <entry>


### PR DESCRIPTION
refs https://github.com/php/doc-en/pull/4220 https://github.com/php/doc-ja/issues/150

`posix_isatty` に関する変更 https://github.com/php/doc-en/pull/4220 を取り込みました。PHP 8.4 で追加された仕様の追加です。