### PR TITLE
mysqliの定数において、一部の未翻訳部分を翻訳

### DIFF
--- a/reference/mysqli/constants.xml
+++ b/reference/mysqli/constants.xml
@@ -1206,8 +1206,11 @@
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry xml:id="constant.mysqli-trans-start-consistent-snapshot">
-    <term><constant>MYSQLI_TRANS_START_WITH_CONSISTENT_SNAPSHOT</constant></term>
+   <varlistentry xml:id="constant.mysqli-trans-start-with-consistent-snapshot">
+    <term>
+     <constant>MYSQLI_TRANS_START_WITH_CONSISTENT_SNAPSHOT</constant>
+     (<type>int</type>)
+    </term>
     <listitem>
      <para>
       トランザクションを "START TRANSACTION WITH CONSISTENT SNAPSHOT" で開始します。

--- a/reference/mysqli/constants.xml
+++ b/reference/mysqli/constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 8fb5db5a5eea9940e1cb5ea599817da36d3f36dd Maintainer: takagi Status: working -->
+<!-- EN-Revision: e11d90ec66baf31038e800870913ff2baec5ba72 Maintainer: takagi Status: working -->
 <!-- CREDITS: hirokawa,mumumu -->
 <appendix xml:id="mysqli.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;

--- a/reference/mysqli/constants.xml
+++ b/reference/mysqli/constants.xml
@@ -31,7 +31,6 @@
      </para>
     </listitem>
    </varlistentry>
-   <!-- to be translated -->
    <varlistentry xml:id="constant.mysqli-opt-can-handle_expired_passwords">
     <term>
      <constant>MYSQLI_OPT_CAN_HANDLE_EXPIRED_PASSWORDS</constant>
@@ -39,9 +38,8 @@
     </term>
     <listitem>
      <simpara>
-      Indicates to the server that the client can handle sandbox mode
-      for expired passwords.
-      Can be used with <function>mysqli_options</function>.
+      サーバーに対して、クライアントが期限切れパスワードのサンドボックスモードを処理できることを示します。
+      <function>mysqli_options</function> と共に使用できます。
      </simpara>
     </listitem>
    </varlistentry>
@@ -52,9 +50,8 @@
     </term>
     <listitem>
      <simpara>
-      If enabled, this option specifies the directory
-      from which client-side <literal>LOCAL</literal> data loading is permitted
-      in <literal>LOAD DATA LOCAL</literal> statements.
+      有効にすると、このオプションは <literal>LOAD DATA LOCAL</literal> ステートメントで
+      クライアント側の <literal>LOCAL</literal> データのロードを許可するディレクトリを指定します。
      </simpara>
     </listitem>
    </varlistentry> 
@@ -147,7 +144,6 @@
      </para>
     </listitem>
    </varlistentry>
-   <!-- to be translated -->
    <varlistentry xml:id="constant.mysqli-client-can-handle_expired_passwords">
     <term>
      <constant>MYSQLI_CLIENT_CAN_HANDLE_EXPIRED_PASSWORDS</constant>
@@ -155,9 +151,8 @@
     </term>
     <listitem>
      <simpara>
-      Indicates to the server that the client can handle sandbox mode
-      for expired passwords.
-      Can be used with <function>mysqli_real_connect</function>.
+      サーバーに対して、クライアントが期限切れパスワードのサンドボックスモードを処理できることを示します。
+      <function>mysqli_real_connect</function> と共に使用できます。
      </simpara>
     </listitem>
    </varlistentry>
@@ -168,7 +163,7 @@
     </term>
     <listitem>
      <simpara>
-      Return number of matched rows, not the number of affected rows.
+      影響を受けた行数ではなく、一致した行数を返します。
      </simpara>
     </listitem>
    </varlistentry>
@@ -179,7 +174,7 @@
     </term>
     <listitem>
      <simpara>
-      Verify server certificate.
+      サーバー証明書を検証します。
      </simpara>
     </listitem>
    </varlistentry>
@@ -474,7 +469,6 @@
      </para>
     </listitem>
    </varlistentry>
-   <!-- to be translated -->
    <varlistentry xml:id="constant.mysqli-no-default-value_flag">
     <term>
      <constant>MYSQLI_NO_DEFAULT_VALUE_FLAG</constant>
@@ -482,11 +476,9 @@
     </term>
     <listitem>
      <simpara>
-      A column has no <literal>DEFAULT</literal> clause in its definition.
-      This does not apply to <literal>NULL</literal>
-      or to <literal>AUTO_INCREMENT</literal> columns
-      because such columns have a default value of <literal>NULL</literal>
-      and an implied default value respectively.
+      カラムの定義に <literal>DEFAULT</literal> 句がありません。これは <literal>NULL</literal> や 
+      <literal>AUTO_INCREMENT</literal> カラムには適用されません。なぜならそのようなカラムはそれぞれ
+      デフォルト値として <literal>NULL</literal> および暗黙のデフォルト値を持っているためです。
      </simpara>
     </listitem>
    </varlistentry>
@@ -1245,7 +1237,6 @@
      </para>
     </listitem>
    </varlistentry>
-   <!-- to be translated -->
    <varlistentry xml:id="constant.mysqli-async">
     <term>
      <constant>MYSQLI_ASYNC</constant>
@@ -1253,8 +1244,8 @@
     </term>
     <listitem>
      <simpara>
-      The query is performed asynchronously and no result set is immediately returned.
-      Available with <literal>mysqlnd</literal> only.
+      クエリは非同期に実行され、結果セットはすぐには返されません。
+      <literal>mysqlnd</literal> でのみ利用可能です。
      </simpara>
     </listitem>
    </varlistentry>
@@ -1265,7 +1256,7 @@
     </term>
     <listitem>
      <simpara>
-      If a field is updated it will get the current time value.
+      フィールドが更新されると、現在時刻の値が設定されます。
      </simpara>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
いつもPHPマニュアルのメンテナンスをして頂き、ありがとうございます。PHPerとして大変助かっております。
以下、対応しましたので、ご確認をよろしくお願いします。

## 概要
- [`mysqli`拡張モジュールの定義済み定数ページ](https://www.php.net/manual/ja/mysqli.constants.php)にて、一部の未翻訳となっていた定数の説明を日本語に翻訳しました。

## 対象の定数
- `MYSQLI_OPT_CAN_HANDLE_EXPIRED_PASSWORDS`
- `MYSQLI_OPT_LOAD_DATA_LOCAL_DIR`
- `MYSQLI_CLIENT_CAN_HANDLE_EXPIRED_PASSWORDS`
- `MYSQLI_CLIENT_FOUND_ROWS`
- `MYSQLI_CLIENT_SSL_VERIFY_SERVER_CERT`
- `MYSQLI_NO_DEFAULT_VALUE_FLAG`
- `MYSQLI_ASYNC`
- `MYSQLI_ON_UPDATE_NOW_FLAG`
