### PR TITLE
PHP 8.4: CSV related changes and deprecations の翻訳

### DIFF
--- a/reference/filesystem/functions/fgetcsv.xml
+++ b/reference/filesystem/functions/fgetcsv.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 73007ad9889ca2a3d85b0a710b55deb44ac370cc Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 2474b979c1a9cd8b6f48445edf634c3d21c29fb2 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: shimooka,mumumu -->
 <refentry xml:id="function.fgetcsv" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -70,7 +70,8 @@
      <term><parameter>separator</parameter></term>
      <listitem>
       <para>
-       オプションの <parameter>separator</parameter> パラメータで、フィールドのデリミタ (シングルバイト文字 1 文字のみ) を設定します。
+       <parameter>separator</parameter> パラメータで、フィールドのデリミタを設定します。
+       シングルバイト文字 1 文字のみでなければなりません。
       </para>
      </listitem>
     </varlistentry>
@@ -78,7 +79,8 @@
      <term><parameter>enclosure</parameter></term>
      <listitem>
       <para>
-       オプションの <parameter>enclosure</parameter> パラメータで、フィールド囲いこみ文字 (シングルバイト文字 1 文字のみ) を設定します。
+       オプションの <parameter>enclosure</parameter> パラメータで、フィールド囲いこみ文字を設定します。
+       シングルバイト文字 1 文字のみでなければなりません。
       </para>
      </listitem>
     </varlistentry>
@@ -86,7 +88,8 @@
      <term><parameter>escape</parameter></term>
      <listitem>
       <para>
-       オプションの <parameter>escape</parameter> パラメータで、エスケープ文字 (シングルバイト文字 最大で1文字) を設定します。
+       オプションの <parameter>escape</parameter> パラメータで、エスケープ文字を設定します。
+       シングルバイト文字 1 文字のみ、または空文字列でなければなりません。
        空文字列(<literal>""</literal>) を指定すると、(RFC 4180 に準拠していない) 独自仕様のエスケープ機構が無効になります。
       </para>
       <note>

--- a/reference/filesystem/functions/fgetcsv.xml
+++ b/reference/filesystem/functions/fgetcsv.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: cef78b0fbe0fbe02003699b027ab50200097e949 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 73007ad9889ca2a3d85b0a710b55deb44ac370cc Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: shimooka,mumumu -->
 <refentry xml:id="function.fgetcsv" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -25,11 +25,12 @@
    読み込んだフィールドを含む配列を返すという違いがあります。
   </para>
   <note>
-   <para>
-    この関数はロケール設定を考慮します。もし <constant>LC_CTYPE</constant>
-    が例えば <literal>en_US.UTF-8</literal> の場合、
-    1 バイトエンコーディングのファイルは間違って読み込まれるかもしれません。
-   </para>
+   <simpara>
+    この関数はロケール設定を考慮します。
+    例えば、<constant>LC_CTYPE</constant> が <literal>en_US.UTF-8</literal> の場合、
+    1 バイトエンコーディングでエンコードされたデータが
+    間違って処理されるかもしれません。
+   </simpara>
   </note>
  </refsect1>
 
@@ -100,6 +101,14 @@
         特別な意味はありません。それ自身をエスケープする意味ですらありません。
        </simpara>
       </note>
+      <warning>
+       <simpara>
+        PHP 8.4.0 以降では、<parameter>escape</parameter>
+        のデフォルト値に依存することは非推奨となりました。
+        位置指定の引数か、<link linkend="functions.named-arguments">名前付き引数</link>
+        を使用して明示的に指定する必要があります。
+       </simpara>
+      </warning>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -123,6 +132,18 @@
   &note.line-endings;
  </refsect1>
 
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   <parameter>separator</parameter> または <parameter>enclosure</parameter> が
+   1 バイト長ではない場合、<exceptionname>ValueError</exceptionname> をスローします。
+  </simpara>
+  <simpara>
+   <parameter>escape</parameter> が 1 バイト長、または空文字列ではない場合、
+   <exceptionname>ValueError</exceptionname> をスローします。
+  </simpara>
+ </refsect1>
+
  <refsect1 role="changelog">
   &reftitle.changelog;
   <para>
