### PR TITLE
Add note about openssl_x509_parse time parsing change in 8.4 を取り込み

### DIFF
--- a/reference/openssl/functions/openssl-x509-parse.xml
+++ b/reference/openssl/functions/openssl-x509-parse.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d1e3ea622e5d4f542cd36eca59a9f22aa0142633 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: af4e920c7232115ba0fe800b280eefbbed078597 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi,mumumu -->
 <refentry xml:id="function.openssl-x509-parse" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -69,6 +69,13 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       すべての OpenSSL バージョンで、UTCTime に秒が含まれていない証明書をパースできなくなりました。
+       OpenSSL のバージョン 3.3 以降を使っていた場合は、以前からパースできませんでした。
+      </entry>
+     </row>
      <row>
       <entry>8.0.0</entry>
       <entry>


### PR DESCRIPTION
refs #150

# 概要

https://github.com/php/doc-en/pull/4317 を取り込みました。

# "UTCTime" について

原文の "UTCTime" は、X.509 の仕様書で定義された用語のため、「UTC 時間」のようには訳さずそのまま用いています。

参考: [RFC 2459: Internet X.509 Public Key Infrastructure Certificate and CRL Profile](https://www.ietf.org/rfc/rfc2459.txt) section 4.1.2.5.1UTCTime