### PR TITLE
ext/bcmath: PHP 8.4の翻訳

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9cd8eb0f11edb4e59fd22f723137bbb91d6ab64f Maintainer: takagi Status: working -->
+<!-- EN-Revision: 3295741565f760edd22e305bd10e37f243e9e194 Maintainer: takagi Status: working -->
 <!-- Credits: hirokawa,haruki,shimooka,mumumu,jdkfx -->
 
 <!ENTITY installation.enabled.disable 'この拡張モジュールはデフォルトで有効になっています。無効にしたい場合は、次のオプションを指定してコンパイルします。'>
@@ -2120,20 +2120,6 @@ PECL 拡張モジュールのインストール</link> という章にありま�
 <!ENTITY safemode '<link xmlns="http://docbook.org/ns/docbook" linkend="ini.safe-mode">セーフモード</link>'>
 
 <!ENTITY sqlsafemode '<link xmlns="http://docbook.org/ns/docbook" linkend="ini.sql.safe-mode">SQL セーフモード</link>'>
-
-<!-- BCMath Notes -->
-<!-- to be translated -->
-<!ENTITY bc.scale.description '<varlistentry xmlns="http://docbook.org/ns/docbook">
- <term><parameter>scale</parameter></term>
- <listitem>
-  <simpara>
-   This parameter is used to set the number of digits after the decimal place in the result.
-   If &null;, it will default to the default scale set with <function>bcscale</function>,
-   or fallback to the value of the
-   <link linkend="ini.bcmath.scale"><literal>bcmath.scale</literal></link> INI directive.
-  </simpara>
- </listitem>
-</varlistentry>'>
 
 <!-- CTYPE Notes -->
 <!ENTITY note.ctype.parameter.integer '<note xmlns="http://docbook.org/ns/docbook"><para>

--- a/reference/bc/bcmath.number.xml
+++ b/reference/bc/bcmath.number.xml
@@ -20,7 +20,6 @@
 
    <note>
     <simpara>
-     This class is not affected by the
      このクラスは、&php.ini;で設定された
      <link linkend="ini.bcmath.scale">bcmath.scale</link>
      INI ディレクティブの影響を受けません。

--- a/reference/bc/bcmath.number.xml
+++ b/reference/bc/bcmath.number.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: saki Status: ready -->
+
+<reference xml:id="class.bcmath-number" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+
+ <title>BcMath\Number クラス</title>
+ <titleabbrev>BcMath\Number</titleabbrev>
+
+ <partintro>
+  <section xml:id="bcmath-number.intro">
+   &reftitle.intro;
+   <simpara>
+    任意精度数値のクラスです。
+    このオブジェクトは、オーバーロードされた
+    <link linkend="language.operators.arithmetic">算術演算子</link>,
+    <link linkend="language.operators.comparison">比較演算子</link>
+    をサポートしています。
+   </simpara>
+
+   <note>
+    <simpara>
+     This class is not affected by the
+     このクラスは、&php.ini;で設定された
+     <link linkend="ini.bcmath.scale">bcmath.scale</link>
+     INI ディレクティブの影響を受けません。
+    </simpara>
+   </note>
+
+   <note>
+    <simpara>
+     オーバーロードされた演算子の動作は、対応するメソッドで
+     <parameter>scale</parameter> パラメータに &null; を指定した場合と同じです。
+    </simpara>
+   </note>
+  </section>
+
+  <section xml:id="bcmath-number.synopsis">
+   &reftitle.classsynopsis;
+
+   <classsynopsis class="class">
+    <ooclass>
+     <modifier>final</modifier>
+     <modifier>readonly</modifier>
+     <classname>BcMath\Number</classname>
+    </ooclass>
+
+    <oointerface>
+     <modifier>implements</modifier>
+     <interfacename>Stringable</interfacename>
+    </oointerface>
+
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <type>string</type>
+     <varname linkend="bcmath-number.props.value">value</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <type>int</type>
+     <varname linkend="bcmath-number.props.scale">scale</varname>
+    </fieldsynopsis>
+
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.bcmath-number')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='BcMath\\Number'])">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.bcmath-number')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='BcMath\\Number'])">
+     <xi:fallback/>
+    </xi:include>
+   </classsynopsis>
+  </section>
+
+  <section xml:id="bcmath-number.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="bcmath-number.props.value">
+     <term><varname>value</varname></term>
+     <listitem>
+      <simpara>
+       任意精度数値の文字表現。
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="bcmath-number.props.scale">
+     <term><varname>scale</varname></term>
+     <listitem>
+      <simpara>
+       オブジェクトに設定されているスケールの値。
+       計算メソッドで明示的に <parameter>scale</parameter> パラメータが設定されていない場合、
+       この値は自動的に計算されて設定されます。
+      </simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+
+ </partintro>
+
+ &reference.bc.bcmath.entities.number;
+
+</reference>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/bc/bcmath/number/add.xml
+++ b/reference/bc/bcmath/number/add.xml
@@ -1,0 +1,195 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: saki Status: ready -->
+
+<refentry xml:id="bcmath-number.add" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>BcMath\Number::add</refname>
+  <refpurpose>任意精度の数値を加算する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="BcMath\\Number">
+   <modifier>public</modifier> <type>BcMath\Number</type><methodname>BcMath\Number::add</methodname>
+   <methodparam><type class="union"><type>BcMath\Number</type><type>string</type><type>int</type></type><parameter>num</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>scale</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   <varname>$this</varname> と <parameter>num</parameter> を加算します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>num</parameter></term>
+    <listitem>
+     <simpara>
+      加数を表す値。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>scale</parameter></term>
+    <listitem>
+     <simpara>
+      計算結果オブジェクトの <property>BcMath\Number::scale</property> を明示的に指定します。
+      &null; の場合、計算結果の <property>BcMath\Number::scale</property> は自動的に設定されます。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   加算結果を新しい <classname>BcMath\Number</classname> オブジェクトとして返します。
+  </simpara>
+  <simpara>
+   加算結果オブジェクトの <property>BcMath\Number::scale</property> が自動的に設定される場合、加算に使用する2つの数値のうち、
+   大きい方の <property>BcMath\Number::scale</property> が使用されます。
+  </simpara>
+  <simpara>
+   つまり、2つの値の <property>BcMath\Number::scale</property> がそれぞれ <literal>2</literal> と <literal>5</literal> の場合、
+   加算結果オブジェクトの <property>BcMath\Number::scale</property> は <literal>5</literal> になります。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   このメソッドは、以下の場合に <classname>ValueError</classname> をスローします:
+   <simplelist>
+    <member><parameter>num</parameter> が、BCMath で有効でない数値形式の文字列である場合</member>
+    <member><parameter>scale</parameter> が範囲外の値である場合</member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><methodname>BcMath\Number::add</methodname> で <parameter>scale</parameter> を指定しない例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$number = new BcMath\Number('1.234');
+
+$ret1 = $number->add(new BcMath\Number('2.34567'));
+$ret2 = $number->add('-3.456');
+$ret3 = $number->add(7);
+
+var_dump($number, $ret1, $ret2, $ret3);
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+object(BcMath\Number)#1 (2) {
+  ["value"]=>
+  string(5) "1.234"
+  ["scale"]=>
+  int(3)
+}
+object(BcMath\Number)#3 (2) {
+  ["value"]=>
+  string(7) "3.57967"
+  ["scale"]=>
+  int(5)
+}
+object(BcMath\Number)#2 (2) {
+  ["value"]=>
+  string(6) "-2.222"
+  ["scale"]=>
+  int(3)
+}
+object(BcMath\Number)#4 (2) {
+  ["value"]=>
+  string(5) "8.234"
+  ["scale"]=>
+  int(3)
+}
+]]>
+   </screen>
+  </example>
+
+  <example>
+   <title><methodname>BcMath\Number::add</methodname> で <parameter>scale</parameter> を指定する例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$number = new BcMath\Number('1.234');
+
+$ret1 = $number->add(new BcMath\Number('2.34567'), 1);
+$ret2 = $number->add('-3.456', 10);
+$ret3 = $number->add(7, 0);
+
+var_dump($number, $ret1, $ret2, $ret3);
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+object(BcMath\Number)#1 (2) {
+  ["value"]=>
+  string(5) "1.234"
+  ["scale"]=>
+  int(3)
+}
+object(BcMath\Number)#3 (2) {
+  ["value"]=>
+  string(3) "3.5"
+  ["scale"]=>
+  int(1)
+}
+object(BcMath\Number)#2 (2) {
+  ["value"]=>
+  string(13) "-2.2220000000"
+  ["scale"]=>
+  int(10)
+}
+object(BcMath\Number)#4 (2) {
+  ["value"]=>
+  string(1) "8"
+  ["scale"]=>
+  int(0)
+}
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>bcadd</function></member>
+   <member><methodname>BcMath\Number::sub</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/bc/bcmath/number/add.xml
+++ b/reference/bc/bcmath/number/add.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: saki Status: ready -->
+<!-- EN-Revision: a414ee95eb79e2c62c80827a46e15da5d15af97e Maintainer: saki Status: ready -->
 
 <refentry xml:id="bcmath-number.add" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/bc/bcmath/number/ceil.xml
+++ b/reference/bc/bcmath/number/ceil.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: saki Status: ready -->
+
+<refentry xml:id="bcmath-number.ceil" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>BcMath\Number::ceil</refname>
+  <refpurpose>任意精度数値を切り上げる</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="BcMath\\Number">
+   <modifier>public</modifier> <type>BcMath\Number</type><methodname>BcMath\Number::ceil</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   必要に応じて <varname>$this</varname> を切り上げ、 <varname>$this</varname> の次に大きい整数値を返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   結果を新しい <classname>BcMath\Number</classname> オブジェクトとして返します。
+   結果の <property>BcMath\Number::scale</property> は常に <literal>0</literal> になります。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><methodname>BcMath\Number::ceil</methodname> の例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$num1 = new BcMath\Number('4.3')->ceil();
+$num2 = new BcMath\Number('9.999')->ceil();
+$num3 = new BcMath\Number('-3.14')->ceil();
+
+var_dump($num1, $num2, $num3);
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+object(BcMath\Number)#2 (2) {
+  ["value"]=>
+  string(1) "5"
+  ["scale"]=>
+  int(0)
+}
+object(BcMath\Number)#3 (2) {
+  ["value"]=>
+  string(2) "10"
+  ["scale"]=>
+  int(0)
+}
+object(BcMath\Number)#4 (2) {
+  ["value"]=>
+  string(2) "-3"
+  ["scale"]=>
+  int(0)
+}
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>bcceil</function></member>
+   <member><methodname>BcMath\Number::floor</methodname></member>
+   <member><methodname>BcMath\Number::round</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/bc/bcmath/number/compare.xml
+++ b/reference/bc/bcmath/number/compare.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: saki Status: ready -->
+
+<refentry xml:id="bcmath-number.compare" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <refnamediv>
+  <refname>BcMath\Number::compare</refname>
+  <refpurpose>任意精度数値を比較する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="BcMath\\Number">
+   <modifier>public</modifier> <type>int</type><methodname>BcMath\Number::compare</methodname>
+   <methodparam><type class="union"><type>BcMath\Number</type><type>string</type><type>int</type></type><parameter>num</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>scale</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   任意精度数値を比較します。
+   このメソッドは、 <link linkend="language.operators.comparison">宇宙船演算子</link> と同じように動作します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>num</parameter></term>
+    <listitem>
+     <simpara>
+      比較する値。
+     </simpara>
+    </listitem>
+   </varlistentry>
+    <varlistentry>
+     <term><parameter>scale</parameter></term>
+     <listitem>
+      <simpara>
+       比較に使用する <parameter>scale</parameter> を指定します。
+       &null; の場合、比較にはすべての桁が使用されます。
+      </simpara>
+     </listitem>
+    </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   2つの値が等しい場合は <literal>0</literal>、<varname>$this</varname> が <parameter>num</parameter>
+   より大きい場合は <literal>1</literal>、小さければ <literal>-1</literal> を返します。
+  </simpara>
+ </refsect1>
+
+ <!-- error -->
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('bcmath-number.add')/db:refsect1[@role='errors'])" />
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><methodname>BcMath\Number::compare</methodname> で <parameter>scale</parameter> を指定しない例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$number = new BcMath\Number('1.234');
+
+var_dump(
+    $number->compare(new BcMath\Number('1.234')),
+    $number->compare('1.23400'),
+    $number->compare('1.23401'),
+    $number->compare(1),
+);
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+int(0)
+int(0)
+int(-1)
+int(1)
+]]>
+   </screen>
+  </example>
+
+  <example>
+   <title><methodname>BcMath\Number::compare</methodname> で <parameter>scale</parameter> を指定する例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$number = new BcMath\Number('1.234');
+
+var_dump(
+    $number->compare(new BcMath\Number('1.299'), 1),
+    $number->compare('1.24', 2),
+    $number->compare('1.22', 2),
+    $number->compare(1, 0),
+);
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+int(0)
+int(-1)
+int(1)
+int(0)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>bccomp</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/bc/bcmath/number/construct.xml
+++ b/reference/bc/bcmath/number/construct.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: saki Status: ready -->
+<!-- EN-Revision: a414ee95eb79e2c62c80827a46e15da5d15af97e Maintainer: saki Status: ready -->
 
 <refentry xml:id="bcmath-number.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/bc/bcmath/number/construct.xml