@@ -135,6 +156,13 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        <parameter>escape</parameter> のデフォルト値に依存することは、
+        非推奨になりました。
+       </entry>
+      </row>
       <row>
        <entry>8.0.0</entry>
        <entry>
@@ -184,15 +212,17 @@ if (($handle = fopen("test.csv", "r")) !== FALSE) {
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>str_getcsv</function></member>
-    <member><function>explode</function></member>
-    <member><function>file</function></member>
-    <member><function>pack</function></member>
-    <member><function>fputcsv</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>fputcsv</function></member>
+   <member><function>str_getcsv</function></member>
+   <member><methodname>SplFileObject::fgetcsv</methodname></member>
+   <member><methodname>SplFileObject::fputcsv</methodname></member>
+   <member><methodname>SplFileObject::setCsvControl</methodname></member>
+   <member><methodname>SplFileObject::getCsvControl</methodname></member>
+   <member><function>explode</function></member>
+   <member><function>file</function></member>
+   <member><function>pack</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/filesystem/functions/fgetcsv.xml
+++ b/reference/filesystem/functions/fgetcsv.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 2474b979c1a9cd8b6f48445edf634c3d21c29fb2 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 781f2ec04ee8817687e5e333bc3e64ab973322d7 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: shimooka,mumumu -->
 <refentry xml:id="function.fgetcsv" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -164,6 +164,14 @@
        <entry>
         <parameter>escape</parameter> のデフォルト値に依存することは、
         非推奨になりました。
+       </entry>
+      </row>
+      <row>
+       <entry>8.3.0</entry>
+       <entry>
+        最後のフィールドが、
+        閉じられていないフィールド囲いこみ文字だけの場合、
+        null バイト 1 つの文字列ではなく、空文字列を返すようになりました。
        </entry>
       </row>
       <row>

--- a/reference/filesystem/functions/fputcsv.xml
+++ b/reference/filesystem/functions/fputcsv.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 73007ad9889ca2a3d85b0a710b55deb44ac370cc Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 898627b9fec5baa51de18adefb9c584369f25aea Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="function.fputcsv" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>
@@ -129,16 +129,16 @@
 <![CDATA[
 <?php
 
-$list = array (
-    array('aaa', 'bbb', 'ccc', 'dddd'),
-    array('123', '456', '789'),
-    array('"aaa"', '"bbb"')
-);
+$list = [
+    ['aaa', 'bbb', 'ccc', 'dddd'],
+    ['123', '456', '789'],
+    ['"aaa"', '"bbb"']
+];
 
 $fp = fopen('file.csv', 'w');
 
 foreach ($list as $fields) {
-    fputcsv($fp, $fields);
+    fputcsv($fp, $fields, ',', '"', '');
 }
 
 fclose($fp);

--- a/reference/filesystem/functions/fputcsv.xml
+++ b/reference/filesystem/functions/fputcsv.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: cef78b0fbe0fbe02003699b027ab50200097e949 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 73007ad9889ca2a3d85b0a710b55deb44ac370cc Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
-<refentry xml:id="function.fputcsv" xmlns="http://docbook.org/ns/docbook">
+<refentry xml:id="function.fputcsv" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>
   <refname>fputcsv</refname>
   <refpurpose>行を CSV 形式にフォーマットし、ファイルポインタに書き込む</refpurpose>
@@ -21,9 +21,9 @@
   </methodsynopsis>
   <para>
    <function>fputcsv</function> は、行（<parameter>fields</parameter>
-   配列として渡されたもの）を CSV としてフォーマットし、それを
-   <parameter>stream</parameter> で指定したファイルに書き込みます
-   (いちばん最後に改行を追加します)。
+   配列として渡されたもの）を <acronym>CSV</acronym> としてフォーマットし、それを、
+   指定した <parameter>stream</parameter> に書き込みます
+   (いちばん最後に <parameter>eol</parameter> を追加します)。
   </para>
  </refsect1>
 
@@ -45,34 +45,15 @@
       </para>
      </listitem>
     </varlistentry>
-    <varlistentry>
-     <term><parameter>separator</parameter></term>
-     <listitem>
-      <para>
-       オプションの <parameter>separator</parameter> はフィールド区切り文字
-       (シングルバイト文字 一文字だけ) を指定します。
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>enclosure</parameter></term>
-     <listitem>
-      <para>
-       オプションの <parameter>enclosure</parameter> はフィールドを囲む文字
-       (シングルバイト文字 一文字だけ) を指定します。
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>escape</parameter></term>
-     <listitem>
-      <para>
-       オプションの <parameter>escape</parameter> は、エスケープ文字
-       (シングルバイト文字 最大で一文字) を指定します。
-       空文字(<literal>""</literal>) を指定すると、(RFC 4180 に準拠していない) 独自仕様のエスケープ機構が無効になります。
-      </para>
-     </listitem>
-    </varlistentry>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='separator']]]/.)">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='enclosure']]]/.)">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='escape']]]/.)">
+     <xi:fallback/>
+    </xi:include>
     <varlistentry>
      <term><parameter>eol</parameter></term>
      <listitem>
