### PR TITLE
[PHP 8.3] Mention E_WARNING on unconsumed input data を取り込み

### DIFF
--- a/reference/var/functions/unserialize.xml
+++ b/reference/var/functions/unserialize.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4150dc92749c177758efe59eab23b6a5d32ffda2 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 3dbbc167de33c0214f454b1d0399a32c88127c10 Maintainer: hirokawa Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="function.unserialize" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -163,6 +163,12 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.3.0</entry>
+       <entry>
+        入力された文字列の末尾に余計なデータがある場合、<constant>E_WARNING</constant> が発生するようになりました。
+       </entry>
+      </row>
       <row>
        <entry>8.3.0</entry>
        <entry>


### PR DESCRIPTION
refs https://github.com/php/doc-en/pull/4174

注: PHP 8.4 ではなく **8.3** の更新です。

PHP 8.3 での `unserialize()` の仕様変更を取り込みました。

# "when the input string has unconsumed data" の訳について

この PR では、やや言葉を補って「入力された文字列の末尾に余計なデータがある場合」としました。

"unconsumed" は直訳すれば「未消費の」となりますが、構文解析などの文脈で入力を「消費する」という言い回しは、やや専門的で馴染みがないかもしれないと思い言い換えています。

## 検討した他の選択肢

* 「入力された文字列に未消費のデータがある場合」
* 「入力された文字列に未処理のデータがある場合」
* 「入力された文字列にデータが残っている場合」
* 「入力された文字列に余計なデータがある場合」