+++ b/reference/bc/bcmath/number/construct.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: saki Status: ready -->
+
+<refentry xml:id="bcmath-number.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>BcMath\Number::__construct</refname>
+  <refpurpose>BcMath\Number オブジェクトを作成する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <constructorsynopsis role="BcMath\\Number">
+   <modifier>public</modifier> <methodname>BcMath\Number::__construct</methodname>
+   <methodparam><type class="union"><type>string</type><type>int</type></type><parameter>num</parameter></methodparam>
+  </constructorsynopsis>
+  <simpara>
+   <type>int</type> もしくは <type>string</type> の値から <classname>BcMath\Number</classname> オブジェクトを作成します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>num</parameter></term>
+    <listitem>
+     <simpara>
+      <type>int</type> もしくは <type>string</type> の値。
+      <parameter>num</parameter> が <type>int</type> の場合、<property>BcMath\Number::scale</property>
+      は常に <literal>0</literal> に設定されます。
+      <parameter>num</parameter> が <type>string</type> の場合、有効な BCMath 数値文字列である必要があり、
+      <property>BcMath\Number::scale</property> は自動的に文字列を解析して設定されます。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   このメソッドは、 <parameter>num</parameter> が <type>string</type> であり、BCMath で有効でない
+   数値形式の文字列である場合、<exceptionname>ValueError</exceptionname> をスローします。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><methodname>BcMath\Number::__construct</methodname> の例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$num1 = new BcMath\Number(100);
+$num2 = new BcMath\Number('-200');
+$num3 = new BcMath\Number('300.00');
+
+var_dump($num1, $num2, $num3);
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+object(BcMath\Number)#1 (2) {
+  ["value"]=>
+  string(3) "100"
+  ["scale"]=>
+  int(0)
+}
+object(BcMath\Number)#2 (2) {
+  ["value"]=>
+  string(4) "-200"
+  ["scale"]=>
+  int(0)
+}
+object(BcMath\Number)#3 (2) {
+  ["value"]=>
+  string(6) "300.00"
+  ["scale"]=>
+  int(2)
+}
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>BcMath\Number::__serialize</methodname></member>
+   <member><methodname>BcMath\Number::__unserialize</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/bc/bcmath/number/div.xml
+++ b/reference/bc/bcmath/number/div.xml
@@ -74,7 +74,7 @@
   </para>
   <simpara>
    このメソッドは、 <parameter>num</parameter> が <literal>0</literal> である場合、
-   <exceptionname>DivisionByZeroError</exceptionname> exception をスローします。
+   <exceptionname>DivisionByZeroError</exceptionname> 例外をスローします。
   </simpara>
  </refsect1>
 

--- a/reference/bc/bcmath/number/div.xml
+++ b/reference/bc/bcmath/number/div.xml
@@ -1,0 +1,246 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: saki Status: ready -->
+
+<refentry xml:id="bcmath-number.div" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <refnamediv>
+  <refname>BcMath\Number::div</refname>
+  <refpurpose>任意精度数値の除算を行う</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="BcMath\\Number">
+   <modifier>public</modifier> <type>BcMath\Number</type><methodname>BcMath\Number::div</methodname>
+   <methodparam><type class="union"><type>BcMath\Number</type><type>string</type><type>int</type></type><parameter>num</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>scale</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   <varname>$this</varname> を <parameter>num</parameter> で割ります。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>num</parameter></term>
+    <listitem>
+     <simpara>
+      除数を表す値。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('bcmath-number.add')/db:refsect1[@role='parameters']/descendant::db:varlistentry[2])" />
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   除算結果を新しい <classname>BcMath\Number</classname> オブジェクトとして返します。
+  </simpara>
+  <simpara>
+   除算結果オブジェクトの <property>BcMath\Number::scale</property> が自動的に設定される場合、被除数の
+   <property>BcMath\Number::scale</property> が使用されます。ただし、割り切れない除算の場合は、
+   除算結果オブジェクトの <property>BcMath\Number::scale</property> が拡張されます。
+   拡張は必要に応じてのみ行われ、最大で <literal>+10</literal> まで拡張されます。
+  </simpara>
+  <simpara>
+   つまり、被除数の <property>BcMath\Number::scale</property> が <literal>5</literal> の場合、
+   除算結果オブジェクトの <property>BcMath\Number::scale</property> は <literal>5</literal> から
+   <literal>15</literal> の間になります。
+  </simpara>
+  <simpara>
+   割り切れない除算の場合でも、除算結果オブジェクトの <property>BcMath\Number::scale</property> は常に <literal>+10</literal>
+   まで拡張されるわけではありません。
+   末尾が <literal>0</literal> である場合は拡張の必要がないと見なされるため、 <property>BcMath\Number::scale</property>
+   はその分だけ少なくなります。
+   また、最終的な <property>BcMath\Number::scale</property> は、拡張前の <property>BcMath\Number::scale</property>
+   よりも小さくなることはありません。
+   <link linkend="bcmath-number.div.example.expansion-scale">コード例</link> も参照してください。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   このメソッドは、以下の場合に <classname>ValueError</classname> をスローします:
+   <simplelist>
+    <member><parameter>num</parameter> が、BCMath で有効でない数値形式の文字列である場合</member>
+    <member><parameter>scale</parameter> が範囲外の値である場合</member>
+    <member>結果オブジェクトの <property>BcMath\Number::scale</property> が範囲外の値である場合</member>
+   </simplelist>
+  </para>
+  <simpara>
+   このメソッドは、 <parameter>num</parameter> が <literal>0</literal> である場合、
+   <exceptionname>DivisionByZeroError</exceptionname> exception をスローします。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><methodname>BcMath\Number::div</methodname> で <parameter>scale</parameter> を指定しない例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$number = new BcMath\Number('0.002');
+
+$ret1 = $number->div(new BcMath\Number('2.000'));
+$ret2 = $number->div('-3');
+$ret3 = $number->div(32);
+
+var_dump($number, $ret1, $ret2, $ret3);
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+object(BcMath\Number)#1 (2) {
+  ["value"]=>
+  string(5) "0.002"
+  ["scale"]=>
+  int(3)
+}
+object(BcMath\Number)#3 (2) {
+  ["value"]=>
+  string(5) "0.001"
+  ["scale"]=>
+  int(3)
+}
+object(BcMath\Number)#2 (2) {
+  ["value"]=>
+  string(16) "-0.0006666666666"
+  ["scale"]=>
+  int(13)
+}
+object(BcMath\Number)#4 (2) {
+  ["value"]=>
+  string(9) "0.0000625"
+  ["scale"]=>
+  int(7)
+}
+]]>
+   </screen>
+  </example>
+
+  <example>
+   <title><methodname>BcMath\Number::div</methodname> で <parameter>scale</parameter> を指定する例</parameter></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$number = new BcMath\Number('0.002');
+
+$ret1 = $number->div(new BcMath\Number('2.000'), 15);
+$ret2 = $number->div('-3', 5);
+$ret3 = $number->div(32, 2);
+
+var_dump($number, $ret1, $ret2, $ret3);
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+object(BcMath\Number)#1 (2) {
+  ["value"]=>
+  string(5) "0.002"
+  ["scale"]=>
+  int(3)
+}
+object(BcMath\Number)#3 (2) {
+  ["value"]=>
+  string(17) "0.001000000000000"
+  ["scale"]=>
+  int(15)
+}
+object(BcMath\Number)#2 (2) {
+  ["value"]=>
+  string(8) "-0.00066"
+  ["scale"]=>
+  int(5)
+}
+object(BcMath\Number)#4 (2) {
+  ["value"]=>
+  string(4) "0.00"
+  ["scale"]=>
+  int(2)
+}
+]]>
+   </screen>
+  </example>
+
+  <example xml:id="bcmath-number.div.example.expansion-scale">
+   <title><methodname>BcMath\Number::div</methodname> の結果の <property>BcMath\Number::scale</property> が拡張される例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+var_dump(
+    new BcMath\Number('0.001')->div('10001'),
+    new BcMath\Number('0.001')->div('10001', 13),
+    new BcMath\Number('0.001')->div('100000000000001'),
+);
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+object(BcMath\Number)#2 (2) {
+  ["value"]=>
+  string(13) "0.00000009999"
+  ["scale"]=>
+  int(11)
+}
+object(BcMath\Number)#3 (2) {
+  ["value"]=>
+  string(15) "0.0000000999900"
+  ["scale"]=>
+  int(13)
+}
+object(BcMath\Number)#4 (2) {
+  ["value"]=>
+  string(5) "0.000"
+  ["scale"]=>
+  int(3)
+}
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>bcdiv</function></member>
+   <member><methodname>BcMath\Number::divmod</methodname></member>
+   <member><methodname>BcMath\Number::mod</methodname></member>
+   <member><methodname>BcMath\Number::sqrt</methodname></member>
+   <member><methodname>BcMath\Number::pow</methodname></member>
+   <member><methodname>BcMath\Number::mul</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/bc/bcmath/number/div.xml
+++ b/reference/bc/bcmath/number/div.xml
@@ -127,7 +127,7 @@ object(BcMath\Number)#4 (2) {
   </example>
 
   <example>
-   <title><methodname>BcMath\Number::div</methodname> で <parameter>scale</parameter> を指定する例</parameter></title>
+   <title><methodname>BcMath\Number::div</methodname> で <parameter>scale</parameter> を指定する例</title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/bc/bcmath/number/div.xml
+++ b/reference/bc/bcmath/number/div.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: saki Status: ready -->
+<!-- EN-Revision: a414ee95eb79e2c62c80827a46e15da5d15af97e Maintainer: saki Status: ready -->
 
 <refentry xml:id="bcmath-number.div" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>

--- a/reference/bc/bcmath/number/divmod.xml
+++ b/reference/bc/bcmath/number/divmod.xml
@@ -1,0 +1,221 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: saki Status: ready -->
+
+<refentry xml:id="bcmath-number.divmod" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <refnamediv>
+  <refname>BcMath\Number::divmod</refname>
+  <refpurpose>任意精度数値の商と剰余を取得する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="BcMath\\Number">
+   <modifier>public</modifier> <type>array</type><methodname>BcMath\Number::divmod</methodname>
+   <methodparam><type class="union"><type>BcMath\Number</type><type>string</type><type>int</type></type><parameter>num</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>scale</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   <varname>$this</varname> を <parameter>num</parameter> で割った商と剰余を取得します。
+  </simpara>
+ </refsect1>
+
+ <!-- parameters -->
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('bcmath-number.div')/db:refsect1[@role='parameters'])" />
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   1つ目の要素に商として新しい <classname>BcMath\Number</classname> オブジェクトが、
+   2つ目の要素に剰余として新しい <classname>BcMath\Number</classname> オブジェクトが格納された配列を返します。
+  </simpara>
+  <simpara>
+   商は常に整数値となるため、商オブジェクトの <property>BcMath\Number::scale</property> は <parameter>scale</parameter>
+   の指定に関わらず、常に <literal>0</literal> になります。
+  </simpara>
+  <simpara>
+   <parameter>scale</parameter> を明示的に指定した場合、剰余オブジェクトの <property>BcMath\Number::scale</property> は指定された値になります。
+   剰余オブジェクトの <property>BcMath\Number::scale</property> が自動的に設定される場合、計算に使用された2つの数値のうち、大きい方の
+   <property>BcMath\Number::scale</property> が使用されます。
+  </simpara>
+  <simpara>
+   つまり、2つの値の <property>BcMath\Number::scale</property> がそれぞれ <literal>2</literal> と <literal>5</literal> の場合、
+   剰余オブジェクトの <property>BcMath\Number::scale</property> は <literal>5</literal> になります。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <!-- ValueError cases -->
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('bcmath-number.add')/db:refsect1[@role='errors']/db:para[1])" />
+  <!-- The DivisionByZeroError case -->
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('bcmath-number.div')/db:refsect1[@role='errors']/db:simpara[1])" />
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><methodname>BcMath\Number::divmod</methodname> で <parameter>scale</parameter> を指定しない例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+echo '8.3 / 2.22' . PHP_EOL;
+[$quot, $rem] = new BcMath\Number('8')->divmod(new BcMath\Number('2.22'));
+var_dump($quot, $rem);
+
+echo PHP_EOL . '8.3 / 8.3' . PHP_EOL;
+[$quot, $rem] = new BcMath\Number('8.3')->divmod('8.3');
+var_dump($quot, $rem);
+
+echo PHP_EOL . '10 / -3' . PHP_EOL;
+[$quot, $rem] = new BcMath\Number('10')->divmod(-3);
+var_dump($quot, $rem);
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+8.3 / 2.22
+object(BcMath\Number)#3 (2) {
+  ["value"]=>
+  string(1) "3"
+  ["scale"]=>
+  int(0)
+}
+object(BcMath\Number)#4 (2) {
+  ["value"]=>
+  string(4) "1.34"
+  ["scale"]=>
+  int(2)
+}
+
+8.3 / 8.3
+object(BcMath\Number)#2 (2) {
+  ["value"]=>
+  string(1) "1"
+  ["scale"]=>
+  int(0)
+}
+object(BcMath\Number)#5 (2) {
+  ["value"]=>
+  string(3) "0.0"
+  ["scale"]=>
+  int(1)
+}
+
+10 / -3
+object(BcMath\Number)#3 (2) {
+  ["value"]=>
+  string(2) "-3"
+  ["scale"]=>
+  int(0)
+}
+object(BcMath\Number)#1 (2) {
+  ["value"]=>
+  string(1) "1"
+  ["scale"]=>
+  int(0)
+}
+]]>
+   </screen>
+  </example>
+
+  <example>
+   <title><methodname>BcMath\Number::divmod</methodname> で <parameter>scale</parameter> を指定する例</parameter></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+echo '8.3 / 2.22' . PHP_EOL;
+[$quot, $rem] = new BcMath\Number('8')->divmod(new BcMath\Number('2.22'), 1);
+var_dump($quot, $rem);
+
+echo PHP_EOL . '8.3 / 8.3' . PHP_EOL;
+[$quot, $rem] = new BcMath\Number('8.3')->divmod('8.3', 4);
+var_dump($quot, $rem);
+
+echo PHP_EOL . '10 / -3' . PHP_EOL;
+[$quot, $rem] = new BcMath\Number('10')->divmod(-3, 5);
+var_dump($quot, $rem);
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+8.3 / 2.22
+object(BcMath\Number)#3 (2) {
+  ["value"]=>
+  string(1) "3"
+  ["scale"]=>
+  int(0)
+}
+object(BcMath\Number)#4 (2) {
+  ["value"]=>
+  string(3) "1.3"
+  ["scale"]=>
+  int(1)
+}
+
+8.3 / 8.3
+object(BcMath\Number)#2 (2) {
+  ["value"]=>
+  string(1) "1"
+  ["scale"]=>
+  int(0)
+}
+object(BcMath\Number)#5 (2) {
+  ["value"]=>
+  string(6) "0.0000"
+  ["scale"]=>
+  int(4)
+}
+
+10 / -3
+object(BcMath\Number)#3 (2) {
+  ["value"]=>
+  string(2) "-3"
+  ["scale"]=>
+  int(0)
+}
+object(BcMath\Number)#1 (2) {
+  ["value"]=>
+  string(7) "1.00000"
+  ["scale"]=>
+  int(5)
+}
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>bcdivmod</function></member>
+   <member><methodname>BcMath\Number::div</methodname></member>
+   <member><methodname>BcMath\Number::mod</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/bc/bcmath/number/divmod.xml
+++ b/reference/bc/bcmath/number/divmod.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: saki Status: ready -->
+<!-- EN-Revision: 6fdd8cf867d2f815053cf710ec0be441c33ed675 Maintainer: saki Status: ready -->
 
 <refentry xml:id="bcmath-number.divmod" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>

