### PR TITLE
`strpos`等の`needle`の説明の誤訳修正

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -4694,12 +4694,12 @@ local: {
 <!ENTITY strings.parameter.needle.non-string '
  <para xmlns="http://docbook.org/ns/docbook">
   PHP 8.0.0 より前のバージョンでは、<parameter>needle</parameter> が文字列でない場合、
-  数値に変換され、文字の通常の値として扱われていました。
+  数値に変換され、文字のコードポイントとして扱われていました。
   この振る舞いは PHP 7.3.0 以降では推奨されないので、
   この機能を使用しないことを強く推奨します。
-  意図した動作に依存する場合、
+  意図する動作に応じて、
   <parameter>needle</parameter> を string に明示的にキャストするか、
-  明示的に <function>chr</function> 関数を呼び出すべきでしょう。 
+  明示的に <function>chr</function> 関数を呼び出すべきでしょう。
  </para>
 '>
 


### PR DESCRIPTION
`strr?i?pos`, `strstr`等の`$needle`に数値を渡したときの動作について、2点の誤訳を修正しています。

原文:
> Prior to PHP 8.0.0, if needle is not a string, it is converted to an integer and applied as the ordinal value of a character. This behavior is deprecated as of PHP 7.3.0, and relying on it is highly discouraged. Depending on the intended behavior, the needle should either be explicitly cast to string, or an explicit call to chr() should be performed.

- the ordinal value of a character
  - ordinary と取り違えたのかと思います。直訳すると「文字の序数値」みたいになるようですが、分かりづらいので「コードポイント」と意訳しています。
- Depending on the intended behavior
  - depending on ～ ＝ ～に応じて