### PR TITLE
Document argon2 installation with OpenSSL in PHP 8.4 を取り込み

### DIFF
--- a/reference/password/setup.xml
+++ b/reference/password/setup.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 48ce43fe79fa0c9f31f187ea8ec995b4cb13037e Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 39b10b2e994f5a39f5face56c5e86ea8507a45a3 Maintainer: takagi Status: ready -->
 
 <chapter xml:id="password.setup" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.setup;
@@ -9,9 +9,10 @@
   &reftitle.required;
   &no.requirement;
   <para>
-   ただし、Argon2 パスワードハッシュの場合、<link
-   xlink:href="&url.libargon2;">libargon2</link> が必要です。
-   PHP 7.3.0 以降では、libargon2 バージョン 20161029 以降が必要です。
+   Argon2 パスワードハッシュには、
+   <link xlink:href="&url.libargon2;">libargon2</link> が必要です。
+   PHP 8.4.0 以降では、libargon2 の代わりに OpenSSL のバージョン 3.2 以降を使うこともできます。
+   libargon2 を使う場合、PHP 7.3.0 以降では libargon2 バージョン 20161029 以降が必要になります。
   </para>
  </section>
 
@@ -19,9 +20,12 @@
   &reftitle.install;
   &no.install;
   <para>
-   ただし、Argon2 パスワードハッシュを有効にするには、<option
-   role="configure">--with-password-argon2</option> オプションを使用して、
+   ただし、Argon2 パスワードハッシュを有効にするには、
+   <option role="configure">--with-password-argon2</option> オプションを使用し
    libargon2 のサポートを有効にして PHP をビルドする必要があります。
+   PHP 8.4.0 以降で libargon2 の代わりに OpenSSL を使う場合、
+   <option role="configure">--with-openssl</option> オプションを使用し
+   OpenSSL を有効にして PHP をビルドする必要があります。
   </para>
   <para>
    PHP 8.1.0 より前のバージョンでは、


### PR DESCRIPTION
refs https://github.com/php/doc-ja/issues/150

https://github.com/php/doc-en/pull/4272 を取り込みました。パスワードのハッシュアルゴリズムに Argon2 を使いたい場合に、PHP をどのようにビルドすればよいかが変わったようです。

# 翻訳

英文では "as of PHP 8.4.0" のような節がカンマ区切りで割り込んできていますが、日本語でこれを再現すると非常に読みづらいので、いくつか言葉を補った上で文を区切っています。

> For Argon2 password hashing, either `libargon2` is required or, as of PHP 8.4.0, OpenSSL version 3.2 or later.

→ Argon2 パスワードハッシュには、`libargon2` が必要です。PHP 8.4.0 以降では、libargon2 の代わりに OpenSSL のバージョン 3.2 以降を使うこともできます。

> As of PHP 7.3.0, libargon2 version 20161029 or later is required if libargon2 is used.

→ libargon2 を使う場合、PHP 7.3.0 以降では libargon2 バージョン 20161029 以降が必要になります。

> However, to enable Argon2 password hashing, PHP must be built either with libargon2 support using the `--with-password-argon2` configure option or, starting from PHP 8.4.0, with OpenSSL using `--with-openssl`.

→ ただし、Argon2 パスワードハッシュを有効にするには、`--with-password-argon2` オプションを使用し libargon2 のサポートを有効にして PHP をビルドする必要があります。PHP 8.4.0 以降で libargon2 の代わりに OpenSSL を使う場合、`--with-openssl` オプションを使用し OpenSSL を有効にして PHP をビルドする必要があります。