--- a/reference/bc/bcmath/number/divmod.xml
+++ b/reference/bc/bcmath/number/divmod.xml
@@ -122,7 +122,7 @@ object(BcMath\Number)#1 (2) {
   </example>
 
   <example>
-   <title><methodname>BcMath\Number::divmod</methodname> で <parameter>scale</parameter> を指定する例</parameter></title>
+   <title><methodname>BcMath\Number::divmod</methodname> で <parameter>scale</parameter> を指定する例</title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/bc/bcmath/number/floor.xml
+++ b/reference/bc/bcmath/number/floor.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: saki Status: ready -->
+
+<refentry xml:id="bcmath-number.floor" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <refnamediv>
+  <refname>BcMath\Number::floor</refname>
+  <refpurpose>任意精度数値を切り下げる</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="BcMath\\Number">
+   <modifier>public</modifier> <type>BcMath\Number</type><methodname>BcMath\Number::floor</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   必要に応じて <varname>$this</varname> を切り下げ、 <varname>$this</varname> の次に小さい整数値を返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <!-- returnvalues -->
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('bcmath-number.ceil')/db:refsect1[@role='returnvalues'])" />
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><methodname>BcMath\Number::floor</methodname> の例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$num1 = new BcMath\Number('4.3')->floor();
+$num2 = new BcMath\Number('9.999')->floor();
+$num3 = new BcMath\Number('-3.14')->floor();
+
+var_dump($num1, $num2, $num3);
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+object(BcMath\Number)#2 (2) {
+  ["value"]=>
+  string(1) "4"
+  ["scale"]=>
+  int(0)
+}
+object(BcMath\Number)#3 (2) {
+  ["value"]=>
+  string(1) "9"
+  ["scale"]=>
+  int(0)
+}
+object(BcMath\Number)#4 (2) {
+  ["value"]=>
+  string(2) "-4"
+  ["scale"]=>
+  int(0)
+}
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>bcfloor</function></member>
+   <member><methodname>BcMath\Number::ceil</methodname></member>
+   <member><methodname>BcMath\Number::round</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/bc/bcmath/number/mod.xml
+++ b/reference/bc/bcmath/number/mod.xml
@@ -95,7 +95,7 @@ object(BcMath\Number)#4 (2) {
   </example>
 
   <example>
-   <title><methodname>BcMath\Number::mod</methodname> で <parameter>scale</parameter> を指定する例</parameter></title>
+   <title><methodname>BcMath\Number::mod</methodname> で <parameter>scale</parameter> を指定する例</title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/bc/bcmath/number/mod.xml
+++ b/reference/bc/bcmath/number/mod.xml
@@ -1,0 +1,174 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: saki Status: ready -->
+
+<refentry xml:id="bcmath-number.mod" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <refnamediv>
+  <refname>BcMath\Number::mod</refname>
+  <refpurpose>任意精度数値の剰余を取得する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="BcMath\\Number">
+   <modifier>public</modifier> <type>BcMath\Number</type><methodname>BcMath\Number::mod</methodname>
+   <methodparam><type class="union"><type>BcMath\Number</type><type>string</type><type>int</type></type><parameter>num</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>scale</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   <varname>$this</varname> を <parameter>num</parameter> で割った剰余を取得します。
+   <parameter>num</parameter> が <literal>0</literal> でない限り, 結果は <varname>$this</varname>
+   と同じ符号になります。
+  </simpara>
+ </refsect1>
+
+ <!-- parameters -->
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('bcmath-number.div')/db:refsect1[@role='parameters'])" />
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   剰余オブジェクトを新しい <classname>BcMath\Number</classname> オブジェクトとして返します。
+  </simpara>
+  <simpara>
+   剰余オブジェクトの <property>BcMath\Number::scale</property> が自動的に設定される場合、剰余計算に使用する2つの数値のうち、
+   大きい方の <property>BcMath\Number::scale</property> が使用されます。
+  </simpara>
+  <!-- Auto scale example -->
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('bcmath-number.add')/db:refsect1[@role='returnvalues']/db:simpara[3])" />
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <!-- ValueError cases -->
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('bcmath-number.add')/db:refsect1[@role='errors']/db:para[1])" />
+  <!-- The DivisionByZeroError case -->
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('bcmath-number.div')/db:refsect1[@role='errors']/db:simpara[1])" />
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><methodname>BcMath\Number::mod</methodname> で <parameter>scale</parameter> を指定しない例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$number = new BcMath\Number('8.3');
+
+$ret1 = $number->mod(new BcMath\Number('2.22'));
+$ret2 = $number->mod('8.3');
+$ret3 = $number->mod(-5);
+
+var_dump($number, $ret1, $ret2, $ret3);
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+object(BcMath\Number)#1 (2) {
+  ["value"]=>
+  string(3) "8.3"
+  ["scale"]=>
+  int(1)
+}
+object(BcMath\Number)#3 (2) {
+  ["value"]=>
+  string(4) "1.64"
+  ["scale"]=>
+  int(2)
+}
+object(BcMath\Number)#2 (2) {
+  ["value"]=>
+  string(3) "0.0"
+  ["scale"]=>
+  int(1)
+}
+object(BcMath\Number)#4 (2) {
+  ["value"]=>
+  string(3) "3.3"
+  ["scale"]=>
+  int(1)
+}
+]]>
+   </screen>
+  </example>
+
+  <example>
+   <title><methodname>BcMath\Number::mod</methodname> で <parameter>scale</parameter> を指定する例</parameter></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$number = new BcMath\Number('8.3');
+
+$ret1 = $number->mod(new BcMath\Number('2.22'), 1);
+$ret2 = $number->mod('8.3', 3);
+$ret3 = $number->mod(-5, 0);
+
+var_dump($number, $ret1, $ret2, $ret3);
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+object(BcMath\Number)#1 (2) {
+  ["value"]=>
+  string(3) "8.3"
+  ["scale"]=>
+  int(1)
+}
+object(BcMath\Number)#3 (2) {
+  ["value"]=>
+  string(3) "1.6"
+  ["scale"]=>
+  int(1)
+}
+object(BcMath\Number)#2 (2) {
+  ["value"]=>
+  string(5) "0.000"
+  ["scale"]=>
+  int(3)
+}
+object(BcMath\Number)#4 (2) {
+  ["value"]=>
+  string(1) "3"
+  ["scale"]=>
+  int(0)
+}
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>bcmod</function></member>
+   <member><methodname>BcMath\Number::div</methodname></member>
+   <member><methodname>BcMath\Number::divmod</methodname></member>
+   <member><methodname>BcMath\Number::powmod</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/bc/bcmath/number/mod.xml
+++ b/reference/bc/bcmath/number/mod.xml
@@ -17,7 +17,7 @@
   </methodsynopsis>
   <simpara>
    <varname>$this</varname> を <parameter>num</parameter> で割った剰余を取得します。
-   <parameter>num</parameter> が <literal>0</literal> でない限り, 結果は <varname>$this</varname>
+   <parameter>num</parameter> が <literal>0</literal> でない限り、 結果は <varname>$this</varname>
    と同じ符号になります。
   </simpara>
  </refsect1>

--- a/reference/bc/bcmath/number/mul.xml
+++ b/reference/bc/bcmath/number/mul.xml
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: saki Status: ready -->
+
+<refentry xml:id="bcmath-number.mul" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <refnamediv>
+  <refname>BcMath\Number::mul</refname>
+  <refpurpose>任意精度数値の乗算を行う</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="BcMath\\Number">
+   <modifier>public</modifier> <type>BcMath\Number</type><methodname>BcMath\Number::mul</methodname>
+   <methodparam><type class="union"><type>BcMath\Number</type><type>string</type><type>int</type></type><parameter>num</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>scale</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   <varname>$this</varname> に <parameter>num</parameter> を掛けます。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>num</parameter></term>
+    <listitem>
+     <simpara>
+      乗数を表す値。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('bcmath-number.add')/db:refsect1[@role='parameters']/descendant::db:varlistentry[2])" />
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   乗算結果を新しい <classname>BcMath\Number</classname> オブジェクトとして返します。
+  </simpara>
+  <simpara>
+   乗算結果オブジェクトの <property>BcMath\Number::scale</property> が自動的に設定される場合、乗算に使用する2つの数値の
+   <property>BcMath\Number::scale</property> の合計値が使用されます。
+  </simpara>
+  <simpara>
+   つまり、2つの値の <property>BcMath\Number::scale</property> がそれぞれ <literal>2</literal> と <literal>5</literal> の場合、
+   乗算結果オブジェクトの <property>BcMath\Number::scale</property> は <literal>7</literal> になります。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <!-- ValueError cases -->
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('bcmath-number.div')/db:refsect1[@role='errors']/db:para[1])" />
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><methodname>BcMath\Number::mul</methodname> で <parameter>scale</parameter> を指定しない例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$number = new BcMath\Number('1.234');
+
+$ret1 = $number->mul(new BcMath\Number('2.3456'));
+$ret2 = $number->mul('-3.4');
+$ret3 = $number->mul(7);
+
+var_dump($number, $ret1, $ret2, $ret3);
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+object(BcMath\Number)#1 (2) {
+  ["value"]=>
+  string(5) "1.234"
+  ["scale"]=>
+  int(3)
+}
+object(BcMath\Number)#3 (2) {
+  ["value"]=>
+  string(9) "2.8944704"
+  ["scale"]=>
+  int(7)
+}
+object(BcMath\Number)#2 (2) {
+  ["value"]=>
+  string(7) "-4.1956"
+  ["scale"]=>
+  int(4)
+}
+object(BcMath\Number)#4 (2) {
+  ["value"]=>
+  string(5) "8.638"
+  ["scale"]=>
+  int(3)
+}
+]]>
+   </screen>
+  </example>
+
+  <example>
+   <title><methodname>BcMath\Number::mul</methodname> で <parameter>scale</parameter> を指定する例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$number = new BcMath\Number('1.234');
+
+$ret1 = $number->mul(new BcMath\Number('2.3456'), 1);
+$ret2 = $number->mul('-3.4', 10);
+$ret3 = $number->mul(7, 0);
+
+var_dump($number, $ret1, $ret2, $ret3);
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+object(BcMath\Number)#1 (2) {
+  ["value"]=>
+  string(5) "1.234"
+  ["scale"]=>
+  int(3)
+}
+object(BcMath\Number)#3 (2) {
+  ["value"]=>
+  string(3) "2.8"
+  ["scale"]=>
+  int(1)
+}
+object(BcMath\Number)#2 (2) {
+  ["value"]=>
+  string(13) "-4.1956000000"
+  ["scale"]=>
+  int(10)
+}
+object(BcMath\Number)#4 (2) {
+  ["value"]=>
+  string(1) "8"
+  ["scale"]=>
+  int(0)
+}
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>bcmul</function></member>
+   <member><methodname>BcMath\Number::div</methodname></member>
+   <member><methodname>BcMath\Number::pow</methodname></member>
+   <member><methodname>BcMath\Number::powmod</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/bc/bcmath/number/pow.xml
+++ b/reference/bc/bcmath/number/pow.xml
@@ -1,0 +1,225 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: saki Status: ready -->
+
+<refentry xml:id="bcmath-number.pow" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <refnamediv>
+  <refname>BcMath\Number::pow</refname>
+  <refpurpose>任意精度数値をべき乗する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="BcMath\\Number">
+   <modifier>public</modifier> <type>BcMath\Number</type><methodname>BcMath\Number::pow</methodname>
+   <methodparam><type class="union"><type>BcMath\Number</type><type>string</type><type>int</type></type><parameter>exponent</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>scale</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   <varname>$this</varname> の
+   <parameter>exponent</parameter> 乗を求めます。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>exponent</parameter></term>
+    <listitem>
+     <simpara>
+       指数を表す値。整数値でなければなりません。
+       <parameter>exponent</parameter> の有効な範囲はプラットフォームに依存しますが、少なくとも
+       <literal>-2147483648</literal> から <literal>2147483647</literal> までの範囲を持ちます。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('bcmath-number.add')/db:refsect1[@role='parameters']/descendant::db:varlistentry[2])" />
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   べき乗の結果を新しい <classname>BcMath\Number</classname> オブジェクトとして返します。
+  </simpara>
+  <para>
+   べき乗結果オブジェクトの <property>BcMath\Number::scale</property> が自動的に設定される場合、
+   <parameter>exponent</parameter> の値に応じて、結果の <property>BcMath\Number::scale</property> が以下のようになります:
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry><parameter>exponent</parameter></entry>
+       <entry>べき乗結果オブジェクトの <property>BcMath\Number::scale</property></entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>正の値</entry>
+       <entry>(基数の <property>BcMath\Number::scale</property>) * (<parameter>exponent</parameter> の値)</entry>
+      </row>
+      <row>
+       <entry><literal>0</literal></entry>
+       <entry><literal>0</literal></entry>
+      </row>
+      <row>
+       <entry>負の値</entry>
+       <entry>(基数の <property>BcMath\Number::scale</property>) と (基数の <property>BcMath\Number::scale</property> +
+       <literal>10</literal>) の間</entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+  <simpara>
+   負の <parameter>exponent</parameter> を指定し割り切れない除算が発生した場合、べき乗結果オブジェクトの <property>
+   BcMath\Number::scale</property> が拡張されます。拡張は必要な場合にのみ行われ、最大で <literal>+10</literal> まで拡張されます。
+   この動作は <methodname>BcMath\Number::div</methodname> と同じですので、詳しくはそちらを参照して下さい。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   このメソッドは、以下の場合に <exceptionname>ValueError</exceptionname> をスローします:
+   <simplelist>
+    <member><parameter>exponent</parameter> が、BCMath で有効でない数値形式の文字列である場合</member>
+    <member><parameter>exponent</parameter> が整数値でない場合</member>
+    <member><parameter>exponent</parameter> もしくは <parameter>scale</parameter> が範囲外の値である場合</member>
+    <member>結果オブジェクトの <property>BcMath\Number::scale</property> が範囲外の値である場合</member>
+   </simplelist>
+  </para>
+  <simpara>
+   このメソッドは、<varname>$this</varname> の値が <literal>0</literal> かつ <parameter>exponent</parameter> が負の値である場合、
+   <exceptionname>DivisionByZeroError</exceptionname> exception をスローします。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><methodname>BcMath\Number::pow</methodname> で <parameter>scale</parameter> を指定しない例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$number = new BcMath\Number('3.0');
+
+$ret1 = $number->pow(new BcMath\Number('5'));
+$ret2 = $number->pow('-1');
+$ret3 = $number->pow(0);
+
+var_dump($number, $ret1, $ret2, $ret3);
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+object(BcMath\Number)#1 (2) {
+  ["value"]=>
+  string(3) "3.0"
+  ["scale"]=>
+  int(1)
+}
+object(BcMath\Number)#3 (2) {
+  ["value"]=>
+  string(9) "243.00000"
+  ["scale"]=>
+  int(5)
+}
+object(BcMath\Number)#2 (2) {
+  ["value"]=>
+  string(13) "0.33333333333"
+  ["scale"]=>
+  int(11)
+}
+object(BcMath\Number)#4 (2) {
+  ["value"]=>
+  string(1) "1"
+  ["scale"]=>
+  int(0)
+}
+]]>
+   </screen>
+  </example>
+
+  <example>
+   <title><methodname>BcMath\Number::pow</methodname> で <parameter>scale</parameter> を指定する例</parameter></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$number = new BcMath\Number('3.0');
+
+$ret1 = $number->pow(new BcMath\Number('5'), 0);
+$ret2 = $number->pow('-1', 2);
+$ret3 = $number->pow(0, 10);
+
+var_dump($number, $ret1, $ret2, $ret3);
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+object(BcMath\Number)#1 (2) {
+  ["value"]=>
+  string(3) "3.0"
+  ["scale"]=>
+  int(1)
+}
+object(BcMath\Number)#3 (2) {
+  ["value"]=>
+  string(3) "243"
+  ["scale"]=>
+  int(0)
+}
+object(BcMath\Number)#2 (2) {
+  ["value"]=>
+  string(4) "0.33"
+  ["scale"]=>
+  int(2)
+}
+object(BcMath\Number)#4 (2) {
+  ["value"]=>
+  string(12) "1.0000000000"
+  ["scale"]=>
+  int(10)
+}
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>bcpow</function></member>
+   <member><methodname>BcMath\Number::powmod</methodname></member>
+   <member><methodname>BcMath\Number::mul</methodname></member>
+   <member><methodname>BcMath\Number::sqrt</methodname></member>
+   <member><methodname>BcMath\Number::div</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/bc/bcmath/number/pow.xml
+++ b/reference/bc/bcmath/number/pow.xml
@@ -92,7 +92,7 @@
   </para>
   <simpara>
    このメソッドは、<varname>$this</varname> の値が <literal>0</literal> かつ <parameter>exponent</parameter> が負の値である場合、