@@ -100,6 +81,10 @@
   </para>
  </refsect1>
 
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='errors']/.)">
+  <xi:fallback/>
+ </xi:include>
+
  <refsect1 role="changelog">
   &reftitle.changelog;
   <para>
@@ -112,6 +97,9 @@
       </row>
      </thead>
      <tbody>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='changelog']//db:row[db:entry[text()='8.4.0']]/.)">
+       <xi:fallback/>
+      </xi:include>
       <row>
        <entry>8.1.0</entry>
        <entry>
@@ -170,18 +158,16 @@ aaa,bbb,ccc,dddd
   </para>
  </refsect1>
 
- <refsect1 role="notes">
-  &reftitle.notes;
-  &note.line-endings;
- </refsect1>
-
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>fgetcsv</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>fgetcsv</function></member>
+   <member><function>str_getcsv</function></member>
+   <member><methodname>SplFileObject::fgetcsv</methodname></member>
+   <member><methodname>SplFileObject::fputcsv</methodname></member>
+   <member><methodname>SplFileObject::setCsvControl</methodname></member>
+   <member><methodname>SplFileObject::getCsvControl</methodname></member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/spl/splfileobject/fgetcsv.xml
+++ b/reference/spl/splfileobject/fgetcsv.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: cef78b0fbe0fbe02003699b027ab50200097e949 Maintainer: masakielastic Status: ready -->
+<!-- EN-Revision: f1eb91d07d2df082384b3f83c9d2a0dc1e439d32 Maintainer: masakielastic Status: ready -->
 <!-- Credits: mumumu -->
-<refentry xml:id="splfileobject.fgetcsv" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<refentry xml:id="splfileobject.fgetcsv" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>
   <refname>SplFileObject::fgetcsv</refname>
   <refpurpose>ファイルから行を取り出し CSV フィールドとして処理する</refpurpose>
@@ -19,14 +19,9 @@
   <para>
    <acronym>CSV</acronym> フォーマットのファイルから行を取り出し読み込まれたフィールドを含む配列を返します。
   </para>
-  <note>
-   <para>
-    この関数は、ロケール設定を考慮します。
-    <constant>LC_CTYPE</constant> がたとえば
-    <literal>en_US.UTF-8</literal> だった場合、
-    ファイルの1バイトのエンコーディングは、この関数では間違った読まれ方をする可能性があります。
-   </para>
-  </note>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='description']//db:note/.)">
+   <xi:fallback/>
+  </xi:include>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -38,8 +33,8 @@
      <listitem>
       <para>
        フィールドの区切り文字 (シングルバイト文字 1 文字のみ)。
-       デフォルトはカンマもしくは
-       <methodname>SplFileObject::setCsvControl</methodname> を使ってセットされた値です。
+       デフォルトはカンマ(<literal>,</literal>)、 もしくは事前に
+       <methodname>SplFileObject::setCsvControl</methodname> を呼び出してセットされた値です。
       </para>
      </listitem>
     </varlistentry>
@@ -48,8 +43,8 @@
      <listitem>
       <para>
        フィールド囲み文字 (シングルバイト文字 1 文字のみ)。
