### PR TITLE
"Tentative return type" の訳語を統一

### DIFF
--- a/reference/dom/domdocument/registernodeclass.xml
+++ b/reference/dom/domdocument/registernodeclass.xml
@@ -77,8 +77,8 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       <methodname>DOMDocument::registerNodeClass</methodname> メソッドは、
-       現在暫定的に <type>true</type> を返すようになりました。
+       <methodname>DOMDocument::registerNodeClass</methodname> の
+       仮の戻り値の型が、<type>true</type> になりました。
       </entry>
      </row>
     </tbody>

--- a/reference/phar/Phar/setAlias.xml
+++ b/reference/phar/Phar/setAlias.xml
@@ -75,8 +75,8 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       <methodname>Phar::setAlias</methodname> は、
-       現在暫定的に <type>true</type> を返すようになりました。
+       <methodname>Phar::setAlias</methodname> の
+       仮の戻り値の型が、<type>true</type> になりました。
       </entry>
      </row>
     </tbody>

--- a/reference/phar/Phar/setDefaultStub.xml
+++ b/reference/phar/Phar/setDefaultStub.xml
@@ -79,8 +79,8 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       <methodname>Phar::setDefaultStub</methodname> は、
-       現在暫定的に <type>true</type> を返すようになりました。
+       <methodname>Phar::setDefaultStub</methodname> の
+       仮の戻り値の型が、<type>true</type> になりました。
       </entry>
      </row>
      <row>

--- a/reference/spl/splfixedarray/setsize.xml
+++ b/reference/spl/splfixedarray/setsize.xml
@@ -68,8 +68,8 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       <methodname>SplFixedArray::setSize</methodname> は
-       現在、暫定的に <type>true</type> を返しています。
+       <methodname>SplFixedArray::setSize</methodname> の
+       仮の戻り値の型が、<type>true</type> になりました。
       </entry>
      </row>
     </tbody>

--- a/reference/spl/splheap/insert.xml
+++ b/reference/spl/splheap/insert.xml
@@ -56,8 +56,8 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       <methodname>SplHeap::insert</methodname> は
-       現在、暫定的に <type>true</type> を返しています。
+       <methodname>SplHeap::insert</methodname> の
+       仮の戻り値の型が、<type>true</type> になりました。
       </entry>
      </row>
     </tbody>

--- a/reference/spl/splheap/recoverfromcorruption.xml
+++ b/reference/spl/splheap/recoverfromcorruption.xml
@@ -41,8 +41,8 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       <methodname>SplHeap::recoverFromCorruption</methodname> は
-       現在、暫定的に <type>true</type> を返しています。
+       <methodname>SplHeap::recoverFromCorruption</methodname> の
+       仮の戻り値の型が、<type>true</type> になりました。
       </entry>
      </row>
     </tbody>

--- a/reference/spl/splpriorityqueue/insert.xml
+++ b/reference/spl/splpriorityqueue/insert.xml
@@ -65,8 +65,8 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       <methodname>SplPriorityQueue::insert</methodname> は
-       現在、暫定的に <type>true</type> を返しています。
+       <methodname>SplPriorityQueue::insert</methodname> の
+       仮の戻り値の型が、<type>true</type> になりました。
       </entry>
      </row>
     </tbody>

--- a/reference/spl/splpriorityqueue/recoverfromcorruption.xml
+++ b/reference/spl/splpriorityqueue/recoverfromcorruption.xml
@@ -41,8 +41,8 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       <methodname>SplPriorityQueue::recoverFromCorruption</methodname> は
-       現在、暫定的に <type>true</type> を返しています。
+       <methodname>SplPriorityQueue::recoverFromCorruption</methodname> の
+       仮の戻り値の型が、<type>true</type> になりました。
       </entry>
      </row>
     </tbody>


### PR DESCRIPTION
# 概要

更新履歴などに書かれる "A now has a tentative return of B." という定型文の訳を、「A の仮の戻り値の型が、B になりました。」に統一しました。

# 訳語選択の根拠

この文章の訳には、3通りの定型文が存在しました。

* 「A の仮の戻り値の型が、B になりました。」
* 「A は、現在暫定的に B を返すようになりました。」
* 「A は現在、暫定的に B を返しています。」

[ReflectionFunctionAbstract::getTentativeReturnType()](https://www.php.net/manual/ja/reflectionfunctionabstract.gettentativereturntype.php) や [ReflectionFunctionAbstract::hasTentativeReturnType()](https://www.php.net/manual/ja/reflectionfunctionabstract.hastentativereturntype.php) での訳語が「仮の戻り値」になっていることから、1番目の文へと統一するのが適切と判断しました。

また、ここでいう "tentative" は、「C で実装された内部関数なので PHP レベルで型宣言がされているわけではないのだが、PHP から見たときの仮の型として一応宣言だけはされている」というような意味で用いられているので、正確さという観点でも1番目の文が適切と考えます。

参考: https://www.php.net/manual/ja/language.oop5.inheritance.php#language.oop5.inheritance.internal-classes