-   <exceptionname>DivisionByZeroError</exceptionname> exception をスローします。
+   <exceptionname>DivisionByZeroError</exceptionname> 例外をスローします。
   </simpara>
  </refsect1>
 

--- a/reference/bc/bcmath/number/pow.xml
+++ b/reference/bc/bcmath/number/pow.xml
@@ -145,7 +145,7 @@ object(BcMath\Number)#4 (2) {
   </example>
 
   <example>
-   <title><methodname>BcMath\Number::pow</methodname> で <parameter>scale</parameter> を指定する例</parameter></title>
+   <title><methodname>BcMath\Number::pow</methodname> で <parameter>scale</parameter> を指定する例</title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/bc/bcmath/number/powmod.xml
+++ b/reference/bc/bcmath/number/powmod.xml
@@ -64,7 +64,7 @@
    このメソッドは、以下の場合に <exceptionname>ValueError</exceptionname> をスローします:
    <simplelist>
     <member><parameter>exponent</parameter> もしくは <parameter>modulus</parameter> が、BCMath で有効でない数値形式の文字列である場合</member>
-    <member><member><varname>$this</varname> か <parameter>exponent</parameter> か <parameter>modulus</parameter> のうち、どれか一つでも整数値でない場合</member>
+    <member><varname>$this</varname> か <parameter>exponent</parameter> か <parameter>modulus</parameter> のうち、どれか一つでも整数値でない場合</member>
     <member><parameter>exponent</parameter> が負の値である場合</member>
     <member><parameter>scale</parameter> が範囲外の値である場合</member>
    </simplelist>

--- a/reference/bc/bcmath/number/powmod.xml
+++ b/reference/bc/bcmath/number/powmod.xml
@@ -1,0 +1,200 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: saki Status: ready -->
+
+<refentry xml:id="bcmath-number.powmod" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <refnamediv>
+  <refname>BcMath\Number::powmod</refname>
+  <refpurpose>任意精度数値のべき乗の、指定した数値による剰余</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="BcMath\\Number">
+   <modifier>public</modifier> <type>BcMath\Number</type><methodname>BcMath\Number::powmod</methodname>
+   <methodparam><type class="union"><type>BcMath\Number</type><type>string</type><type>int</type></type><parameter>exponent</parameter></methodparam>
+   <methodparam><type class="union"><type>BcMath\Number</type><type>string</type><type>int</type></type><parameter>modulus</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>scale</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   <parameter>modulus</parameter> で割った余りを求めることを考慮して、
+   <varname>$this</varname> の
+   <parameter>exponent</parameter> 乗を高速に計算します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>exponent</parameter></term>
+    <listitem>
+     <simpara>
+       基数を表す整数の値。
+       (つまり、scale は 0 でなければいけません)
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>modulus</parameter></term>
+    <listitem>
+     <simpara>
+       指数を表す、負でない、整数の値。
+       (つまり、scale は 0 でなければいけません)
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('bcmath-number.add')/db:refsect1[@role='parameters']/descendant::db:varlistentry[2])" />
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   計算結果を新しい <classname>BcMath\Number</classname> オブジェクトとして返します。
+  </simpara>
+  <simpara>
+   計算結果オブジェクトの <property>BcMath\Number::scale</property> が自動的に設定される場合、常に <literal>0</literal> になります。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   このメソッドは、以下の場合に <exceptionname>ValueError</exceptionname> をスローします:
+   <simplelist>
+    <member><parameter>exponent</parameter> もしくは <parameter>modulus</parameter> が、BCMath で有効でない数値形式の文字列である場合</member>
+    <member><member><varname>$this</varname> か <parameter>exponent</parameter> か <parameter>modulus</parameter> のうち、どれか一つでも整数値でない場合</member>
+    <member><parameter>exponent</parameter> が負の値である場合</member>
+    <member><parameter>scale</parameter> が範囲外の値である場合</member>
+   </simplelist>
+  </para>
+  <simpara>
+   このメソッドは、 <parameter>modulus</parameter> が <literal>0</literal> である場合、
+   <exceptionname>DivisionByZeroError</exceptionname> exception をスローします。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><methodname>BcMath\Number::powmod</methodname> で <parameter>scale</parameter> を指定しない例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+var_dump(
+    new BcMath\Number('8')->powmod(new BcMath\Number('3'), 5),
+    new BcMath\Number('-8')->powmod(new BcMath\Number('3'), 5),
+    new BcMath\Number('8')->powmod('2', -3),
+    new BcMath\Number('-8')->powmod(5, 7),
+);
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+object(BcMath\Number)#3 (2) {
+  ["value"]=>
+  string(1) "2"
+  ["scale"]=>
+  int(0)
+}
+object(BcMath\Number)#4 (2) {
+  ["value"]=>
+  string(2) "-2"
+  ["scale"]=>
+  int(0)
+}
+object(BcMath\Number)#2 (2) {
+  ["value"]=>
+  string(1) "1"
+  ["scale"]=>
+  int(0)
+}
+object(BcMath\Number)#5 (2) {
+  ["value"]=>
+  string(2) "-1"
+  ["scale"]=>
+  int(0)
+}
+]]>
+   </screen>
+  </example>
+
+  <example>
+   <title><methodname>BcMath\Number::powmod</methodname> で <parameter>scale</parameter> を指定する例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+var_dump(
+    new BcMath\Number('8')->powmod(new BcMath\Number('3'), 5, 1),
+    new BcMath\Number('-8')->powmod(new BcMath\Number('3'), 5, 2),
+    new BcMath\Number('8')->powmod('2', -3, 3),
+    new BcMath\Number('-8')->powmod(5, 7, 4),
+);
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+object(BcMath\Number)#3 (2) {
+  ["value"]=>
+  string(3) "2.0"
+  ["scale"]=>
+  int(1)
+}
+object(BcMath\Number)#4 (2) {
+  ["value"]=>
+  string(5) "-2.00"
+  ["scale"]=>
+  int(2)
+}
+object(BcMath\Number)#2 (2) {
+  ["value"]=>
+  string(5) "1.000"
+  ["scale"]=>
+  int(3)
+}
+object(BcMath\Number)#5 (2) {
+  ["value"]=>
+  string(7) "-1.0000"
+  ["scale"]=>
+  int(4)
+}
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>bcpowmod</function></member>
+   <member><methodname>BcMath\Number::pow</methodname></member>
+   <member><methodname>BcMath\Number::mod</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/bc/bcmath/number/powmod.xml
+++ b/reference/bc/bcmath/number/powmod.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: saki Status: ready -->
+<!-- EN-Revision: 6fdd8cf867d2f815053cf710ec0be441c33ed675 Maintainer: saki Status: ready -->
 
 <refentry xml:id="bcmath-number.powmod" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>

--- a/reference/bc/bcmath/number/powmod.xml
+++ b/reference/bc/bcmath/number/powmod.xml
@@ -71,7 +71,7 @@
   </para>
   <simpara>
    このメソッドは、 <parameter>modulus</parameter> が <literal>0</literal> である場合、
-   <exceptionname>DivisionByZeroError</exceptionname> exception をスローします。
+   <exceptionname>DivisionByZeroError</exceptionname> 例外をスローします。
   </simpara>
  </refsect1>
 

--- a/reference/bc/bcmath/number/round.xml
+++ b/reference/bc/bcmath/number/round.xml
@@ -141,7 +141,7 @@ object(BcMath\Number)#11 (2) {
   </example>
   <example>
    <title>
