### PR TITLE
誤訳の修正

### DIFF
--- a/appendices/migration74/incompatible.xml
+++ b/appendices/migration74/incompatible.xml
@@ -42,12 +42,11 @@
 
    <para>
     ファイルの最後の (改行が最後に付かない) <literal>&lt;?php</literal>
-    タグは、PHPタグの開始タグとして解釈されるようになりました。以前は、短い形式の開始タグ <literal>&lt;?</literal> の後にリテラル
+    タグは、PHPタグの開始タグとして解釈されるようになりました。以前は、短縮型の開始タグ <literal>&lt;?</literal> の後にリテラル
     <literal>php</literal>
-    を続けたものとして解釈されるか、(<literal>short_open_tag=1</literal>
-    の場合は) 文法エラー になるか、(<literal>short_open_tag=0</literal>
-    の場合は) <literal>&lt;?php</literal>
-    というリテラルとして解釈されていました。
+    を続けたものとして解釈された結果文法エラーになる (<literal>short_open_tag=1</literal>
+    の場合) か、<literal>&lt;?php</literal> という文字列リテラルとして解釈されていました (<literal>short_open_tag=0</literal>
+    の場合) 。
    </para>
   </sect3>
 


### PR DESCRIPTION
short_open_tag=0,1 の2パターンしかないのに、3パターンあるような訳になっていたのを修正しています。

「`<?php`という文字列リテラル」の部分は`T_INLINE_HTML`として解釈されるという意味のはずなので、"文字列リテラル"というのが正しいか微妙に思いましたが、英語版もliteralとなっているのと、`T_INLINE_HTML`を指す用語がマニュアル中で見つけられなかったので一旦直訳にしています。

また、https://www.php.net/manual/ja/language.basic-syntax.phptags.php に合わせて「短い形式の開始タグ」を「短縮型の」に直しています。
（上記ページも「短縮型」「短縮形」で入り交じっていますが……）