-       デフォルトはダブルクォートもしくは
-       <methodname>SplFileObject::setCsvControl</methodname> を使ってセットされた値です。
+       デフォルトはダブルクォート(<literal>"</literal>)、もしくは事前に
+       <methodname>SplFileObject::setCsvControl</methodname> を呼び出してセットされた値です。
       </para>
      </listitem>
     </varlistentry>
@@ -58,8 +53,8 @@
      <listitem>
       <para>
        エスケープ文字 (シングルバイト文字 最大で1文字)。
-       デフォルトはバックスラッシュ (<literal>\</literal>) もしくは
-       <methodname>SplFileObject::setCsvControl</methodname> を使ってセットされた値です。
+       デフォルトはバックスラッシュ(<literal>\</literal>)、 もしくは事前に
+       <methodname>SplFileObject::setCsvControl</methodname> を呼び出してセットされた値です。
        空文字列(<literal>""</literal>)の場合、(RFC 4180 に準拠していない) 独自仕様のエスケープ機構が無効になります。
       </para>
       <note>
@@ -74,6 +69,15 @@
         特別な意味はありません。それ自身をエスケープする意味ですらありません。
        </simpara>
       </note>
+      <warning>
+       <simpara>
+        PHP 8.4.0 以降では、<parameter>escape</parameter>
+        のデフォルト値に依存することは非推奨となりました。
+        位置指定の引数か、<link linkend="functions.named-arguments">名前付き引数</link>を使用するか、
+        あるいは <methodname>SplFileObject::setCsvControl</methodname>
+        を呼び出して、明示的に指定する必要があります。
+       </simpara>
+      </warning>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -93,6 +97,10 @@
   </note>
  </refsect1>
 
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='errors']/.)">
+  <xi:fallback/>
+ </xi:include>
+
  <refsect1 role="changelog">
   &reftitle.changelog;
   <para>
@@ -105,6 +113,9 @@
       </row>
      </thead>
      <tbody>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='changelog']//db:row[db:entry[text()='8.4.0']]/.)">
+       <xi:fallback/>
+      </xi:include>
       <row>
        <entry>7.4.0</entry>
        <entry>
@@ -176,14 +187,17 @@ A salmon is a fish with 0 legs
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><methodname>SplFileObject::setCsvControl</methodname></member>
-    <member><methodname>SplFileObject::setFlags</methodname></member>
-    <member><link linkend="splfileobject.constants.read-csv">SplFileObject::READ_CSV</link></member>
-    <member><methodname>SplFileObject::current</methodname></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><methodname>SplFileObject::fputcsv</methodname></member>
+   <member><methodname>SplFileObject::setCsvControl</methodname></member>
+   <member><methodname>SplFileObject::getCsvControl</methodname></member>
+   <member><methodname>SplFileObject::setFlags</methodname></member>
+   <member><constant>SplFileObject::READ_CSV</constant></member>
+   <member><methodname>SplFileObject::current</methodname></member>
+   <member><function>fputcsv</function></member>
+   <member><function>fgetcsv</function></member>
+   <member><function>str_getcsv</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/spl/splfileobject/fputcsv.xml
+++ b/reference/spl/splfileobject/fputcsv.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: cef78b0fbe0fbe02003699b027ab50200097e949 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 73007ad9889ca2a3d85b0a710b55deb44ac370cc Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
-<refentry xml:id="splfileobject.fputcsv" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<refentry xml:id="splfileobject.fputcsv" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>
   <refname>SplFileObject::fputcsv</refname>
   <refpurpose>フィールドの配列を CSV の行として書き出す</refpurpose>
@@ -19,7 +19,8 @@
    <methodparam choice="opt"><type>string</type><parameter>eol</parameter><initializer>"\n"</initializer></methodparam>
   </methodsynopsis>
   <para>
-   <parameter>fields</parameter> の配列を、CSV の行としてファイルに書き出します。
+   <parameter>fields</parameter> の配列を、<acronym>CSV</acronym>
+   の行としてファイルに書き出します。
   </para>
  </refsect1>
 