-    Example of using <methodname>BcMath\Number::round</methodname> で異なる <parameter>precision</parameter> を指定した例
+    <methodname>BcMath\Number::round</methodname> で異なる <parameter>precision</parameter> を指定した例
    </title>
    <programlisting role="php">
 <![CDATA[
@@ -210,7 +210,7 @@ object(BcMath\Number)#8 (2) {
   </example>
   <example>
    <title>
-    Example of using <methodname>BcMath\Number::round</methodname> で異なる <parameter>mode</parameter> を指定した例
+    <methodname>BcMath\Number::round</methodname> で異なる <parameter>mode</parameter> を指定した例
    </title>
    <programlisting role="php">
 <![CDATA[
@@ -351,7 +351,7 @@ object(BcMath\Number)#3 (2) {
   </example>
   <example>
    <title>
-    Example of using <methodname>BcMath\Number::round</methodname> で <parameter>precision</parameter> を指定し、
+    <methodname>BcMath\Number::round</methodname> で <parameter>precision</parameter> を指定し、
     異なる <parameter>mode</parameter> を指定した例
    </title>
    <programlisting role="php">

--- a/reference/bc/bcmath/number/round.xml
+++ b/reference/bc/bcmath/number/round.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: saki Status: ready -->
+<!-- EN-Revision: a414ee95eb79e2c62c80827a46e15da5d15af97e Maintainer: saki Status: ready -->
 
 <refentry xml:id="bcmath-number.round" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>
@@ -41,6 +41,13 @@
   &reftitle.returnvalues;
   <simpara>
    結果を新しい <classname>BcMath\Number</classname> オブジェクトとして返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   このメソッドは、無効な <parameter>mode</parameter> が指定された場合に <exceptionname>ValueError</exceptionname> をスローします。
   </simpara>
  </refsect1>
 

--- a/reference/bc/bcmath/number/round.xml
+++ b/reference/bc/bcmath/number/round.xml
@@ -1,0 +1,561 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: saki Status: ready -->
+
+<refentry xml:id="bcmath-number.round" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <refnamediv>
+  <refname>BcMath\Number::round</refname>
+  <refpurpose>任意精度数値を丸める</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="BcMath\\Number">
+   <modifier>public</modifier> <type>BcMath\Number</type><methodname>BcMath\Number::round</methodname>
+   <methodparam choice="opt"><type>int</type><parameter>precision</parameter><initializer>0</initializer></methodparam>
+   <methodparam choice="opt"><type>RoundingMode</type><parameter>mode</parameter><initializer>RoundingMode::HalfAwayFromZero</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   <varname>$this</varname> を、指定した <parameter>precision</parameter>(小数点以下の桁数)に丸めた値を返します。
+   <parameter>precision</parameter> を負またはゼロ(デフォルト) とすることも可能です。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <!-- precision parameter -->
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.round')/db:refsect1[@role='parameters']/descendant::db:varlistentry[2])" />
+   <varlistentry>
+    <term><parameter>mode</parameter></term>
+    <listitem>
+     <simpara>
+      指定する丸めモード。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   結果を新しい <classname>BcMath\Number</classname> オブジェクトとして返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+   <example>
+   <title><methodname>BcMath\Number::round</methodname> の例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+var_dump(
+    new BcMath\Number('3.4')->round(),
+    new BcMath\Number('3.5')->round(),
+    new BcMath\Number('3.6')->round(),
+    new BcMath\Number('3.6')->round(0),
+    new BcMath\Number('5.045')->round(2),
+    new BcMath\Number('5.055')->round(2),
+    new BcMath\Number('345')->round(-2),
+    new BcMath\Number('345')->round(-3),
+    new BcMath\Number('678')->round(-2),
+    new BcMath\Number('678')->round(-3),
+);
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen role="php">
+<![CDATA[
+object(BcMath\Number)#2 (2) {
+  ["value"]=>
+  string(1) "3"
+  ["scale"]=>
+  int(0)
+}
+object(BcMath\Number)#3 (2) {
+  ["value"]=>
+  string(1) "4"
+  ["scale"]=>
+  int(0)
+}
+object(BcMath\Number)#4 (2) {
+  ["value"]=>
+  string(1) "4"
+  ["scale"]=>
+  int(0)
+}
+object(BcMath\Number)#5 (2) {
+  ["value"]=>
+  string(1) "4"
+  ["scale"]=>
+  int(0)
+}
+object(BcMath\Number)#6 (2) {
+  ["value"]=>
+  string(4) "5.05"
+  ["scale"]=>
+  int(2)
+}
+object(BcMath\Number)#7 (2) {
+  ["value"]=>
+  string(4) "5.06"
+  ["scale"]=>
+  int(2)
+}
+object(BcMath\Number)#8 (2) {
+  ["value"]=>
+  string(3) "300"
+  ["scale"]=>
+  int(0)
+}
+object(BcMath\Number)#9 (2) {
+  ["value"]=>
+  string(1) "0"
+  ["scale"]=>
+  int(0)
+}
+object(BcMath\Number)#10 (2) {
+  ["value"]=>
+  string(3) "700"
+  ["scale"]=>
+  int(0)
+}
+object(BcMath\Number)#11 (2) {
+  ["value"]=>
+  string(4) "1000"
+  ["scale"]=>
+  int(0)
+}
+]]>
+   </screen>
+  </example>
+  <example>
+   <title>
+    Example of using <methodname>BcMath\Number::round</methodname> で異なる <parameter>precision</parameter> を指定した例
+   </title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$number = new BcMath\Number('123.45');
+
+var_dump(
+    $number->round(3),
+    $number->round(2),
+    $number->round(1),
+    $number->round(0),
+    $number->round(-1),
+    $number->round(-2),
+    $number->round(-3),
+);
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen role="php">
+<![CDATA[
+object(BcMath\Number)#2 (2) {
+  ["value"]=>
+  string(6) "123.45"
+  ["scale"]=>
+  int(2)
+}
+object(BcMath\Number)#3 (2) {
+  ["value"]=>
+  string(6) "123.45"
+  ["scale"]=>
+  int(2)
+}
+object(BcMath\Number)#4 (2) {
+  ["value"]=>
+  string(5) "123.5"
+  ["scale"]=>
+  int(1)
+}
+object(BcMath\Number)#5 (2) {
+  ["value"]=>
+  string(3) "123"
+  ["scale"]=>
+  int(0)
+}
+object(BcMath\Number)#6 (2) {
+  ["value"]=>
+  string(3) "120"
+  ["scale"]=>
+  int(0)
+}
+object(BcMath\Number)#7 (2) {
+  ["value"]=>
+  string(3) "100"
+  ["scale"]=>
+  int(0)
+}
+object(BcMath\Number)#8 (2) {
+  ["value"]=>
+  string(1) "0"
+  ["scale"]=>
+  int(0)
+}
+]]>
+   </screen>
+  </example>
+  <example>
+   <title>
+    Example of using <methodname>BcMath\Number::round</methodname> で異なる <parameter>mode</parameter> を指定した例
+   </title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+echo 'Rounding modes with 9.5' . PHP_EOL;
+$number = new BcMath\Number('9.5');
+var_dump(
+    $number->round(0, RoundingMode::HalfAwayFromZero),
+    $number->round(0, RoundingMode::HalfTowardsZero),
+    $number->round(0, RoundingMode::HalfEven),
+    $number->round(0, RoundingMode::HalfOdd),
+    $number->round(0, RoundingMode::TowardsZero),
+    $number->round(0, RoundingMode::AwayFromZero),
+    $number->round(0, RoundingMode::NegativeInfinity),
+    $number->round(0, RoundingMode::PositiveInfinity),
+);
+
+echo PHP_EOL;
+echo 'Rounding modes with 8.5' . PHP_EOL;
+$number = new BcMath\Number('8.5');
+var_dump(
+    $number->round(0, RoundingMode::HalfAwayFromZero),
+    $number->round(0, RoundingMode::HalfTowardsZero),
+    $number->round(0, RoundingMode::HalfEven),
+    $number->round(0, RoundingMode::HalfOdd),
+    $number->round(0, RoundingMode::TowardsZero),
+    $number->round(0, RoundingMode::AwayFromZero),
+    $number->round(0, RoundingMode::NegativeInfinity),
+    $number->round(0, RoundingMode::PositiveInfinity),
+);
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen role="php">
+<![CDATA[
+Rounding modes with 9.5
+object(BcMath\Number)#3 (2) {
+  ["value"]=>
+  string(2) "10"
+  ["scale"]=>
+  int(0)
+}
+object(BcMath\Number)#5 (2) {
+  ["value"]=>
+  string(1) "9"
+  ["scale"]=>
+  int(0)
+}
+object(BcMath\Number)#7 (2) {
+  ["value"]=>
+  string(2) "10"
+  ["scale"]=>
+  int(0)
+}
+object(BcMath\Number)#9 (2) {
+  ["value"]=>
+  string(1) "9"
+  ["scale"]=>
+  int(0)
+}
+object(BcMath\Number)#11 (2) {
+  ["value"]=>
+  string(1) "9"
+  ["scale"]=>
+  int(0)
+}
+object(BcMath\Number)#13 (2) {
+  ["value"]=>
+  string(2) "10"
+  ["scale"]=>
+  int(0)
+}
+object(BcMath\Number)#15 (2) {
+  ["value"]=>
+  string(1) "9"
+  ["scale"]=>
+  int(0)
+}
+object(BcMath\Number)#17 (2) {
+  ["value"]=>
+  string(2) "10"
+  ["scale"]=>
+  int(0)
+}
+
+Rounding modes with 8.5
+object(BcMath\Number)#1 (2) {
+  ["value"]=>
+  string(1) "9"
+  ["scale"]=>
+  int(0)
+}
+object(BcMath\Number)#15 (2) {
+  ["value"]=>
+  string(1) "8"
+  ["scale"]=>
+  int(0)
+}
+object(BcMath\Number)#13 (2) {
+  ["value"]=>
+  string(1) "8"
+  ["scale"]=>
+  int(0)
+}
+object(BcMath\Number)#11 (2) {
+  ["value"]=>
+  string(1) "9"
+  ["scale"]=>
+  int(0)
+}
+object(BcMath\Number)#9 (2) {
+  ["value"]=>
+  string(1) "8"
+  ["scale"]=>
+  int(0)
+}
+object(BcMath\Number)#7 (2) {
+  ["value"]=>
+  string(1) "9"
+  ["scale"]=>
+  int(0)
+}
+object(BcMath\Number)#5 (2) {
+  ["value"]=>
+  string(1) "8"
+  ["scale"]=>
+  int(0)
+}
+object(BcMath\Number)#3 (2) {
+  ["value"]=>
+  string(1) "9"
+  ["scale"]=>
+  int(0)
+}
+]]>
+   </screen>
+  </example>
+  <example>
+   <title>
+    Example of using <methodname>BcMath\Number::round</methodname> で <parameter>precision</parameter> を指定し、
+    異なる <parameter>mode</parameter> を指定した例
+   </title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$positive = new BcMath\Number('1.55');
+$negative = new BcMath\Number('-1.55');
+
+echo 'Using RoundingMode::HalfAwayFromZero with 1 decimal digit precision' . PHP_EOL;
+var_dump(
+    $positive->round(1, RoundingMode::HalfAwayFromZero),
+    $negative->round(1, RoundingMode::HalfAwayFromZero),
+);
+
+echo PHP_EOL;
+echo 'Using RoundingMode::HalfTowardsZero with 1 decimal digit precision' . PHP_EOL;
+var_dump(
+    $positive->round(1, RoundingMode::HalfTowardsZero),
+    $negative->round(1, RoundingMode::HalfTowardsZero),
+);
+
+echo PHP_EOL;
+echo 'Using RoundingMode::HalfEven with 1 decimal digit precision' . PHP_EOL;
+var_dump(
+    $positive->round(1, RoundingMode::HalfEven),
+    $negative->round(1, RoundingMode::HalfEven),
+);
+
+echo PHP_EOL;
+echo 'Using RoundingMode::HalfOdd with 1 decimal digit precision' . PHP_EOL;
+var_dump(
+    $positive->round(1, RoundingMode::HalfOdd),
+    $negative->round(1, RoundingMode::HalfOdd),
+);
+
+echo PHP_EOL;
+echo 'Using RoundingMode::TowardsZero with 1 decimal digit precision' . PHP_EOL;
+var_dump(
+    $positive->round(1, RoundingMode::TowardsZero),
+    $negative->round(1, RoundingMode::TowardsZero),
+);
+
+echo PHP_EOL;
+echo 'Using RoundingMode::AwayFromZero with 1 decimal digit precision' . PHP_EOL;
+var_dump(
+    $positive->round(1, RoundingMode::AwayFromZero),
+    $negative->round(1, RoundingMode::AwayFromZero),
+);
+
+echo PHP_EOL;
+echo 'Using RoundingMode::NegativeInfinity with 1 decimal digit precision' . PHP_EOL;
+var_dump(
+    $positive->round(1, RoundingMode::NegativeInfinity),
+    $negative->round(1, RoundingMode::NegativeInfinity),
+);
+
+echo PHP_EOL;
+echo 'Using RoundingMode::PositiveInfinity with 1 decimal digit precision' . PHP_EOL;
+var_dump(
+    $positive->round(1, RoundingMode::PositiveInfinity),
+    $negative->round(1, RoundingMode::PositiveInfinity),
+);
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen role="php">
+<![CDATA[
+Using RoundingMode::HalfAwayFromZero with 1 decimal digit precision
+object(BcMath\Number)#4 (2) {
+  ["value"]=>
+  string(3) "1.6"
+  ["scale"]=>
+  int(1)
+}
+object(BcMath\Number)#5 (2) {
+  ["value"]=>
+  string(4) "-1.6"
+  ["scale"]=>
+  int(1)
+}
+
+Using RoundingMode::HalfTowardsZero with 1 decimal digit precision
+object(BcMath\Number)#4 (2) {
+  ["value"]=>
+  string(3) "1.5"
+  ["scale"]=>
+  int(1)
+}
+object(BcMath\Number)#6 (2) {
+  ["value"]=>
+  string(4) "-1.5"
+  ["scale"]=>
+  int(1)
+}
+
+Using RoundingMode::HalfEven with 1 decimal digit precision
+object(BcMath\Number)#4 (2) {
+  ["value"]=>
+  string(3) "1.6"
+  ["scale"]=>
+  int(1)
+}
+object(BcMath\Number)#7 (2) {
+  ["value"]=>
+  string(4) "-1.6"
+  ["scale"]=>
+  int(1)
+}
+
+Using RoundingMode::HalfOdd with 1 decimal digit precision
+object(BcMath\Number)#4 (2) {
+  ["value"]=>
+  string(3) "1.5"
+  ["scale"]=>
+  int(1)
+}
+object(BcMath\Number)#8 (2) {
+  ["value"]=>
+  string(4) "-1.5"
+  ["scale"]=>
+  int(1)
+}
+
+Using RoundingMode::TowardsZero with 1 decimal digit precision
+object(BcMath\Number)#4 (2) {
+  ["value"]=>
+  string(3) "1.5"
+  ["scale"]=>
+  int(1)
+}
+object(BcMath\Number)#9 (2) {
+  ["value"]=>
+  string(4) "-1.5"
+  ["scale"]=>
+  int(1)
+}
+
+Using RoundingMode::AwayFromZero with 1 decimal digit precision
+object(BcMath\Number)#4 (2) {
+  ["value"]=>
+  string(3) "1.6"
+  ["scale"]=>
+  int(1)
+}
+object(BcMath\Number)#10 (2) {
+  ["value"]=>
+  string(4) "-1.6"
+  ["scale"]=>
+  int(1)
+}
+
+Using RoundingMode::NegativeInfinity with 1 decimal digit precision
+object(BcMath\Number)#4 (2) {
+  ["value"]=>
+  string(3) "1.5"
+  ["scale"]=>
+  int(1)
+}
+object(BcMath\Number)#11 (2) {
+  ["value"]=>
+  string(4) "-1.6"
+  ["scale"]=>
+  int(1)
+}
+
+Using RoundingMode::PositiveInfinity with 1 decimal digit precision
+object(BcMath\Number)#4 (2) {
+  ["value"]=>
+  string(3) "1.6"
+  ["scale"]=>
+  int(1)
+}
+object(BcMath\Number)#12 (2) {
+  ["value"]=>
+  string(4) "-1.5"
+  ["scale"]=>
+  int(1)
+}
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>bcround</function></member>
+   <member><methodname>BcMath\Number::ceil</methodname></member>
+   <member><methodname>BcMath\Number::floor</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/bc/bcmath/number/serialize.xml
+++ b/reference/bc/bcmath/number/serialize.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: saki Status: ready -->
+
+<refentry xml:id="bcmath-number.serialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>BcMath\Number::__serialize</refname>
+  <refpurpose>BcMath\Number オブジェクトをシリアライズする</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="BcMath\\Number">
+   <modifier>public</modifier> <type>array</type><methodname>BcMath\Number::__serialize</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   <varname>$this</varname> をシリアライズします。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>BcMath\Number::__construct</methodname></member>
+   <member><methodname>BcMath\Number::__unserialize</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/bc/bcmath/number/sqrt.xml
+++ b/reference/bc/bcmath/number/sqrt.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: saki Status: ready -->
+
+<refentry xml:id="bcmath-number.sqrt" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <refnamediv>
+  <refname>BcMath\Number::sqrt</refname>
+  <refpurpose>任意精度数値の平方根を取得する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="BcMath\\Number">
+   <modifier>public</modifier> <type>BcMath\Number</type><methodname>BcMath\Number::sqrt</methodname>
+   <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>scale</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   <varname>$this</varname> の平方根を返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('bcmath-number.add')/db:refsect1[@role='parameters']/descendant::db:varlistentry[2])" />
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   平方根を新しい <classname>BcMath\Number</classname> オブジェクトとして返します。
+  </simpara>
+  <simpara>
+   計算結果オブジェクトの <property>BcMath\Number::scale</property> が自動的に設定される場合、<varname>$this</varname> の
+   <property>BcMath\Number::scale</property> が使用されます。ただし、割り切れない除算が発生した場合は、
+   計算結果オブジェクトの <property>BcMath\Number::scale</property> が拡張されます。
+   拡張は必要に応じてのみ行われ、最大で <literal>+10</literal> まで拡張されます。
+  </simpara>
+  <simpara>
+   つまり、<varname>$this</varname> の <property>BcMath\Number::scale</property> が <literal>5</literal> の場合、
+   計算結果オブジェクトの <property>BcMath\Number::scale</property> は <literal>5</literal> から
+   <literal>15</literal> の間になります。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   このメソッドは、以下の場合に <classname>ValueError</classname> をスローします:
+   <simplelist>
+    <member><varname>$this</varname> が負の値である場合</member>
+    <member><parameter>scale</parameter> が範囲外の値である場合</member>
+    <member>結果オブジェクトの <property>BcMath\Number::scale</property> が範囲外の値である場合</member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><methodname>BcMath\Number::sqrt</methodname> の例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+var_dump(
+    new BcMath\Number('2')->sqrt(),
+    new BcMath\Number('2')->sqrt(3),
+    new BcMath\Number('4')->sqrt(),
+    new BcMath\Number('4')->sqrt(3),
+);
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+object(BcMath\Number)#2 (2) {
+  ["value"]=>
+  string(12) "1.4142135623"
+  ["scale"]=>
+  int(10)
+}
+object(BcMath\Number)#3 (2) {
+  ["value"]=>
+  string(5) "1.414"
+  ["scale"]=>
+  int(3)
+}
+object(BcMath\Number)#4 (2) {
+  ["value"]=>
+  string(1) "2"
+  ["scale"]=>
+  int(0)
+}
+object(BcMath\Number)#5 (2) {
+  ["value"]=>
+  string(5) "2.000"
+  ["scale"]=>
+  int(3)
+}
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>bcsqrt</function></member>
+   <member><methodname>BcMath\Number::div</methodname></member>
+   <member><methodname>BcMath\Number::pow</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/bc/bcmath/number/sqrt.xml
+++ b/reference/bc/bcmath/number/sqrt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: saki Status: ready -->
+<!-- EN-Revision: a414ee95eb79e2c62c80827a46e15da5d15af97e Maintainer: saki Status: ready -->
 
 <refentry xml:id="bcmath-number.sqrt" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>
