### PR TITLE
unserialize() の更新を取り込み

### DIFF
--- a/reference/var/functions/unserialize.xml
+++ b/reference/var/functions/unserialize.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 42bb18bcfef4f715008d00bbdc7ea5203f8ec30a Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: d75036c386e37ce56dafb7607b72aedc3e33fe09 Maintainer: hirokawa Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="function.unserialize" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -164,6 +164,12 @@
     <tgroup cols="2">
      <thead>
       <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
        <entry>8.4.0</entry>
        <entry>
         <parameter>options</parameter> の <literal>allowed_classes</literal> 要素が
@@ -172,12 +178,6 @@
         スローするようになりました。
        </entry>
       </row>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
       <row>
        <entry>8.3.0</entry>
        <entry>

--- a/reference/var/functions/unserialize.xml
+++ b/reference/var/functions/unserialize.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 3dbbc167de33c0214f454b1d0399a32c88127c10 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 792c392854b954fc5626c1ac194d516312e51f43 Maintainer: hirokawa Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="function.unserialize" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -145,10 +145,16 @@
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    オブジェクトは、
    アンシリアライズを実行するハンドラで <classname>Throwable</classname> をスローしても構いません。
-  </para>
+  </simpara>
+  <simpara>
+   PHP 8.4.0 以降では、<parameter>options</parameter> の <literal>allowed_classes</literal> 要素が
+   クラス名の <type>array</type> でない場合、
+   <function>unserialize</function> は <exceptionname>TypeError</exceptionname> と
+   <exceptionname>ValueError</exceptionname> をスローします。
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -157,6 +163,15 @@
    <informaltable>
     <tgroup cols="2">
      <thead>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        <parameter>options</parameter> の <literal>allowed_classes</literal> 要素が
+        クラス名の <type>array</type> でない場合、
+        <exceptionname>TypeError</exceptionname> と <exceptionname>ValueError</exceptionname> を
+        スローするようになりました。
+       </entry>
+      </row>
       <row>
        <entry>&Version;</entry>
        <entry>&Description;</entry>

--- a/reference/var/functions/unserialize.xml
+++ b/reference/var/functions/unserialize.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 792c392854b954fc5626c1ac194d516312e51f43 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 42bb18bcfef4f715008d00bbdc7ea5203f8ec30a Maintainer: hirokawa Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="function.unserialize" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -90,7 +90,7 @@
         <tbody>
          <row>
           <entry><literal>allowed_classes</literal></entry>
-          <entry><type>mixed</type></entry>
+          <entry><type>array|bool</type></entry>
           <entry>
            <simpara>
             受け付けるクラス名の配列を指定します。あらゆるクラスを拒否する場合は


### PR DESCRIPTION
refs https://github.com/php/doc-ja/issues/150

# 変更点

`unserialize()` 関数のマニュアルに現在までに出された変更をすべて取り込みました。

https://github.com/php/doc-en/commits/master/reference/var/functions/unserialize.xml

* https://github.com/php/doc-en/pull/4260
* https://github.com/php/doc-en/pull/4328
    * この PR に対しては何もしていません。もとの PR は余計なカッコがあるというものでしたが、日本語版には以前から存在しなかったためです。
* https://github.com/php/doc-en/pull/4333
* https://github.com/php/doc-en/pull/4383

各コミットが各 PR に対応しています (除 4328)。


# 備考

> `TypeError` と `ValueError` をスローするようになりました。

について、同時に複数種類の例外をスローするはずはないので意味を取るために php-src を調べたところ、 `$options['allowed_classes']` の各要素が `string` でないときに `TypeError` を、その文字列がクラス名として不正なとき (`\n` が含まれている等) に `ValueError` をスローするという動作のようです。

これを考えると、

> `TypeError` や `ValueError` をスローするようになりました。

のように説明したほうがよいとは思うのですが、どちらかというと "and" でなく "or" を使うように原文側を直すべきだと思ったので、この PR ではそのまま「`TypeError` と `ValueError`」と訳すことにしました。