### PR TITLE
誤訳の修正

### DIFF
--- a/reference/misc/functions/exit.xml
+++ b/reference/misc/functions/exit.xml
@@ -199,7 +199,7 @@ exit;
   &reftitle.notes;
   <warning>
    <simpara>
-    PHP 8.4.0 以降は、 <function>exit</function> は関数ではなく言語構造でした。 
+    PHP 8.4.0 より前は、 <function>exit</function> は関数ではなく言語構造でした。 
     したがって、 <link linkend="functions.variable-functions">可変関数</link> や <link linkend="functions.named-arguments">名前付き引数</link> を使って関数を呼び出すことはできませんでした。
    </simpara>
   </warning>


### PR DESCRIPTION
英語版は

> Prior to PHP 8.4.0, exit() was a language construct and not a function, therefore it was not possible to call it using variable functions, or named arguments.

のため `PHP 8.4.0より前` が正しいと思われる