@@ -34,34 +35,15 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry>
-    <term><parameter>separator</parameter></term>
-    <listitem>
-     <para>
-      オプションで指定する、フィールドの区切り文字
-      (シングルバイト文字 一文字のみ)。
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term><parameter>enclosure</parameter></term>
-    <listitem>
-     <para>
-      オプションで指定する。フィールドの囲み文字
-      (シングルバイト文字 一文字のみ)。
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term><parameter>escape</parameter></term>
-    <listitem>
-     <para>
-      オプションの <parameter>escape</parameter> は、エスケープ文字
-      (シングルバイト文字 最大で一文字) を指定します。
-      空文字列 (<literal>""</literal>) を与えると、(RFC 4180 に準拠していない) 独自仕様のエスケープ機構を無効にします。
-     </para>
-    </listitem>
-   </varlistentry>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('splfileobject.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='separator']]]/.)">
+    <xi:fallback/>
+   </xi:include>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('splfileobject.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='enclosure']]]/.)">
+    <xi:fallback/>
+   </xi:include>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('splfileobject.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='escape']]]/.)">
+    <xi:fallback/>
+   </xi:include>
    <varlistentry>
     <term><parameter>eol</parameter></term>
     <listitem>
@@ -87,19 +69,11 @@
   <para>
    書き出した文字列の長さを返します。&return.falseforfailure;。
   </para>
-  <para>
-   <parameter>separator</parameter> や <parameter>enclosure</parameter>
-   が一文字でない場合は &false; を返し、何もファイルに書き出しません。
-  </para>
  </refsect1>
 
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   <parameter>separator</parameter> や <parameter>enclosure</parameter>
-   が一文字でない場合は <constant>E_WARNING</constant> レベルのエラーが発生します。
-  </para>
- </refsect1>
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='errors']/.)">
+  <xi:fallback/>
+ </xi:include>
 
  <refsect1 role="changelog">
   &reftitle.changelog;
@@ -113,6 +87,9 @@
       </row>
      </thead>
      <tbody>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='changelog']//db:row[db:entry[text()='8.4.0']]/.)">
+       <xi:fallback/>
+      </xi:include>
       <row>
        <entry>8.1.0</entry>
        <entry>
@@ -171,12 +148,14 @@ aaa,bbb,ccc,dddd
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>fputcsv</function></member>
-    <member><methodname>SplFileObject::fgetcsv</methodname></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><methodname>SplFileObject::fgetcsv</methodname></member>
+   <member><methodname>SplFileObject::setCsvControl</methodname></member>
+   <member><methodname>SplFileObject::getCsvControl</methodname></member>
+   <member><function>fputcsv</function></member>
+   <member><function>fgetcsv</function></member>
+   <member><function>str_getcsv</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/spl/splfileobject/getcsvcontrol.xml
+++ b/reference/spl/splfileobject/getcsvcontrol.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d51166ca16fda8e766849505b84f9306ef443f71 Maintainer: masakielastic Status: ready -->
+<!-- EN-Revision: 73007ad9889ca2a3d85b0a710b55deb44ac370cc Maintainer: masakielastic Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="splfileobject.getcsvcontrol" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,7 +15,8 @@
    <void/>
   </methodsynopsis>
   <para>
-   CSV フィールドを処理するのに使われる区切りと囲み文字とエスケープ文字を取得します。
+   <acronym>CSV</acronym> フィールドを処理するのに使われる
+   区切りと囲み文字とエスケープ文字を取得します。
   </para>
  </refsect1>
 
@@ -91,12 +92,14 @@ Array
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><methodname>SplFileObject::setCsvControl</methodname></member>
-    <member><methodname>SplFileObject::fgetcsv</methodname></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><methodname>SplFileObject::setCsvControl</methodname></member>
+   <member><methodname>SplFileObject::fgetcsv</methodname></member>
+   <member><methodname>SplFileObject::fputcsv</methodname></member>
+   <member><function>fputcsv</function></member>
+   <member><function>fgetcsv</function></member>
+   <member><function>str_getcsv</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/spl/splfileobject/getcsvcontrol.xml
+++ b/reference/spl/splfileobject/getcsvcontrol.xml
@@ -101,7 +101,6 @@ Array
    <member><function>str_getcsv</function></member>
   </simplelist>
  </refsect1>
-
 </refentry>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/spl/splfileobject/setcsvcontrol.xml
+++ b/reference/spl/splfileobject/setcsvcontrol.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: cef78b0fbe0fbe02003699b027ab50200097e949 Maintainer: masakielastic Status: ready -->
+<!-- EN-Revision: 4a0ce5d81a6944dd882946ca1a204b1d2efb2416 Maintainer: masakielastic Status: ready -->
 <!-- Credits: mumumu -->
