### PR TITLE
PHP 8.4: Document DOM deprecations

### DIFF
--- a/reference/dom/constants.xml
+++ b/reference/dom/constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: f44eff3695dbe664b4acf5d32e1643fe6448b51c Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 38d0723a6e865c163527b252afbca7fc91ac473d Maintainer: takagi Status: ready -->
 <chapter xml:id="dom.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
  &extension.constants;
@@ -261,6 +261,8 @@
       <entry>0</entry>
       <entry>
        DOM の仕様にないエラーコードです。PHP のエラーを意味します。
+       今後使用されないため、非推奨となりました。
+       PHP8.4.0より前では、メモリ不足を示すために一貫性がなく使用されてきました。
       </entry>
      </row>
      <row xml:id="constant.dom-index-size-err">

--- a/reference/dom/domdocument.xml
+++ b/reference/dom/domdocument.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 0217f85ed26dc9511fb6b44e87d82f4b77adafa1 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 38d0723a6e865c163527b252afbca7fc91ac473d Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <reference xml:id="class.domdocument" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>DOMDocument クラス</title>
@@ -188,7 +188,7 @@
      <term><varname>actualEncoding</varname></term>
      <listitem>
       <para>
-       <emphasis>非推奨</emphasis>。ドキュメントの実際のエンコーディング。
+       <emphasis>PHP8.4.0より非推奨</emphasis>。ドキュメントの実際のエンコーディング。
        読み込み専用で、
        <varname linkend="domdocument.props.encoding">encoding</varname>
        と同等の内容です。
@@ -205,7 +205,7 @@
      <term><varname>config</varname></term>
      <listitem>
       <para>
-       <emphasis>非推奨</emphasis>。
+       <emphasis>PHP8.4.0より非推奨</emphasis>。
        <function>DOMDocument::normalizeDocument</function>
        を実行する際に使用する設定。
       </para>
@@ -407,6 +407,13 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        <varname>actualEncoding</varname> と
+        <varname>config</varname> は正式に非推奨となりました。
+       </entry>
+      </row>
       <row>
        <entry>8.0.0</entry>
        <entry>

--- a/reference/dom/domentity.xml
+++ b/reference/dom/domentity.xml
@@ -115,7 +115,7 @@
      <listitem>
       <para>
        パースされていないエンティティの場合はそのエンティティの名前、
-       パース済みのエンティティの場合は &null;
+       パース済みのエンティティの場合は &null; 。
       </para>
      </listitem>
     </varlistentry>
@@ -123,7 +123,7 @@
      <term><varname>actualEncoding</varname></term>
      <listitem>
       <para>
-       <emphasis>PHP8.4.0より非推奨</emphasis>.
+       <emphasis>PHP8.4.0より非推奨</emphasis>。
        常に &null; と等しくなります。
       </para>
      </listitem>
@@ -132,7 +132,7 @@
      <term><varname>encoding</varname></term>
      <listitem>
       <para>
-       <emphasis>PHP8.4.0より非推奨</emphasis>.
+       <emphasis>PHP8.4.0より非推奨</emphasis>。
        常に &null; と等しくなります。
       </para>
      </listitem>
@@ -141,7 +141,7 @@
      <term><varname>version</varname></term>
      <listitem>
       <para>
-       <emphasis>PHP8.4.0より非推奨</emphasis>.
+       <emphasis>PHP8.4.0より非推奨</emphasis>。
        常に &null; と等しくなります。
       </para>
      </listitem>

--- a/reference/dom/domentity.xml
+++ b/reference/dom/domentity.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 38d0723a6e865c163527b252afbca7fc91ac473d Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <reference xml:id="class.domentity" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>DOMEntity クラス</title>
@@ -123,10 +123,8 @@
      <term><varname>actualEncoding</varname></term>
      <listitem>
       <para>
-       外部でパースされたエンティティの場合は、このエンティティの
-       パース時に使用されたエンコーディングを指定する属性。
-       内部サブセットからのエンティティであったり未知のエンティティで
-       あった場合は &null;
+       <emphasis>PHP8.4.0より非推奨</emphasis>.
+       常に &null; と等しくなります。
       </para>
      </listitem>
     </varlistentry>
@@ -134,9 +132,8 @@
      <term><varname>encoding</varname></term>
      <listitem>
       <para>
-       外部でパースされたエンティティの場合は、テキスト宣言の一部として
-       このエンティティのエンコーディングを指定する属性。それ以外の場合は
-       &null;
+       <emphasis>PHP8.4.0より非推奨</emphasis>.
+       常に &null; と等しくなります。
       </para>
      </listitem>
     </varlistentry>
@@ -144,16 +141,41 @@
      <term><varname>version</varname></term>
      <listitem>
       <para>
-       外部でパースされたエンティティの場合は、テキスト宣言の一部として
-       このエンティティのバージョン番号を指定する属性。それ以外の場合は
-       &null;
+       <emphasis>PHP8.4.0より非推奨</emphasis>.
+       常に &null; と等しくなります。
       </para>
      </listitem>
     </varlistentry>
    </variablelist>
   </section>
 <!-- }}} -->
-  
+
+
+<section role="changelog">
+ &reftitle.changelog;
+ <informaltable>
+  <tgroup cols="2">
+   <thead>
+    <row>
+     <entry>&Version;</entry>
+     <entry>&Description;</entry>
+    </row>
+   </thead>
+   <tbody>
+    <row>
+     <entry>8.4.0</entry>
+     <entry>
+      <varname>actualEncoding</varname>,
+      <varname>encoding</varname>, と
+      <varname>version</varname> は常に &null; と等しくなるため、
+      正式に非推奨となりました。
+     </entry>
+    </row>
+   </tbody>
+  </tgroup>
+ </informaltable>
+</section>
+
 <!-- {{{ See also -->
 <!--
   <section role="seealso">


### PR DESCRIPTION
https://github.com/php/doc-en/pull/4113 を反映しました。