### PR TITLE
Fix missing lines in enumerations.xml

### DIFF
--- a/language/enumerations.xml
+++ b/language/enumerations.xml
@@ -693,6 +693,7 @@ class Foo
 }
 
 // これは、完全に正しいコードです。定数式ではないからです。
+$x = Direction::Up['short'];
 var_dump("\$x is " . var_export($x, true));
 
 $foo = new Foo();


### PR DESCRIPTION
列挙型(Enum)＞定数式における列挙型の値　に書かれているサンプルコード内に
英語版では存在していますが、日本語版では不足している行がありました。
英語版からその行を移植したPRです。
https://github.com/php/doc-en/blob/master/language/enumerations.xml#L617

※ `$x = Direction::Up['short'];`という行は英語版enumerations.xmlの初期コミットから存在していました。
https://github.com/php/doc-en/commit/9fe810352095922a68ce2807745a9bc35c0afe1f#diff-57723d13442b7d9760b6993403b07a90ff451e1cb9d6a3ecc7d6e40ac393bdb4R564