### PR TITLE
Update requirements for minimal OpenSSL version を取り込み

### DIFF
--- a/reference/openssl/setup.xml
+++ b/reference/openssl/setup.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d5da0808c4d6343eb8f0099307d3139102a6f4bf Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 3fa666ce023c7f5005cae5c3bf4fbef2b47ef9d1 Maintainer: takagi Status: ready -->
 <!-- CREDITS: shimooka,hirokawa,mumumu -->
 
 <chapter xml:id="openssl.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -15,6 +15,7 @@
    PHP 7.0 の場合、OpenSSL &gt;= 0.9.8 かつ &lt; 1.2 が必要です。
    PHP 7.1-8.0 の場合、OpenSSL &gt;= 1.0.1 かつ &lt; 3.0 が必要です。
    PHP &gt;= 8.1 の場合、OpenSSL &gt;= 1.0.2 かつ &lt; 4.0 が必要です。
+   PHP &gt;= 8.4 の場合、OpenSSL &gt;= 1.1.1 かつ &lt; 4.0 が必要です。
   </para>
   <warning>
    <para>


### PR DESCRIPTION
refs https://github.com/php/doc-ja/issues/150

https://github.com/php/doc-en/pull/4318 を取り込みました。PHP 8.4 で OpenSSL の要求バージョンが上がったことによる更新です。