@@ -36,6 +36,7 @@
    <property>BcMath\Number::scale</property> が使用されます。ただし、割り切れない除算が発生した場合は、
    計算結果オブジェクトの <property>BcMath\Number::scale</property> が拡張されます。
    拡張は必要に応じてのみ行われ、最大で <literal>+10</literal> まで拡張されます。
+   この動作は <methodname>BcMath\Number::div</methodname> と同じですので、詳しくはそちらを参照して下さい。
   </simpara>
   <simpara>
    つまり、<varname>$this</varname> の <property>BcMath\Number::scale</property> が <literal>5</literal> の場合、

--- a/reference/bc/bcmath/number/sub.xml
+++ b/reference/bc/bcmath/number/sub.xml
@@ -1,0 +1,177 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: saki Status: ready -->
+
+<refentry xml:id="bcmath-number.sub" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <refnamediv>
+  <refname>BcMath\Number::sub</refname>
+  <refpurpose>任意精度数値の減算を行う</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="BcMath\\Number">
+   <modifier>public</modifier> <type>BcMath\Number</type><methodname>BcMath\Number::sub</methodname>
+   <methodparam><type class="union"><type>BcMath\Number</type><type>string</type><type>int</type></type><parameter>num</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>scale</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   <varname>$this</varname> と <parameter>num</parameter> を減算します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>num</parameter></term>
+    <listitem>
+     <simpara>
+      減数を表す値。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('bcmath-number.add')/db:refsect1[@role='parameters']/descendant::db:varlistentry[2])" />
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   減算結果を新しい <classname>BcMath\Number</classname> オブジェクトとして返します。
+  </simpara>
+  <simpara>
+   減算結果オブジェクトの <property>BcMath\Number::scale</property> が自動的に設定される場合、減算に使用する2つの数値のうち、
+   大きい方の <property>BcMath\Number::scale</property> が使用されます。
+  </simpara>
+  <!-- Auto scale example -->
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('bcmath-number.add')/db:refsect1[@role='returnvalues']/db:simpara[3])" />
+ </refsect1>
+
+ <!-- error -->
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('bcmath-number.add')/db:refsect1[@role='errors'])" />
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><methodname>BcMath\Number::sub</methodname> で <parameter>scale</parameter> を指定しない例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$number = new BcMath\Number('1.234');
+
+$ret1 = $number->sub(new BcMath\Number('2.34567'));
+$ret2 = $number->sub('-3.456');
+$ret3 = $number->sub(7);
+
+var_dump($number, $ret1, $ret2, $ret3);
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+object(BcMath\Number)#1 (2) {
+  ["value"]=>
+  string(5) "1.234"
+  ["scale"]=>
+  int(3)
+}
+object(BcMath\Number)#3 (2) {
+  ["value"]=>
+  string(8) "-1.11167"
+  ["scale"]=>
+  int(5)
+}
+object(BcMath\Number)#2 (2) {
+  ["value"]=>
+  string(5) "4.690"
+  ["scale"]=>
+  int(3)
+}
+object(BcMath\Number)#4 (2) {
+  ["value"]=>
+  string(6) "-5.766"
+  ["scale"]=>
+  int(3)
+}
+]]>
+   </screen>
+  </example>
+
+  <example>
+   <title><methodname>BcMath\Number::sub</methodname> で <parameter>scale</parameter> を指定する例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$number = new BcMath\Number('1.234');
+
+$ret1 = $number->sub(new BcMath\Number('2.34567'), 1);
+$ret2 = $number->sub('-3.456', 10);
+$ret3 = $number->sub(7, 0);
+
+var_dump($number, $ret1, $ret2, $ret3);
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+object(BcMath\Number)#1 (2) {
+  ["value"]=>
+  string(5) "1.234"
+  ["scale"]=>
+  int(3)
+}
+object(BcMath\Number)#3 (2) {
+  ["value"]=>
+  string(4) "-1.1"
+  ["scale"]=>
+  int(1)
+}
+object(BcMath\Number)#2 (2) {
+  ["value"]=>
+  string(12) "4.6900000000"
+  ["scale"]=>
+  int(10)
+}
+object(BcMath\Number)#4 (2) {
+  ["value"]=>
+  string(2) "-5"
+  ["scale"]=>
+  int(0)
+}
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>bcsub</function></member>
+   <member><methodname>BcMath\Number::add</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/bc/bcmath/number/tostring.xml
+++ b/reference/bc/bcmath/number/tostring.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: saki Status: ready -->
+
+<refentry xml:id="bcmath-number.tostring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>BcMath\Number::__toString</refname>
+  <refpurpose>BcMath\Number オブジェクトを文字列に変換する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="BcMath\\Number">
+   <modifier>public</modifier> <type>string</type><methodname>BcMath\Number::__toString</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   <classname>BcMath\Number</classname> を <type>string</type> に変換します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   <property>BcMath\Number::value</property> を <type>string</type> として返します。
+  </simpara>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/bc/bcmath/number/unserialize.xml
+++ b/reference/bc/bcmath/number/unserialize.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: saki Status: ready -->
+
+<refentry xml:id="bcmath-number.unserialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>BcMath\Number::__unserialize</refname>
+  <refpurpose>data 引数を BcMath\Number オブジェクトとして復元する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="BcMath\\Number">
+   <modifier>public</modifier> <type>void</type><methodname>BcMath\Number::__unserialize</methodname>
+   <methodparam><type>array</type><parameter>data</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   data 引数を BcMath\Number オブジェクトとして復元します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>data</parameter></term>
+    <listitem>
+     <simpara>
+      連想配列としてシリアライズされたデータ。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   このメソッドは、不正なシリアライズデータが渡された場合、<exceptionname>ValueError</exceptionname> をスローします。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>BcMath\Number::__construct</methodname></member>
+   <member><methodname>BcMath\Number::serialize</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/bc/book.xml
+++ b/reference/bc/book.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 46a9cdd2dbef4ec89bf65fad9930e2feb78bbb98 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa,mumumu -->
  
 <book xml:id="book.bc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -55,6 +55,7 @@ echo bcsub($num1, $num2, 1); // => '0.0'
 
  &reference.bc.setup;
  &reference.bc.reference;
+ &reference.bc.bcmath.number;
 
 </book>
 

--- a/reference/bc/functions/bcadd.xml
+++ b/reference/bc/functions/bcadd.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: hirokawa Status: working -->
+<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi -->
 <refentry xml:id="function.bcadd" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/bc/functions/bcadd.xml
+++ b/reference/bc/functions/bcadd.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 3295741565f760edd22e305bd10e37f243e9e194 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi -->
 <refentry xml:id="function.bcadd" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -42,7 +42,7 @@
       </para>
      </listitem>
     </varlistentry>
-    <varlistentry>
+    <varlistentry xml:id="function.bcadd..parameters.scale">
      <term><parameter>scale</parameter></term>
      <listitem>
       <simpara>

--- a/reference/bc/functions/bcadd.xml
+++ b/reference/bc/functions/bcadd.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ddb05f8827151e25dd1c3e058f95f6c024bc881b Maintainer: hirokawa Status: working -->
+<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: hirokawa Status: working -->
 <!-- CREDITS: takagi -->
 <refentry xml:id="function.bcadd" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -42,7 +42,17 @@
       </para>
      </listitem>
     </varlistentry>
-    &bc.scale.description;
+    <varlistentry>
+     <term><parameter>scale</parameter></term>
+     <listitem>
+      <simpara>
+       結果の小数点以下の桁数を指定します。&null; の場合は、 <function>bcscale</function> 関数でグローバルに
+       設定した桁数をデフォルトとして使用します。
+       それも設定されていない場合は <link linkend="ini.bcmath.scale"><literal>bcmath.scale</literal></link>
+       INI ディレクティブの値を使用します。
+      </simpara>
+     </listitem>
+    </varlistentry>
    </variablelist>
   </para>
  </refsect1>
@@ -58,15 +68,10 @@
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
-   This function throws a <exceptionname>ValueError</exceptionname> in the following cases:
+   この関数は、以下の場合に <classname>ValueError</classname> をスローします:
    <simplelist>
-    <member>
-     <parameter>num1</parameter> or <parameter>num2</parameter>
-     is not a well-formed BCMath numeric string.
-    </member>
-    <member>
-     <parameter>scale</parameter> is outside the valid range.
-    </member>
+    <member><parameter>num1</parameter> もしくは <parameter>num1</parameter> が、BCMath で有効でない数値形式の文字列である場合</member>
+    <member><parameter>scale</parameter> が範囲外の値である場合</member>
    </simplelist>
   </para>
  </refsect1>
@@ -118,6 +123,7 @@ echo bcadd($a, $b, 4);  // 6.2340
   <para>
    <simplelist>
     <member><function>bcsub</function></member>
+    <member><methodname>BcMath\Number::add</methodname></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/bc/functions/bcceil.xml
+++ b/reference/bc/functions/bcceil.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: saki Status: ready -->
+
+<refentry xml:id="function.bcceil" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>bcceil</refname>
+  <refpurpose>任意精度数値を切り上げる</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>string</type><methodname>bcceil</methodname>
+   <methodparam><type>string</type><parameter>num</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   必要に応じて <parameter>num</parameter> を切り上げ、 <parameter>num</parameter> の次に大きい整数値を返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>num</parameter></term>
+    <listitem>
+     <simpara>
+      切り上げる値を表す文字列。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   <parameter>num</parameter> に最も近い整数に切り上げられた数値を表す数値文字列を返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   この関数は、<parameter>num</parameter> が BCMath で有効でない数値形式の文字列である場合、<classname>ValueError</classname> をスローします。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><function>bcceil</function> の例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+var_dump(bcceil('4.3'));
+var_dump(bcceil('9.999'));
+var_dump(bcceil('-3.14'));
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen role="php">
+<![CDATA[
+string(1) "5"
+string(2) "10"
+string(2) "-3"
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>bcfloor</function></member>
+   <member><function>bcround</function></member>
+   <member><methodname>BcMath\Number::ceil</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/bc/functions/bccomp.xml
+++ b/reference/bc/functions/bccomp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ddb05f8827151e25dd1c3e058f95f6c024bc881b Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi -->
 <refentry xml:id="function.bccomp" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>
@@ -76,6 +76,13 @@ echo bccomp('1.00001', '1', 5); // 1
 ]]>
    </programlisting>
   </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>BcMath\Number::compare</methodname></member>
+  </simplelist>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/bc/functions/bcdiv.xml
+++ b/reference/bc/functions/bcdiv.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 3295741565f760edd22e305bd10e37f243e9e194 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi,mumumu -->
 <refentry xml:id="function.bcdiv" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>
@@ -42,7 +42,7 @@
       </para>
      </listitem>
     </varlistentry>
-    &bc.scale.description;
+    <xi:include xpointer="function.bcadd..parameters.scale" />
    </variablelist>
   </para>
  </refsect1>

--- a/reference/bc/functions/bcdiv.xml
+++ b/reference/bc/functions/bcdiv.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: hirokawa Status: working -->
+<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi,mumumu -->
 <refentry xml:id="function.bcdiv" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>

--- a/reference/bc/functions/bcdiv.xml
+++ b/reference/bc/functions/bcdiv.xml
@@ -61,7 +61,7 @@
   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.bcadd')/db:refsect1[@role='errors']/*)" />
   <simpara>
    この関数は、 <parameter>num2</parameter> が <literal>0</literal> である場合、
-   <exceptionname>DivisionByZeroError</exceptionname> exception をスローします。
+   <exceptionname>DivisionByZeroError</exceptionname> 例外をスローします。
   </simpara>
  </refsect1>
 