-<refentry xml:id="splfileobject.setcsvcontrol" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<refentry xml:id="splfileobject.setcsvcontrol" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>
   <refname>SplFileObject::setCsvControl</refname>
   <refpurpose>CSV の区切り文字、囲み文字、エスケープ文字をセットする</refpurpose>
@@ -17,41 +17,24 @@
    <methodparam choice="opt"><type>string</type><parameter>escape</parameter><initializer>"\\"</initializer></methodparam>
   </methodsynopsis>
   <para>
-   CSV フィールド処理用の区切り文字と囲み文字とエスケープ文字をセットします。
+   <acronym>CSV</acronym> フィールド処理用の
+   区切り文字と囲み文字とエスケープ文字をセットします。
   </para>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>separator</parameter></term>
-     <listitem>
-      <para>
-       フィールドの区切り文字 (シングルバイト文字 1 文字のみ)。
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>enclosure</parameter></term>
-     <listitem>
-      <para>
-       フィールドの囲み文字 (シングルバイト文字 1 文字のみ)。
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>escape</parameter></term>
-     <listitem>
-      <para>
-       フィールドのエスケープ文字 (シングルバイト文字 最大で1文字)。
-       空文字列(<literal>""</literal>)を指定すると、(RFC 4180 に準拠していない) 独自仕様のエスケープ機構が無効になります。
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  <variablelist>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='separator']]]/.)">
+    <xi:fallback><varlistentry><term></term><listitem><simpara></simpara></listitem></varlistentry></xi:fallback>
+   </xi:include>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='enclosure']]]/.)">
+    <xi:fallback/>
+   </xi:include>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='escape']]]/.)">
+    <xi:fallback/>
+   </xi:include>
+  </variablelist>
   &warning.csv.escape-parameter;
  </refsect1>
 
@@ -61,6 +44,10 @@
    &return.void;
   </para>
  </refsect1>
+
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='errors']/.)">
+  <xi:fallback/>
+ </xi:include>
 
  <refsect1 role="changelog">
   &reftitle.changelog;
@@ -74,6 +61,9 @@
       </row>
      </thead>
      <tbody>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='changelog']//db:row[db:entry[text()='8.4.0']]/.)">
+       <xi:fallback/>
+      </xi:include>
       <row>
        <entry>7.4.0</entry>
        <entry>
@@ -121,12 +111,14 @@ cherries|87
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><methodname>SplFileObject::getCsvControl</methodname></member>
-    <member><methodname>SplFileObject::fgetcsv</methodname></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><methodname>SplFileObject::getCsvControl</methodname></member>
+   <member><methodname>SplFileObject::fgetcsv</methodname></member>
+   <member><methodname>SplFileObject::fputcsv</methodname></member>
+   <member><function>fputcsv</function></member>
+   <member><function>fgetcsv</function></member>
+   <member><function>str_getcsv</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/strings/functions/str-getcsv.xml
+++ b/reference/strings/functions/str-getcsv.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: cef78b0fbe0fbe02003699b027ab50200097e949 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 73007ad9889ca2a3d85b0a710b55deb44ac370cc Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
-<refentry xml:id="function.str-getcsv" xmlns="http://docbook.org/ns/docbook">
+<refentry xml:id="function.str-getcsv" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>
   <refname>str_getcsv</refname>
   <refpurpose>
@@ -23,13 +23,9 @@
    <acronym>CSV</acronym> 形式の文字列入力のフィールドをパースして、
    読み込んだフィールドの内容を配列で返します。
   </para>
-  <note>
-   <para>
-    この関数はロケール設定を考慮します。もし <constant>LC_CTYPE</constant> 
-    が例えば <literal>en_US.UTF-8</literal> の場合、
-    1 バイトエンコーディングの文字列は間違って読み込まれるかもしれません。
-   </para>
-  </note>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='description']//db:note/.)">
+   <xi:fallback/>
+  </xi:include>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -44,46 +40,15 @@
       </para>
      </listitem>
     </varlistentry>
