### PR TITLE
Enum関連の微修正など

### DIFF
--- a/language-defs.ent
+++ b/language-defs.ent
@@ -87,6 +87,7 @@ supplemental files to mark section titles -->
 <!ENTITY reftitle.changelog    '<title xmlns="http://docbook.org/ns/docbook">&Changelog;</title>'>
 <!ENTITY reftitle.classes      '<title xmlns="http://docbook.org/ns/docbook">定義済みクラス</title>'>
 <!ENTITY reftitle.classsynopsis '<title xmlns="http://docbook.org/ns/docbook">クラス概要</title>'>
+<!ENTITY reftitle.enumsynopsis '<title xmlns="http://docbook.org/ns/docbook">列挙型概要</title>'>
 <!ENTITY reftitle.constants    '<title xmlns="http://docbook.org/ns/docbook">定義済み定数</title>'>
 <!ENTITY reftitle.constructor  '<title xmlns="http://docbook.org/ns/docbook">コンストラクタ</title>'>
 <!ENTITY reftitle.description  '<title xmlns="http://docbook.org/ns/docbook">説明</title>'>

--- a/reference/math/roundingmode.xml
+++ b/reference/math/roundingmode.xml
@@ -10,7 +10,7 @@
   <section xml:id="enum.roundingmode.intro">
    &reftitle.intro;
    <simpara>
-    <enumname>RoundingMode</enumname> enum は、<function>round</function> 、<function>bcround</function> 、
+    列挙型の <enumname>RoundingMode</enumname> は、<function>round</function> 、<function>bcround</function> 、
     <methodname>BcMath\Number::round</methodname> で丸めの方法を指定するために使用されます。
    </simpara>
   </section>

--- a/reference/pcntl/qosclass.xml
+++ b/reference/pcntl/qosclass.xml
@@ -2,7 +2,7 @@
 <!-- $Revision$ -->
 <!-- EN-Revision: ee8d203f9230b0496f6d69cc1237d9ca63475ad7 Maintainer: Ippey Status: ready -->
 <reference xmlns="http://docbook.org/ns/docbook" xml:id="enum.qosclass" role="enum">
- <title>The QosClass Enum</title>
+ <title>QosClass Enum</title>
  <titleabbrev>QosClass</titleabbrev>
 
  <partintro>


### PR DESCRIPTION
すでに`QosClass`というEnumのドキュメントがあったことに気がつきました。

なので、`RoundingMode`の説明文を、一部既存の表現に寄せました。

その他、「列挙型概要」というreftitleの翻訳追加、英語表記の名残りの`The`の削除など