--- a/reference/bc/functions/bcdiv.xml
+++ b/reference/bc/functions/bcdiv.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ddb05f8827151e25dd1c3e058f95f6c024bc881b Maintainer: hirokawa Status: working -->
+<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: hirokawa Status: working -->
 <!-- CREDITS: takagi,mumumu -->
 <refentry xml:id="function.bcdiv" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>
@@ -60,8 +60,8 @@
   <!-- Include standard ValueErrors for num1, num2, and scale, this includes the title -->
   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.bcadd')/db:refsect1[@role='errors']/*)" />
   <simpara>
-   This function throws a <exceptionname>DivisionByZeroError</exceptionname>
-   exception if <parameter>num2</parameter> is <literal>0</literal>.
+   この関数は、 <parameter>num2</parameter> が <literal>0</literal> である場合、
+   <exceptionname>DivisionByZeroError</exceptionname> exception をスローします。
   </simpara>
  </refsect1>
 
@@ -108,6 +108,7 @@ echo bcdiv('105', '6.55957', 3);  // 16.007
   <para>
    <simplelist>
     <member><function>bcmul</function></member>
+    <member><methodname>BcMath\Number::div</methodname></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/bc/functions/bcdivmod.xml
+++ b/reference/bc/functions/bcdivmod.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- $Revision$ -->
+<!-- EN-Revision: 5783476ce3e4e827f85045b7c5c76f966b9acffd Maintainer: saki Status: ready -->
+
+<refentry xml:id="function.bcdivmod" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <refnamediv>
+  <refname>bcdivmod</refname>
+  <refpurpose>任意精度数値の商と剰余を取得する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>array</type><methodname>bcdivmod</methodname>
+   <methodparam><type>string</type><parameter>num1</parameter></methodparam>
+   <methodparam><type>string</type><parameter>num2</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>scale</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   <parameter>num1</parameter> を <parameter>num2</parameter> で割った商と剰余を取得します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.bcdiv')/db:refsect1[@role='parameters']/*)" />
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   1つ目の要素に商の値を表す <type>string</type> が、2つ目の要素に剰余の値を表す <type>string</type> が格納された配列を返します。
+  </simpara>
+ </refsect1>
+
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.bcdiv')/db:refsect1[@role='errors'])" />
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><function>bcdivmod</function> の例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+bcscale(0);
+
+[$quot, $rem] = bcdivmod('5',  '3');
+echo $quot; // 1
+echo $rem;  // 2
+
+[$quot, $rem] = bcdivmod('5',  '-3');
+echo $quot; // -1
+echo $rem;  // 2
+
+[$quot, $rem] = bcdivmod('-5',  '3');
+echo $quot; // -1
+echo $rem;  // -2
+
+[$quot, $rem] = bcdivmod('-5',  '-3');
+echo $quot; // 1
+echo $rem;  // -2
+?>
+]]>
+   </programlisting>
+  </example>
+  <example>
+   <title><function>bcdivmod</function> に小数の値を指定する</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+[$quot, $rem] = bcdivmod('5.7', '1.3', 1);
+echo $quot; // 4
+echo $rem;  // 0.5
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>bcdiv</function></member>
+   <member><function>bcmod</function></member>
+   <member><methodname>BcMath\Number::divmod</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/bc/functions/bcfloor.xml
+++ b/reference/bc/functions/bcfloor.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: saki Status: ready -->
+
+<refentry xml:id="function.bcfloor" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <refnamediv>
+  <refname>bcfloor</refname>
+  <refpurpose>任意精度数値を切り下げる</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>string</type><methodname>bcfloor</methodname>
+   <methodparam><type>string</type><parameter>num</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   必要に応じて <parameter>num</parameter> を切り下げ、 <parameter>num</parameter> の次に小さい整数値を返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.bcceil')/db:refsect1[@role='parameters']/*)" />
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   <parameter>num</parameter> に最も近い整数に切り下げられた数値を表す数値文字列を返します。
+  </simpara>
+ </refsect1>
+
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.bcceil')/db:refsect1[@role='errors'])" />
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><function>bcfloor</function> の例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+var_dump(bcfloor('4.3'));
+var_dump(bcfloor('9.999'));
+var_dump(bcfloor('-3.14'));
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen role="php">
+<![CDATA[
+string(1) "4"
+string(1) "9"
+string(2) "-4"
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>bcceil</function></member>
+   <member><function>bcround</function></member>
+   <member><methodname>BcMath\Number::floor</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/bc/functions/bcmod.xml
+++ b/reference/bc/functions/bcmod.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ddb05f8827151e25dd1c3e058f95f6c024bc881b Maintainer: hirokawa Status: working -->
+<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: hirokawa Status: working -->
 <!-- CREDITS: takagi,mumumu -->
 <refentry xml:id="function.bcmod" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>
@@ -57,7 +57,8 @@
      <row>
       <entry>8.0.0</entry>
       <entry>
-       Dividing by <literal>0</literal> now throws a <exceptionname>DivisionByZeroError</exceptionname> exception instead of returning null.
+       <literal>0</literal> 除算を行うと、<exceptionname>DivisionByZeroError</exceptionname>
+       exception がスローされるようになりました。以前は &null; が返されていました。
       </entry>
      </row>
      <row>
@@ -115,6 +116,7 @@ echo bcmod('5.7', '1.3'); // 0.5 as of PHP 7.2.0; 0 previously
   <para>
    <simplelist>
     <member><function>bcdiv</function></member>
+    <member><methodname>BcMath\Number::mod</methodname></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/bc/functions/bcmod.xml
+++ b/reference/bc/functions/bcmod.xml
@@ -58,7 +58,7 @@
       <entry>8.0.0</entry>
       <entry>
        <literal>0</literal> 除算を行うと、<exceptionname>DivisionByZeroError</exceptionname>
-       exception がスローされるようになりました。以前は &null; が返されていました。
+       例外がスローされるようになりました。以前は &null; が返されていました。
       </entry>
      </row>
      <row>

--- a/reference/bc/functions/bcmod.xml
+++ b/reference/bc/functions/bcmod.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: hirokawa Status: working -->
+<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi,mumumu -->
 <refentry xml:id="function.bcmod" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>

--- a/reference/bc/functions/bcmul.xml
+++ b/reference/bc/functions/bcmul.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ddb05f8827151e25dd1c3e058f95f6c024bc881b Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi,mumumu -->
 <refentry xml:id="function.bcmul" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>
@@ -108,6 +108,7 @@ echo bcmul('5', '2', 2);     // prints "10", not "10.00"
   <para>
    <simplelist>
     <member><function>bcdiv</function></member>
+    <member><methodname>BcMath\Number::mul</methodname></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/bc/functions/bcpow.xml
+++ b/reference/bc/functions/bcpow.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ddb05f8827151e25dd1c3e058f95f6c024bc881b Maintainer: hirokawa Status: working -->
+<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: hirokawa Status: working -->
 <!-- CREDITS: takagi,mumumu -->
 <refentry xml:id="function.bcpow" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -61,16 +61,16 @@
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
-   This function throws a <exceptionname>ValueError</exceptionname> in the following cases:
+   この関数は、以下の場合に <exceptionname>ValueError</exceptionname> をスローします:
    <simplelist>
-    <member><parameter>num</parameter> or <parameter>exponent</parameter> is not a well-formed BCMath numeric string</member>
-    <member><parameter>exponent</parameter> has a fractional part</member>
-    <member><parameter>exponent</parameter> or <parameter>scale</parameter> is outside the valid range</member>
+    <member><parameter>num</parameter> もしくは <parameter>exponent</parameter> が、BCMath で有効でない数値形式の文字列である場合</member>
+    <member><parameter>exponent</parameter> が整数値でない場合</member>
+    <member><parameter>exponent</parameter> もしくは <parameter>scale</parameter> が範囲外の値である場合</member>
    </simplelist>
   </para>
   <simpara>
-   This function throws a <exceptionname>DivisionByZeroError</exceptionname> exception if <parameter>num</parameter>
-   is <literal>0</literal> and <parameter>exponent</parameter> is a negative value.
+   この関数は、<parameter>num</parameter> の値が <literal>0</literal> かつ <parameter>exponent</parameter> が負の値である場合、
+   <exceptionname>DivisionByZeroError</exceptionname> exception をスローします。
   </simpara>
  </refsect1>
 
@@ -88,15 +88,16 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Negative powers of <literal>0</literal> previously returned 0, but now throw a <exceptionname>DivisionByZeroError</exceptionname>
-       exception.
+       <literal>0</literal> の負のべき乗を行った場合、<literal>0</literal> を返す代わりに
+       <exceptionname>DivisionByZeroError</exceptionname> がスローされるようになりました。
       </entry>
      </row>
      <row>
       <entry>8.0.0</entry>
       <entry>
-       When <parameter>exponent</parameter> has a fractional part, it now throws a <exceptionname>ValueError</exceptionname>
-       instead of truncating.
+       <parameter>exponent</parameter> が小数部を持つ場合、<exceptionname>ValueError</exceptionname>
+       がスローされるようになりました。
+       以前は、小数部を切り捨てて整数として計算を行っていました。
       </entry>
      </row>
      <row>
@@ -156,6 +157,7 @@ echo bcpow('5', '2', 2);     // 結果は "25.00" ではなく "25" となりま
    <simplelist>
     <member><function>bcpowmod</function></member>
     <member><function>bcsqrt</function></member>
+    <member><methodname>BcMath\Number::pow</methodname></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/bc/functions/bcpow.xml
+++ b/reference/bc/functions/bcpow.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 3295741565f760edd22e305bd10e37f243e9e194 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi,mumumu -->
-<refentry xml:id="function.bcpow" xmlns="http://docbook.org/ns/docbook">
+<refentry xml:id="function.bcpow" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>
   <refname>bcpow</refname>
   <refpurpose>任意精度数値をべき乗する</refpurpose>
@@ -46,7 +46,7 @@
       </para>
      </listitem>
     </varlistentry>
-    &bc.scale.description;
+    <xi:include xpointer="function.bcadd..parameters.scale" />
    </variablelist>
   </para>
  </refsect1>

--- a/reference/bc/functions/bcpow.xml
+++ b/reference/bc/functions/bcpow.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: hirokawa Status: working -->
+<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi,mumumu -->
 <refentry xml:id="function.bcpow" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/bc/functions/bcpow.xml
+++ b/reference/bc/functions/bcpow.xml
@@ -70,7 +70,7 @@
   </para>
   <simpara>
    この関数は、<parameter>num</parameter> の値が <literal>0</literal> かつ <parameter>exponent</parameter> が負の値である場合、
-   <exceptionname>DivisionByZeroError</exceptionname> exception をスローします。
+   <exceptionname>DivisionByZeroError</exceptionname> 例外をスローします。
   </simpara>
  </refsect1>
 

--- a/reference/bc/functions/bcpowmod.xml
+++ b/reference/bc/functions/bcpowmod.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: takagi Status: working -->
+<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="function.bcpowmod" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/bc/functions/bcpowmod.xml
+++ b/reference/bc/functions/bcpowmod.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 3295741565f760edd22e305bd10e37f243e9e194 Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
-<refentry xml:id="function.bcpowmod" xmlns="http://docbook.org/ns/docbook">
+<refentry xml:id="function.bcpowmod" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>
   <refname>bcpowmod</refname>
   <refpurpose>任意精度数値のべき乗の、指定した数値による剰余</refpurpose>
@@ -55,7 +55,7 @@
       </para>
      </listitem>
     </varlistentry>
-    &bc.scale.description;
+    <xi:include xpointer="function.bcadd..parameters.scale" />
    </variablelist>
   </para>
  </refsect1>

--- a/reference/bc/functions/bcpowmod.xml
+++ b/reference/bc/functions/bcpowmod.xml
@@ -80,7 +80,7 @@
   </para>
   <simpara>
    この関数は、<parameter>modulus</parameter> の値が <literal>0</literal> である場合、
-   <exceptionname>DivisionByZeroError</exceptionname> exception をスローします。
+   <exceptionname>DivisionByZeroError</exceptionname> 例外をスローします。
   </simpara>
  </refsect1>
 
@@ -111,7 +111,7 @@
       <entry>8.0.0</entry>
       <entry>
        <literal>0</literal> 除算を行うと、<exceptionname>DivisionByZeroError</exceptionname>
-       exception がスローされるようになりました。以前は &false; が返されていました。
+       例外がスローされるようになりました。以前は &false; が返されていました。
       </entry>
      </row>
     </tbody>

--- a/reference/bc/functions/bcpowmod.xml
+++ b/reference/bc/functions/bcpowmod.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ddb05f8827151e25dd1c3e058f95f6c024bc881b Maintainer: takagi Status: working -->
+<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: takagi Status: working -->
 <!-- Credits: mumumu -->
 <refentry xml:id="function.bcpowmod" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -70,17 +70,17 @@
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
-   This function throws a <exceptionname>ValueError</exceptionname> in the following cases:
+   この関数は、以下の場合に <exceptionname>ValueError</exceptionname> をスローします:
    <simplelist>
-    <member><parameter>num</parameter>, <parameter>exponent</parameter> or <parameter>modulus</parameter> is not a well-formed BCMath numeric string</member>
-    <member><parameter>num</parameter>, <parameter>exponent</parameter> or <parameter>modulus</parameter> has a fractional part</member>
-    <member><parameter>exponent</parameter> is a negative value</member>
-    <member><parameter>scale</parameter> is outside the valid range</member>
+    <member><parameter>num</parameter> か <parameter>exponent</parameter> か <parameter>modulus</parameter> のいずれかが、BCMath で有効でない数値形式の文字列である場合</member>
+    <member><parameter>num</parameter> か <parameter>exponent</parameter> か <parameter>modulus</parameter> のいずれかが整数値でない場合</member>
+    <member><parameter>exponent</parameter> が負の値である場合</member>
+    <member><parameter>scale</parameter> が範囲外の値である場合</member>
    </simplelist>
   </para>
   <simpara>
-   This function throws a <exceptionname>DivisionByZeroError</exceptionname> exception if <parameter>modulus</parameter>
-   is <literal>0</literal>.
+   この関数は、<parameter>modulus</parameter> の値が <literal>0</literal> である場合、
+   <exceptionname>DivisionByZeroError</exceptionname> exception をスローします。
   </simpara>
  </refsect1>
 
@@ -104,13 +104,14 @@
      <row>
       <entry>8.0.0</entry>
       <entry>
-       Now throws a <exceptionname>ValueError</exceptionname> instead of returning &false; if <parameter>exponent</parameter> is a negative value.
+       <parameter>exponent</parameter> が負の値の場合、&false; を返す代わりに <exceptionname>ValueError</exceptionname> をスローするようになりました。
       </entry>
      </row>
      <row>
       <entry>8.0.0</entry>
       <entry>
-       Dividing by <literal>0</literal> now throws a <exceptionname>DivisionByZeroError</exceptionname> exception instead of returning &false;.
+       <literal>0</literal> 除算を行うと、<exceptionname>DivisionByZeroError</exceptionname>
+       exception がスローされるようになりました。以前は &false; が返されていました。
       </entry>
      </row>
     </tbody>
@@ -157,6 +158,7 @@ $b = bcmod(bcpow($x, $y), $mod);
    <simplelist>
     <member><function>bcpow</function></member>
     <member><function>bcmod</function></member>
+    <member><methodname>BcMath\Number::powmod</methodname></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/bc/functions/bcround.xml
+++ b/reference/bc/functions/bcround.xml
@@ -1,0 +1,298 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: saki Status: ready -->
+
+<refentry xml:id="function.bcround" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <refnamediv>
+  <refname>bcround</refname>
+  <refpurpose>任意精度数値を丸める</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>string</type><methodname>bcround</methodname>
+   <methodparam><type>string</type><parameter>num</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>precision</parameter><initializer>0</initializer></methodparam>
+   <methodparam choice="opt"><type>RoundingMode</type><parameter>mode</parameter><initializer>RoundingMode::HalfAwayFromZero</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   <parameter>num</parameter> を、指定した <parameter>precision</parameter>(小数点以下の桁数)に丸めた値を返します。
+   <parameter>precision</parameter> を負またはゼロ(デフォルト) とすることも可能です。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.round')/db:refsect1[@role='parameters']/descendant::db:varlistentry[1])" />
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.round')/db:refsect1[@role='parameters']/descendant::db:varlistentry[2])" />
+   <varlistentry>
+    <term><parameter>mode</parameter></term>
+    <listitem>
+     <simpara>
+      指定する丸めモード。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   <parameter>num</parameter> を指定された精度へ丸めた数値を表す文字列を返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   この関数は、以下の場合に <classname>ValueError</classname> をスローします:
+   <simplelist>
+    <member><parameter>num</parameter> が、BCMath で有効でない数値形式の文字列である場合</member>
+    <member>無効な <parameter>mode</parameter> を指定した場合</member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+   <example>
+   <title><function>bcround</function> の例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+var_dump(bcround('3.4'));
+var_dump(bcround('3.5'));
+var_dump(bcround('3.6'));
+var_dump(bcround('3.6', 0));
+var_dump(bcround('5.045', 2));
+var_dump(bcround('5.055', 2));
+var_dump(bcround('345', -2));
+var_dump(bcround('345', -3));
+var_dump(bcround('678', -2));
+var_dump(bcround('678', -3));
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen role="php">
+<![CDATA[
+string(1) "3"
+string(1) "4"
+string(1) "4"
+string(1) "4"
+string(4) "5.05"
+string(4) "5.06"
+string(3) "300"
+string(1) "0"
+string(3) "700"
+string(4) "1000"
+]]>
+   </screen>
+  </example>
+  <example>
+   <title>
+    <function>bcround</function> で異なる <parameter>precision</parameter> を指定した例
+   </title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$number = '123.45';
+
+var_dump(bcround($number, 3));
+var_dump(bcround($number, 2));
+var_dump(bcround($number, 1));
+var_dump(bcround($number, 0));
+var_dump(bcround($number, -1));
+var_dump(bcround($number, -2));
+var_dump(bcround($number, -3));
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen role="php">
+<![CDATA[
+string(7) "123.450"
+string(6) "123.45"
+string(5) "123.5"
+string(3) "123"
+string(3) "120"
+string(3) "100"
+string(1) "0"
+]]>
+   </screen>
+  </example>
+  <example>
+   <title>
+    <function>bcround</function> で異なる <parameter>mode</parameter> を指定した例
+   </title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+echo 'Rounding modes with 9.5' . PHP_EOL;
+var_dump(bcround('9.5', 0, RoundingMode::HalfAwayFromZero));
+var_dump(bcround('9.5', 0, RoundingMode::HalfTowardsZero));
+var_dump(bcround('9.5', 0, RoundingMode::HalfEven));
+var_dump(bcround('9.5', 0, RoundingMode::HalfOdd));
+var_dump(bcround('9.5', 0, RoundingMode::TowardsZero));
+var_dump(bcround('9.5', 0, RoundingMode::AwayFromZero));
+var_dump(bcround('9.5', 0, RoundingMode::NegativeInfinity));
+var_dump(bcround('9.5', 0, RoundingMode::PositiveInfinity));
+
+echo PHP_EOL;
+echo 'Rounding modes with 8.5' . PHP_EOL;
+var_dump(bcround('8.5', 0, RoundingMode::HalfAwayFromZero));
+var_dump(bcround('8.5', 0, RoundingMode::HalfTowardsZero));
+var_dump(bcround('8.5', 0, RoundingMode::HalfEven));
+var_dump(bcround('8.5', 0, RoundingMode::HalfOdd));
+var_dump(bcround('8.5', 0, RoundingMode::TowardsZero));
+var_dump(bcround('8.5', 0, RoundingMode::AwayFromZero));
+var_dump(bcround('8.5', 0, RoundingMode::NegativeInfinity));
+var_dump(bcround('8.5', 0, RoundingMode::PositiveInfinity));
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen role="php">
+<![CDATA[
+Rounding modes with 9.5
+string(2) "10"
+string(1) "9"
+string(2) "10"
+string(1) "9"
+string(1) "9"
+string(2) "10"
+string(1) "9"
+string(2) "10"
+
+Rounding modes with 8.5
+string(1) "9"
+string(1) "8"
+string(1) "8"
+string(1) "9"
+string(1) "8"
+string(1) "9"
+string(1) "8"
+string(1) "9"
+]]>
+   </screen>
+  </example>
+  <example>
+   <title>
+    <function>bcround</function> で <parameter>precision</parameter> を指定し、
+    異なる <parameter>mode</parameter> を指定した例
+   </title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+echo 'Using RoundingMode::HalfAwayFromZero with 1 decimal digit precision' . PHP_EOL;
+var_dump(bcround( 1.55, 1, RoundingMode::HalfAwayFromZero));
+var_dump(bcround(-1.55, 1, RoundingMode::HalfAwayFromZero));
+
+echo PHP_EOL;
+echo 'Using RoundingMode::HalfTowardsZero with 1 decimal digit precision' . PHP_EOL;
+var_dump(bcround( 1.55, 1, RoundingMode::HalfTowardsZero));
+var_dump(bcround(-1.55, 1, RoundingMode::HalfTowardsZero));
+
+echo PHP_EOL;
+echo 'Using RoundingMode::HalfEven with 1 decimal digit precision' . PHP_EOL;
+var_dump(bcround( 1.55, 1, RoundingMode::HalfEven));
+var_dump(bcround(-1.55, 1, RoundingMode::HalfEven));
+
+echo PHP_EOL;
+echo 'Using RoundingMode::HalfOdd with 1 decimal digit precision' . PHP_EOL;
+var_dump(bcround( 1.55, 1, RoundingMode::HalfOdd));
+var_dump(bcround(-1.55, 1, RoundingMode::HalfOdd));
+
+echo PHP_EOL;
+echo 'Using RoundingMode::TowardsZero with 1 decimal digit precision' . PHP_EOL;
+var_dump(bcround( 1.55, 1, RoundingMode::TowardsZero));
+var_dump(bcround(-1.55, 1, RoundingMode::TowardsZero));
+
+echo PHP_EOL;
+echo 'Using RoundingMode::AwayFromZero with 1 decimal digit precision' . PHP_EOL;
+var_dump(bcround( 1.55, 1, RoundingMode::AwayFromZero));
+var_dump(bcround(-1.55, 1, RoundingMode::AwayFromZero));
+
+echo PHP_EOL;
+echo 'Using RoundingMode::NegativeInfinity with 1 decimal digit precision' . PHP_EOL;
+var_dump(bcround( 1.55, 1, RoundingMode::NegativeInfinity));
+var_dump(bcround(-1.55, 1, RoundingMode::NegativeInfinity));
+
+echo PHP_EOL;
+echo 'Using RoundingMode::PositiveInfinity with 1 decimal digit precision' . PHP_EOL;
+var_dump(bcround( 1.55, 1, RoundingMode::PositiveInfinity));
+var_dump(bcround(-1.55, 1, RoundingMode::PositiveInfinity));
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen role="php">
+<![CDATA[
+Using RoundingMode::HalfAwayFromZero with 1 decimal digit precision
+string(3) "1.6"
+string(4) "-1.6"
+
+Using RoundingMode::HalfTowardsZero with 1 decimal digit precision
+string(3) "1.5"
+string(4) "-1.5"
+
+Using RoundingMode::HalfEven with 1 decimal digit precision
+string(3) "1.6"
+string(4) "-1.6"
+
+Using RoundingMode::HalfOdd with 1 decimal digit precision
+string(3) "1.5"
+string(4) "-1.5"
+
+Using RoundingMode::TowardsZero with 1 decimal digit precision
+string(3) "1.5"
+string(4) "-1.5"
+
+Using RoundingMode::AwayFromZero with 1 decimal digit precision
+string(3) "1.6"
+string(4) "-1.6"
+
+Using RoundingMode::NegativeInfinity with 1 decimal digit precision
+string(3) "1.5"
+string(4) "-1.6"
+
+Using RoundingMode::PositiveInfinity with 1 decimal digit precision
+string(3) "1.6"
+string(4) "-1.5"
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>bcceil</function></member>
+   <member><function>bcfloor</function></member>
+   <member><methodname>BcMath\Number::round</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/bc/functions/bcround.xml
+++ b/reference/bc/functions/bcround.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: saki Status: ready -->
+<!-- EN-Revision: a414ee95eb79e2c62c80827a46e15da5d15af97e Maintainer: saki Status: ready -->
 
 <refentry xml:id="function.bcround" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>

--- a/reference/bc/functions/bcscale.xml
+++ b/reference/bc/functions/bcscale.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ddb05f8827151e25dd1c3e058f95f6c024bc881b Maintainer: hirokawa Status: working -->
+<!-- EN-Revision: ddb05f8827151e25dd1c3e058f95f6c024bc881b Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi -->
 <refentry xml:id="function.bcscale" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/bc/functions/bcsqrt.xml
+++ b/reference/bc/functions/bcsqrt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ddb05f8827151e25dd1c3e058f95f6c024bc881b Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi -->
 <refentry xml:id="function.bcsqrt" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -116,6 +116,7 @@ echo bcsqrt('2', 3); // 1.414
   <para>
    <simplelist>
     <member><function>bcpow</function></member>
+    <member><methodname>BcMath\Number::sqrt</methodname></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/bc/functions/bcsqrt.xml
+++ b/reference/bc/functions/bcsqrt.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 3295741565f760edd22e305bd10e37f243e9e194 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi -->
-<refentry xml:id="function.bcsqrt" xmlns="http://docbook.org/ns/docbook">
+<refentry xml:id="function.bcsqrt" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>
   <refname>bcsqrt</refname>
   <refpurpose>任意精度数値の平方根を取得する</refpurpose>
@@ -32,7 +32,7 @@
       </para>
      </listitem>
     </varlistentry>
-    &bc.scale.description;
+    <xi:include xpointer="function.bcadd..parameters.scale" />
    </variablelist>
   </para>
  </refsect1>

--- a/reference/bc/functions/bcsub.xml
+++ b/reference/bc/functions/bcsub.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: hirokawa Status: working -->
+<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi -->
 <refentry xml:id="function.bcsub" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>

--- a/reference/bc/functions/bcsub.xml
+++ b/reference/bc/functions/bcsub.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ddb05f8827151e25dd1c3e058f95f6c024bc881b Maintainer: hirokawa Status: working -->
+<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: hirokawa Status: working -->
 <!-- CREDITS: takagi -->
 <refentry xml:id="function.bcsub" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>
@@ -48,7 +48,7 @@
      <row>
       <entry>8.0.0</entry>
       <entry>
-       <parameter>scale</parameter> is now nullable.
+       <parameter>scale</parameter> は nullable になりました。
       </entry>
      </row>
     </tbody>
@@ -81,6 +81,7 @@ echo bcsub($a, $b, 4);  // -3.7660
   <para>
    <simplelist>
     <member><function>bcadd</function></member>
+    <member><methodname>BcMath\Number::sub</methodname></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/bc/ini.xml
+++ b/reference/bc/ini.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 6dfe0767250cdbdf509223f6bc266557b0a3fec9 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: shimooka -->
 <section xml:id="bc.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;
@@ -44,6 +44,9 @@
       全ての bcmath 関数に関する 10 進桁数。
       <function>bcscale</function> も参照ください。
      </para>
+     <note>
+      <simpara><classname>BcMath\Number</classname> クラスは、この設定の影響を受けません。</simpara>
+     </note>
     </listitem>
    </varlistentry>
 

--- a/translation.xml
+++ b/translation.xml
@@ -31,6 +31,7 @@
    <person name="Kenta Usami" email="tadsan@zonu.me" nick="zonuexe" vcs="no" />
    <person name="Kentaro Takeda" email="takeda@youmind.jp" nick="KentarouTakeda" vcs="yes" />
    <person name="Yuya Hamada" email="youkidearitai@gmail.com" nick="youkidearitai" vcs="yes" />
+   <person name="Saki Takamachi" email="saki@php.net" nick="saki" vcs="yes" />
   </translators>
 
   <work-in-progress>


### PR DESCRIPTION
2024/1/30時点での最新適用

原文書いたのが私なので、技術的な内容は全て合っていると考えて大丈夫です。
その他、誤字脱字や何かしらのjaのルールに沿わない表現があるかなど特に見ていただけると助かります。