### PR TITLE
[PHP 8.4] PCRE - PCRE2-v10.44 updates を取り込み

### DIFF
--- a/reference/pcre/pattern.modifiers.xml
+++ b/reference/pcre/pattern.modifiers.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 288ea761f5a8e7c685fe7f6fce2d7de0a87b31bd Maintainer: takagi Status: ready -->
+<!-- EN-Revision: c43393d1b64a41be1b8c45f997062b0f645bc91e Maintainer: takagi Status: ready -->
 <!-- Credits: hirokawa,haruki,mumumu -->
 <article xml:id="reference.pcre.pattern.modifiers" xmlns="http://docbook.org/ns/docbook">
  <title>パターン修飾子</title>
@@ -178,6 +178,22 @@
           番号付きのサブパターンによる参照もまだ使えますし、
           その場合マッチ結果が格納される配列には数値が含まれています。
           PHP 8.2.0 以降で利用可能です。
+         </simpara>
+        </listitem>
+       </varlistentry>
+       <varlistentry>
+        <term><emphasis>r</emphasis> (<literal>PCRE2_EXTRA_CASELESS_RESTRICT</literal>)</term>
+        <listitem>
+         <simpara>
+          <emphasis>u</emphasis> (<literal>PCRE_UTF8</literal>) と <emphasis>i</emphasis> (<literal>PCRE_CASELESS</literal>) が
+          有効なとき、この修飾子を使うと ASCII 文字と非 ASCII 文字同士がマッチしなくなります。
+         </simpara>
+         <simpara>
+          例えば、<code>preg_match('/\x{212A}/iu', "K")</code> はケルビン記号 <literal>K</literal> (U+212A) にマッチします。
+          <emphasis>r</emphasis> を使うと (<code>preg_match('/\x{212A}/iur', "K")</code>)、マッチしなくなります。
+         </simpara>
+         <simpara>
+          PHP 8.4.0 以降で利用可能です。
          </simpara>
         </listitem>
        </varlistentry>

--- a/reference/pcre/pattern.syntax.xml
+++ b/reference/pcre/pattern.syntax.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 <!-- splitted from ./ja/functions/pcre.xml, last change in rev 1.1 -->
-<!-- EN-Revision: 77fe733a1ba9c961424adcb7c9af00c1f5443a77 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: c43393d1b64a41be1b8c45f997062b0f645bc91e Maintainer: takagi Status: ready -->
 <!-- Credits: haruki,hirokawa,mumumu -->
 <chapter xml:id="reference.pcre.pattern.syntax" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>パターン構文</title>
@@ -1621,11 +1621,23 @@
       \d{8}
       </literallayout>
 
-     は、ぴったり 8 桁の数字にのみマッチします。開き波カッコは、
+     は、ぴったり 8 桁の数字にのみマッチします。
+
+    </para>
+    <simpara>
+     PHP 8.4.0 より前のバージョンでは、開き波カッコは、
      量指定子を置けない場所、つまり量指定子の構文に適合しない場所に
      記述された場合、文字リテラルとして解釈されます。例えば、
-     {,6} は量指定子ではなく、4つの文字からなる文字リテラルとなります。
-    </para>
+     <literal>{,6}</literal> は量指定子ではなく、4つの文字からなる文字列リテラルとなります。
+
+     PHP 8.4.0 以降では、PCRE 拡張モジュールに PCRE2 ライブラリのバージョン 10.44 がバンドルされています。
+     このバージョンでは <literal>\d{,8}</literal> のようなパターンが書けるようになり、
+     <literal>\d{0,8}</literal> と同じ意味になります。
+
+     更に、PHP 8.4.0 以降では、
+     <literal>\d{0 , 8}</literal> や <literal>\d{ 0 , 8 }</literal> のように
+     量指定子の開き波カッコの周りに空白文字を入れることができます。
+    </simpara>
     <para>
      {0} という量指定子の指定も可能です。
      直前の項目および量指定子が存在しないという指定になります。


### PR DESCRIPTION
refs https://github.com/php/doc-ja/issues/150

https://github.com/php/doc-en/pull/4078 を取り込みました。

* `reference/pcre/pattern.modifiers.xml`: `r` フラグの追加
* `reference/pcre/pattern.syntax.xml`: PCRE2 のバージョン更新に伴う量指定子の文法の変化