-    <varlistentry>
-     <term><parameter>separator</parameter></term>
-     <listitem>
-      <para>
-       フィールド区切り文字 (シングルバイト文字 1 文字のみ)。
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>enclosure</parameter></term>
-     <listitem>
-      <para>
-       フィールド囲み文字 (シングルバイト文字 1 文字のみ)。
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>escape</parameter></term>
-     <listitem>
-      <para>
-       エスケープ文字 (シングルバイト文字 最大1文字)。デフォルトはバックスラッシュ
-       (<literal>\</literal>)。
-       空文字列 (<literal>""</literal>) を指定すると、
-       (RFC 4180 に準拠していない) 独自仕様のエスケープ機構を無効にします。
-      </para>
-      <note>
-       <simpara>
-        通常、 <parameter>enclosure</parameter> の文字は、
-        フィールドの中では二回出力されることでエスケープされます。
-        しかし、<parameter>escape</parameter>
-        の文字を代わりに使うこともできます。
-        よって、デフォルト値 <literal>""</literal> 
-        および <literal>\"</literal> は同じ意味になります。
-        <parameter>enclosure</parameter> 文字をエスケープすることを許可する以外に、
-        <parameter>escape</parameter> 文字は特別な意味を何ら持ちません;
-        つまり、自分自身をエスケープすることすら意味しません。
-       </simpara>
-      </note>
-     </listitem>
-    </varlistentry>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='separator']]]/.)">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='enclosure']]]/.)">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='escape']]]/.)">
+     <xi:fallback/>
+    </xi:include>
    </variablelist>
   </para>
   &warning.csv.escape-parameter;
@@ -95,6 +60,10 @@
    読み込んだフィールドの内容を配列で返します。
   </para>
  </refsect1>
+
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='errors']/.)">
+  <xi:fallback/>
+ </xi:include>
 
  <refsect1 role="changelog">
   &reftitle.changelog;
@@ -108,6 +77,19 @@
       </row>
      </thead>
      <tbody>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='changelog']//db:row[db:entry[text()='8.4.0']]/.)">
+       <xi:fallback/>
+      </xi:include>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        <parameter>separator</parameter>、<parameter>enclosure</parameter>、
+        または <parameter>escape</parameter> が不正な場合、
+        <exceptionname>ValueError</exceptionname> をスローするようになりました。
+        これは、<function>fgetcsv</function> と <function>fputcsv</function>
+        の動作に倣ったものとなります。
+       </entry>
+      </row>
       <row>
        <entry>7.4.0</entry>
        <entry>
@@ -192,11 +174,14 @@ array(1) {
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>fgetcsv</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>fputcsv</function></member>
+   <member><function>fgetcsv</function></member>
+   <member><methodname>SplFileObject::fgetcsv</methodname></member>
+   <member><methodname>SplFileObject::fputcsv</methodname></member>
+   <member><methodname>SplFileObject::setCsvControl</methodname></member>
+   <member><methodname>SplFileObject::getCsvControl</methodname></member>
+  </simplelist>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/strings/functions/str-getcsv.xml
+++ b/reference/strings/functions/str-getcsv.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 73007ad9889ca2a3d85b0a710b55deb44ac370cc Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 781f2ec04ee8817687e5e333bc3e64ab973322d7 Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="function.str-getcsv" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>
@@ -90,6 +90,9 @@
         の動作に倣ったものとなります。
        </entry>
       </row>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='changelog']//db:row[db:entry[text()='8.3.0']]/.)">
+       <xi:fallback/>
+      </xi:include>
       <row>
        <entry>7.4.0</entry>
        <entry>


### PR DESCRIPTION
refs #150 

php/doc-en#4093 を取り込みました。

また、上記後に変更されてマージされている以下に関しても取り込んでいます。

reference/filesystem/functions/fgetcsv.xml

- https://github.com/php/doc-en/pull/4177
- https://github.com/php/doc-en/pull/4198

reference/filesystem/functions/fputcsv.xml

- https://github.com/php/doc-en/pull/4283

reference/spl/splfileobject/fgetcsv.xml

- https://github.com/php/doc-en/pull/4111

reference/spl/splfileobject/setcsvcontrol.xml

- https://github.com/php/doc-en/pull/4128
- https://github.com/php/doc-en/pull/4379
  
reference/strings/functions/str-getcsv.xml

- https://github.com/php/doc-en/pull/4198
