### PR TITLE
[PHP 8.4] Add ext-intl constant typesの翻訳

### DIFF
--- a/reference/intl/collator-constants.xml
+++ b/reference/intl/collator-constants.xml
@@ -8,6 +8,7 @@
    <varlistentry xml:id="collator.constants.french-collation">
     <term>
      <constant>Collator::FRENCH_COLLATION</constant>
+     <type>int</type>
     </term>
     <listitem>
      <para>
@@ -101,6 +102,7 @@
    <varlistentry xml:id="collator.constants.case-first">
     <term>
      <constant>Collator::CASE_FIRST</constant>
+     <type>int</type>
     </term>
     <listitem>
      <para>
@@ -146,6 +148,7 @@
    <varlistentry xml:id="collator.constants.case-level">
     <term>
      <constant>Collator::CASE_LEVEL</constant>
+     <type>int</type>
     </term>
     <listitem>
      <para>
@@ -181,6 +184,7 @@
    <varlistentry xml:id="collator.constants.normalization-mode">
     <term>
      <constant>Collator::NORMALIZATION_MODE</constant>
+     <type>int</type>
     </term>
     <listitem>
      <para>
@@ -211,6 +215,7 @@
    <varlistentry xml:id="collator.constants.strength">
     <term>
      <constant>Collator::STRENGTH</constant>
+     <type>int</type>
     </term>
     <listitem>
      <para>
@@ -239,6 +244,7 @@
    <varlistentry xml:id="collator.constants.hiragana-quaternary-mode">
     <term>
      <constant>Collator::HIRAGANA_QUATERNARY_MODE</constant>
+     <type>int</type>
     </term>
     <listitem>
      <para>
@@ -262,6 +268,7 @@
    <varlistentry xml:id="collator.constants.numeric-collation">
     <term>
      <constant>Collator::NUMERIC_COLLATION</constant>
+     <type>int</type>
     </term>
     <listitem>
      <para>
@@ -282,6 +289,7 @@
    <varlistentry xml:id="collator.constants.default-value">
     <term>
      <constant>Collator::DEFAULT_VALUE</constant>
+     <type>int</type>
     </term>
     <listitem>
      <simpara>
@@ -293,6 +301,7 @@
    <varlistentry xml:id="collator.constants.primary">
     <term>
      <constant>Collator::PRIMARY</constant>
+     <type>int</type>
     </term>
     <listitem>
      <simpara>
@@ -304,6 +313,7 @@
    <varlistentry xml:id="collator.constants.secondary">
     <term>
      <constant>Collator::SECONDARY</constant>
+     <type>int</type>
     </term>
     <listitem>
      <simpara>
@@ -315,6 +325,7 @@
    <varlistentry xml:id="collator.constants.tertiary">
     <term>
      <constant>Collator::TERTIARY</constant>
+     <type>int</type>
     </term>
     <listitem>
      <simpara>
@@ -326,6 +337,7 @@
    <varlistentry xml:id="collator.constants.default-strength">
     <term>
      <constant>Collator::DEFAULT_STRENGTH</constant>
+     <type>int</type>
     </term>
     <listitem>
      <simpara>
@@ -337,6 +349,7 @@
    <varlistentry xml:id="collator.constants.quaternary">
     <term>
      <constant>Collator::QUATERNARY</constant>
+     <type>int</type>
     </term>
     <listitem>
      <simpara>
@@ -348,6 +361,7 @@
    <varlistentry xml:id="collator.constants.identical">
     <term>
      <constant>Collator::IDENTICAL</constant>
+     <type>int</type>
     </term>
     <listitem>
      <simpara>
@@ -359,6 +373,7 @@
    <varlistentry xml:id="collator.constants.off">
     <term>
      <constant>Collator::OFF</constant>
+     <type>int</type>
     </term>
     <listitem>
      <simpara>
@@ -370,6 +385,7 @@
    <varlistentry xml:id="collator.constants.on">
     <term>
      <constant>Collator::ON</constant>
+     <type>int</type>
     </term>
     <listitem>
      <simpara>
@@ -381,6 +397,7 @@
    <varlistentry xml:id="collator.constants.shifted">
     <term>
      <constant>Collator::SHIFTED</constant>
+     <type>int</type>
     </term>
     <listitem>
      <simpara>
@@ -392,6 +409,7 @@
    <varlistentry xml:id="collator.constants.non-ignorable">
     <term>
      <constant>Collator::NON_IGNORABLE</constant>
+     <type>int</type>
     </term>
     <listitem>
      <simpara>
@@ -403,6 +421,7 @@
    <varlistentry xml:id="collator.constants.lower-first">
     <term>
      <constant>Collator::LOWER_FIRST</constant>
+     <type>int</type>
     </term>
     <listitem>
      <simpara>
@@ -414,6 +433,7 @@
    <varlistentry xml:id="collator.constants.upper-first">
     <term>
      <constant>Collator::UPPER_FIRST</constant>
+     <type>int</type>
     </term>
     <listitem>
      <simpara>
@@ -423,21 +443,30 @@
    </varlistentry>
 
    <varlistentry xml:id="collator.constants.sort-regular">
-    <term><constant>Collator::SORT_REGULAR</constant></term>
+    <term>
+     <constant>Collator::SORT_REGULAR</constant>
+     <type>int</type>
+    </term>
     <listitem>
      <para/>
     </listitem>
    </varlistentry>
 
    <varlistentry xml:id="collator.constants.sort-string">
-    <term><constant>Collator::SORT_STRING</constant></term>
+    <term>
+     <constant>Collator::SORT_STRING</constant>
+     <type>int</type>
+    </term>
     <listitem>
      <para/>
     </listitem>
    </varlistentry>
 
    <varlistentry xml:id="collator.constants.sort-numeric">
-    <term><constant>Collator::SORT_NUMERIC</constant></term>
+    <term>
+     <constant>Collator::SORT_NUMERIC</constant>
+     <type>int</type>
+    </term>
     <listitem>
      <para/>
     </listitem>

--- a/reference/intl/collator-constants.xml
+++ b/reference/intl/collator-constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 6e6c154057b6d96518de039f40ff1e4feb44b04f Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 1f68eecaa7c4c723abe72a5a040ea7b15023a5aa Maintainer: takagi Status: ready -->
 <section xml:id="intl.collator-constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.constants;
  <para>

--- a/reference/intl/collator.xml
+++ b/reference/intl/collator.xml
@@ -198,6 +198,28 @@
    }}} -->
 
   &reference.intl.collator-constants;
+
+  <section role="changelog" xml:id="collator.changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        クラス定数が型付けされました。
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
  </partintro>
 
  &reference.intl.entities.collator;

--- a/reference/intl/collator.xml
+++ b/reference/intl/collator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 2a8b2f1c53edae923b5bb196183e476e5cca46a3 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 1f68eecaa7c4c723abe72a5a040ea7b15023a5aa Maintainer: takagi Status: ready -->
 <reference xml:id="class.collator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>Collator クラス</title>
  <titleabbrev>Collator</titleabbrev>

--- a/reference/intl/dateformatter-constants.xml
+++ b/reference/intl/dateformatter-constants.xml
@@ -12,6 +12,7 @@
    <varlistentry xml:id="intldateformatter.constants.none">
     <term>
      <constant>IntlDateFormatter::NONE</constant>
+     <type>int</type>
     </term>
     <listitem>
      <simpara>この要素を含まない</simpara>
@@ -20,6 +21,7 @@
    <varlistentry xml:id="intldateformatter.constants.full">
     <term>
      <constant>IntlDateFormatter::FULL</constant>
+     <type>int</type>
     </term>
     <listitem>
      <simpara>完全に指定した形式 (Tuesday, April 12, 1952 AD あるいは 3:30:42pm PST)</simpara>
@@ -28,6 +30,7 @@
    <varlistentry xml:id="intldateformatter.constants.long">
     <term>
      <constant>IntlDateFormatter::LONG</constant>
+     <type>int</type>
     </term>
     <listitem>
      <simpara>長い形式 (January 12, 1952 あるいは 3:30:32pm)</simpara>
@@ -36,6 +39,7 @@
    <varlistentry xml:id="intldateformatter.constants.medium">
     <term>
      <constant>IntlDateFormatter::MEDIUM</constant>
+     <type>int</type>
     </term>
     <listitem>
      <simpara>中間の形式 (Jan 12, 1952)</simpara>
@@ -44,6 +48,7 @@
    <varlistentry xml:id="intldateformatter.constants.short">
     <term>
      <constant>IntlDateFormatter::SHORT</constant>
+     <type>int</type>
     </term>
     <listitem>
      <simpara>不可欠なデータのみを扱う最も省略した形式 (12/13/52 あるいは 3:30pm)</simpara>
@@ -52,6 +57,7 @@
    <varlistentry xml:id="intldateformatter.constants.relative-full">
     <term>
      <constant>IntlDateFormatter::RELATIVE_FULL</constant>
+     <type>int</type>
     </term>
     <listitem>
      <simpara>
@@ -67,6 +73,7 @@
    <varlistentry xml:id="intldateformatter.constants.relative-long">
     <term>
      <constant>IntlDateFormatter::RELATIVE_LONG</constant>
+     <type>int</type>
     </term>
     <listitem>
      <simpara>
@@ -82,6 +89,7 @@
    <varlistentry xml:id="intldateformatter.constants.relative-medium">
     <term>
      <constant>IntlDateFormatter::RELATIVE_MEDIUM</constant>
+     <type>int</type>
     </term>
     <listitem>
      <simpara>
@@ -97,6 +105,7 @@
    <varlistentry xml:id="intldateformatter.constants.relative-short">
     <term>
      <constant>IntlDateFormatter::RELATIVE_SHORT</constant>
+     <type>int</type>
     </term>
     <listitem>
      <simpara>
@@ -121,6 +130,7 @@
    <varlistentry xml:id="intldateformatter.constants.traditional">
     <term>
      <constant>IntlDateFormatter::TRADITIONAL</constant>
+     <type>int</type>
     </term>
     <listitem>
      <simpara>非グレゴリオ暦</simpara>
@@ -129,6 +139,7 @@
    <varlistentry xml:id="intldateformatter.constants.gregorian">
     <term>
      <constant>IntlDateFormatter::GREGORIAN</constant>
+     <type>int</type>
     </term>
     <listitem>
      <simpara>グレゴリオ暦</simpara>

--- a/reference/intl/dateformatter-constants.xml
+++ b/reference/intl/dateformatter-constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 6e6c154057b6d96518de039f40ff1e4feb44b04f Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 1f68eecaa7c4c723abe72a5a040ea7b15023a5aa Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <section xml:id="intl.intldateformatter-constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.constants;

--- a/reference/intl/dateformatter.xml
+++ b/reference/intl/dateformatter.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 1f68eecaa7c4c723abe72a5a040ea7b15023a5aa Maintainer: takagi Status: ready -->
 <reference xml:id="class.intldateformatter" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>IntlDateFormatter クラス</title>
  <titleabbrev>IntlDateFormatter</titleabbrev>

--- a/reference/intl/dateformatter.xml
+++ b/reference/intl/dateformatter.xml
@@ -130,6 +130,28 @@
   </section>
 
   &reference.intl.dateformatter-constants;
+
+  <section role="changelog" xml:id="intldateformatter.changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        クラス定数が型付けされました。
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
  </partintro>
 
  &reference.intl.entities.dateformatter;

--- a/reference/intl/intlbreakiterator.xml
+++ b/reference/intl/intlbreakiterator.xml
@@ -187,133 +187,190 @@
    <variablelist>
 
     <varlistentry xml:id="intlbreakiterator.constants.done">
-     <term><constant>IntlBreakIterator::DONE</constant></term>
+     <term>
+      <constant>IntlBreakIterator::DONE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlbreakiterator.constants.word-none">
-     <term><constant>IntlBreakIterator::WORD_NONE</constant></term>
+     <term>
+      <constant>IntlBreakIterator::WORD_NONE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlbreakiterator.constants.word-none-limit">
-     <term><constant>IntlBreakIterator::WORD_NONE_LIMIT</constant></term>
+     <term>
+      <constant>IntlBreakIterator::WORD_NONE_LIMIT</constant>
+      <type>int</type>
+     </term>     
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlbreakiterator.constants.word-number">
-     <term><constant>IntlBreakIterator::WORD_NUMBER</constant></term>
+     <term>
+      <constant>IntlBreakIterator::WORD_NUMBER</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlbreakiterator.constants.word-number-limit">
-     <term><constant>IntlBreakIterator::WORD_NUMBER_LIMIT</constant></term>
+     <term>
+      <constant>IntlBreakIterator::WORD_NUMBER_LIMIT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlbreakiterator.constants.word-letter">
-     <term><constant>IntlBreakIterator::WORD_LETTER</constant></term>
+     <term>
+      <constant>IntlBreakIterator::WORD_LETTER</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlbreakiterator.constants.word-letter-limit">
-     <term><constant>IntlBreakIterator::WORD_LETTER_LIMIT</constant></term>
+     <term>
+      <constant>IntlBreakIterator::WORD_LETTER_LIMIT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlbreakiterator.constants.word-kana">
-     <term><constant>IntlBreakIterator::WORD_KANA</constant></term>
+     <term>
+      <constant>IntlBreakIterator::WORD_KANA</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlbreakiterator.constants.word-kana-limit">
-     <term><constant>IntlBreakIterator::WORD_KANA_LIMIT</constant></term>
+     <term>
+      <constant>IntlBreakIterator::WORD_KANA_LIMIT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlbreakiterator.constants.word-ideo">
-     <term><constant>IntlBreakIterator::WORD_IDEO</constant></term>
+     <term>
+      <constant>IntlBreakIterator::WORD_IDEO</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlbreakiterator.constants.word-ideo-limit">
-     <term><constant>IntlBreakIterator::WORD_IDEO_LIMIT</constant></term>
+     <term>
+      <constant>IntlBreakIterator::WORD_IDEO_LIMIT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlbreakiterator.constants.line-soft">
-     <term><constant>IntlBreakIterator::LINE_SOFT</constant></term>
+     <term>
+      <constant>IntlBreakIterator::LINE_SOFT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlbreakiterator.constants.line-soft-limit">
-     <term><constant>IntlBreakIterator::LINE_SOFT_LIMIT</constant></term>
+     <term>
+      <constant>IntlBreakIterator::LINE_SOFT_LIMIT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlbreakiterator.constants.line-hard">
-     <term><constant>IntlBreakIterator::LINE_HARD</constant></term>
+     <term>
+      <constant>IntlBreakIterator::LINE_HARD</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlbreakiterator.constants.line-hard-limit">
-     <term><constant>IntlBreakIterator::LINE_HARD_LIMIT</constant></term>
+     <term>
+      <constant>IntlBreakIterator::LINE_HARD_LIMIT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlbreakiterator.constants.sentence-term">
-     <term><constant>IntlBreakIterator::SENTENCE_TERM</constant></term>
+     <term>
+      <constant>IntlBreakIterator::SENTENCE_TERM</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlbreakiterator.constants.sentence-term-limit">
-     <term><constant>IntlBreakIterator::SENTENCE_TERM_LIMIT</constant></term>
+     <term>
+      <constant>IntlBreakIterator::SENTENCE_TERM_LIMIT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlbreakiterator.constants.sentence-sep">
-     <term><constant>IntlBreakIterator::SENTENCE_SEP</constant></term>
+     <term>
+      <constant>IntlBreakIterator::SENTENCE_SEP</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlbreakiterator.constants.sentence-sep-limit">
-     <term><constant>IntlBreakIterator::SENTENCE_SEP_LIMIT</constant></term>
+     <term>
+      <constant>IntlBreakIterator::SENTENCE_SEP_LIMIT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
@@ -333,6 +390,12 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        クラス定数が型付けされました。
+       </entry>
+      </row>
       <row>
        <entry>8.0.0</entry>
        <entry>

--- a/reference/intl/intlbreakiterator.xml
+++ b/reference/intl/intlbreakiterator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 1f68eecaa7c4c723abe72a5a040ea7b15023a5aa Maintainer: mumumu Status: ready -->
 <reference xml:id="class.intlbreakiterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>IntlBreakIterator クラス</title>

--- a/reference/intl/intlcalendar.xml
+++ b/reference/intl/intlcalendar.xml
@@ -281,7 +281,10 @@
    <variablelist>
 
     <varlistentry xml:id="intlcalendar.constants.field-era">
-     <term><constant>IntlCalendar::FIELD_ERA</constant></term>
+     <term>
+      <constant>IntlCalendar::FIELD_ERA</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para>
        カレンダーのフィールドで、時代を表す数値です。たとえば、グレゴリオ暦やユリウス暦の場合は
@@ -293,7 +296,10 @@
     </varlistentry>
 
     <varlistentry xml:id="intlcalendar.constants.field-year">
-     <term><constant>IntlCalendar::FIELD_YEAR</constant></term>
+     <term>
+      <constant>IntlCalendar::FIELD_YEAR</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para>
        カレンダーの、年を表すフィールド。時代が違えば同じ数字になることもあります。
@@ -304,7 +310,10 @@
     </varlistentry>
 
     <varlistentry xml:id="intlcalendar.constants.field-month">
-     <term><constant>IntlCalendar::FIELD_MONTH</constant></term>
+     <term>
+      <constant>IntlCalendar::FIELD_MONTH</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para>
        カレンダーの、月を表すフィールド。月番号はゼロからはじまるので、1月が
@@ -315,7 +324,10 @@
     </varlistentry>
 
     <varlistentry xml:id="intlcalendar.constants.field-week-of-year">
-     <term><constant>IntlCalendar::FIELD_WEEK_OF_YEAR</constant></term>
+     <term>
+      <constant>IntlCalendar::FIELD_WEEK_OF_YEAR</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para>
        カレンダーの、年内の週番号を表すフィールド。
@@ -327,7 +339,10 @@
     </varlistentry>
 
     <varlistentry xml:id="intlcalendar.constants.field-week-of-month">
-     <term><constant>IntlCalendar::FIELD_WEEK_OF_MONTH</constant></term>
+     <term>
+      <constant>IntlCalendar::FIELD_WEEK_OF_MONTH</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para>
        カレンダーの、月内の週番号を表すフィールド。
@@ -339,7 +354,10 @@
     </varlistentry>
 
     <varlistentry xml:id="intlcalendar.constants.field-date">
-     <term><constant>IntlCalendar::FIELD_DATE</constant></term>
+     <term>
+      <constant>IntlCalendar::FIELD_DATE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para>
        カレンダーの、月内の日数を表すフィールド。
@@ -350,7 +368,10 @@
     </varlistentry>
 
     <varlistentry xml:id="intlcalendar.constants.field-day-of-year">
-     <term><constant>IntlCalendar::FIELD_DAY_OF_YEAR</constant></term>
+     <term>
+      <constant>IntlCalendar::FIELD_DAY_OF_YEAR</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para>
        カレンダーの、年内の日数を表すフィールド。
@@ -361,7 +382,10 @@
     </varlistentry>
 
     <varlistentry xml:id="intlcalendar.constants.field-day-of-week">
-     <term><constant>IntlCalendar::FIELD_DAY_OF_WEEK</constant></term>
+     <term>
+      <constant>IntlCalendar::FIELD_DAY_OF_WEEK</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para>
        カレンダーの、曜日を表すフィールド。
@@ -374,7 +398,10 @@
     </varlistentry>
 
     <varlistentry xml:id="intlcalendar.constants.field-day-of-week-in-month">
-     <term><constant>IntlCalendar::FIELD_DAY_OF_WEEK_IN_MONTH</constant></term>
+     <term>
+      <constant>IntlCalendar::FIELD_DAY_OF_WEEK_IN_MONTH</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para>
        曜日 (日曜日、月曜日、…) を指定されたときに、このフィールドには当月内でその曜日が何番目に登場するのかを代入します。
@@ -404,7 +431,10 @@
     </varlistentry>
 
     <varlistentry xml:id="intlcalendar.constants.field-am-pm">
-     <term><constant>IntlCalendar::FIELD_AM_PM</constant></term>
+     <term>
+      <constant>IntlCalendar::FIELD_AM_PM</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para>
        カレンダーの、午前 (<literal>0</literal>) か午後 (<literal>1</literal>) かを表すフィールド。
@@ -414,7 +444,10 @@
     </varlistentry>
 
     <varlistentry xml:id="intlcalendar.constants.field-hour">
-     <term><constant>IntlCalendar::FIELD_HOUR</constant></term>
+     <term>
+      <constant>IntlCalendar::FIELD_HOUR</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para>
        カレンダーの、時間を表すフィールド。午前か午後かは含みません。
@@ -424,7 +457,10 @@
     </varlistentry>
 
     <varlistentry xml:id="intlcalendar.constants.field-hour-of-day">
-     <term><constant>IntlCalendar::FIELD_HOUR_OF_DAY</constant></term>
+     <term>
+      <constant>IntlCalendar::FIELD_HOUR_OF_DAY</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para>
        カレンダーの、24 時間制の時間を表すフィールド。
@@ -434,7 +470,10 @@
     </varlistentry>
 
     <varlistentry xml:id="intlcalendar.constants.field-minute">
-     <term><constant>IntlCalendar::FIELD_MINUTE</constant></term>
+     <term>
+      <constant>IntlCalendar::FIELD_MINUTE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para>
        カレンダーの、分を表すフィールド。
@@ -443,7 +482,10 @@
     </varlistentry>
 
     <varlistentry xml:id="intlcalendar.constants.field-second">
-     <term><constant>IntlCalendar::FIELD_SECOND</constant></term>
+     <term>
+      <constant>IntlCalendar::FIELD_SECOND</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para>
        カレンダーの、秒を表すフィールド。
@@ -452,7 +494,10 @@
     </varlistentry>
 
     <varlistentry xml:id="intlcalendar.constants.field-millisecond">
-     <term><constant>IntlCalendar::FIELD_MILLISECOND</constant></term>
+     <term>
+      <constant>IntlCalendar::FIELD_MILLISECOND</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para>
        カレンダーの、ミリ秒を表すフィールド。
@@ -461,7 +506,10 @@
     </varlistentry>
 
     <varlistentry xml:id="intlcalendar.constants.field-zone-offset">
-     <term><constant>IntlCalendar::FIELD_ZONE_OFFSET</constant></term>
+     <term>
+      <constant>IntlCalendar::FIELD_ZONE_OFFSET</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para>
        カレンダーの、タイムゾーンのオフセットをミリ秒で表すフィールド。
@@ -471,7 +519,10 @@
     </varlistentry>
 
     <varlistentry xml:id="intlcalendar.constants.field-dst-offset">
-     <term><constant>IntlCalendar::FIELD_DST_OFFSET</constant></term>
+     <term>
+      <constant>IntlCalendar::FIELD_DST_OFFSET</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para>
        カレンダーの、夏時間によるオフセットをミリ秒で表すフィールド。
@@ -481,7 +532,10 @@
     </varlistentry>
 
     <varlistentry xml:id="intlcalendar.constants.field-year-woy">
-     <term><constant>IntlCalendar::FIELD_YEAR_WOY</constant></term>
+     <term>
+      <constant>IntlCalendar::FIELD_YEAR_WOY</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para>
        カレンダーの、<link
@@ -492,7 +546,10 @@
     </varlistentry>
 
     <varlistentry xml:id="intlcalendar.constants.field-dow-local">
-     <term><constant>IntlCalendar::FIELD_DOW_LOCAL</constant></term>
+     <term>
+      <constant>IntlCalendar::FIELD_DOW_LOCAL</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para>
        カレンダーの、ローカライズした曜日を表すフィールド。
@@ -505,7 +562,10 @@
     </varlistentry>
 
     <varlistentry xml:id="intlcalendar.constants.field-extended-year">
-     <term><constant>IntlCalendar::FIELD_EXTENDED_YEAR</constant></term>
+     <term>
+      <constant>IntlCalendar::FIELD_EXTENDED_YEAR</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para>
        カレンダーの、年番号を表すフィールド。この番号は、時代をまたがって続きます。
@@ -517,7 +577,10 @@
     </varlistentry>
 
     <varlistentry xml:id="intlcalendar.constants.field-julian-day">
-     <term><constant>IntlCalendar::FIELD_JULIAN_DAY</constant></term>
+     <term>
+      <constant>IntlCalendar::FIELD_JULIAN_DAY</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para>
        カレンダーの、ユリウス日を表すフィールド。
@@ -529,7 +592,10 @@
     </varlistentry>
 
     <varlistentry xml:id="intlcalendar.constants.field-milliseconds-in-day">
-     <term><constant>IntlCalendar::FIELD_MILLISECONDS_IN_DAY</constant></term>
+     <term>
+      <constant>IntlCalendar::FIELD_MILLISECONDS_IN_DAY</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para>
        カレンダーの、
@@ -546,7 +612,10 @@
     </varlistentry>
 
     <varlistentry xml:id="intlcalendar.constants.field-is-leap-month">
-     <term><constant>IntlCalendar::FIELD_IS_LEAP_MONTH</constant></term>
+     <term>
+      <constant>IntlCalendar::FIELD_IS_LEAP_MONTH</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para>
        カレンダーのフィールドで、値が <literal>1</literal> のときはうるう月、
@@ -556,7 +625,10 @@
     </varlistentry>
 
     <varlistentry xml:id="intlcalendar.constants.field-field-count">
-     <term><constant>IntlCalendar::FIELD_FIELD_COUNT</constant></term>
+     <term>
+      <constant>IntlCalendar::FIELD_FIELD_COUNT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para>
        フィールドの総数。
@@ -565,7 +637,10 @@
     </varlistentry>
 
     <varlistentry xml:id="intlcalendar.constants.field-day-of-month">
-     <term><constant>IntlCalendar::FIELD_DAY_OF_MONTH</constant></term>
+     <term>
+      <constant>IntlCalendar::FIELD_DAY_OF_MONTH</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para>
        <link
@@ -576,56 +651,80 @@
     </varlistentry>
 
     <varlistentry xml:id="intlcalendar.constants.dow-sunday">
-     <term><constant>IntlCalendar::DOW_SUNDAY</constant></term>
+     <term>
+      <constant>IntlCalendar::DOW_SUNDAY</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para>日曜日。</para>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlcalendar.constants.dow-monday">
-     <term><constant>IntlCalendar::DOW_MONDAY</constant></term>
+     <term>
+      <constant>IntlCalendar::DOW_MONDAY</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para>月曜日。</para>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlcalendar.constants.dow-tuesday">
-     <term><constant>IntlCalendar::DOW_TUESDAY</constant></term>
+     <term>
+      <constant>IntlCalendar::DOW_TUESDAY</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para>火曜日。</para>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlcalendar.constants.dow-wednesday">
-     <term><constant>IntlCalendar::DOW_WEDNESDAY</constant></term>
+     <term>
+      <constant>IntlCalendar::DOW_WEDNESDAY</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para>水曜日。</para>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlcalendar.constants.dow-thursday">
-     <term><constant>IntlCalendar::DOW_THURSDAY</constant></term>
+     <term>
+      <constant>IntlCalendar::DOW_THURSDAY</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para>木曜日。</para>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlcalendar.constants.dow-friday">
-     <term><constant>IntlCalendar::DOW_FRIDAY</constant></term>
+     <term>
+      <constant>IntlCalendar::DOW_FRIDAY</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para>金曜日。</para>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlcalendar.constants.dow-saturday">
-     <term><constant>IntlCalendar::DOW_SATURDAY</constant></term>
+     <term>
+      <constant>IntlCalendar::DOW_SATURDAY</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para>土曜日。</para>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlcalendar.constants.dow-type-weekday">
-     <term><constant>IntlCalendar::DOW_TYPE_WEEKDAY</constant></term>
+     <term>
+      <constant>IntlCalendar::DOW_TYPE_WEEKDAY</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para>
        平日であることを示す
@@ -636,7 +735,10 @@
     </varlistentry>
 
     <varlistentry xml:id="intlcalendar.constants.dow-type-weekend">
-     <term><constant>IntlCalendar::DOW_TYPE_WEEKEND</constant></term>
+     <term>
+      <constant>IntlCalendar::DOW_TYPE_WEEKEND</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para>
        週末であることを示す
@@ -647,7 +749,10 @@
     </varlistentry>
 
     <varlistentry xml:id="intlcalendar.constants.dow-type-weekend-offset">
-     <term><constant>IntlCalendar::DOW_TYPE_WEEKEND_OFFSET</constant></term>
+     <term>
+      <constant>IntlCalendar::DOW_TYPE_WEEKEND_OFFSET</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para>
        指定した曜日から週末が始まることを示す
@@ -658,7 +763,10 @@
     </varlistentry>
 
     <varlistentry xml:id="intlcalendar.constants.dow-type-weekend-cease">
-     <term><constant>IntlCalendar::DOW_TYPE_WEEKEND_CEASE</constant></term>
+     <term>
+      <constant>IntlCalendar::DOW_TYPE_WEEKEND_CEASE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para>
        指定した曜日で週末が終わることを示す
@@ -669,7 +777,10 @@
     </varlistentry>
 
     <varlistentry xml:id="intlcalendar.constants.walltime-first">
-     <term><constant>IntlCalendar::WALLTIME_FIRST</constant></term>
+     <term>
+      <constant>IntlCalendar::WALLTIME_FIRST</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para>
        スキップした範囲内の実測時間が一時間前の実測時間と同じ瞬間を指すことを示す
@@ -681,7 +792,10 @@
     </varlistentry>
 
     <varlistentry xml:id="intlcalendar.constants.walltime-last">
-     <term><constant>IntlCalendar::WALLTIME_LAST</constant></term>
+     <term>
+      <constant>IntlCalendar::WALLTIME_LAST</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para>
        スキップした範囲内の実測時間が一時間後の実測時間と同じ瞬間を指すことを示す
@@ -693,7 +807,10 @@
     </varlistentry>
 
     <varlistentry xml:id="intlcalendar.constants.walltime-next-valid">
-     <term><constant>IntlCalendar::WALLTIME_NEXT_VALID</constant></term>
+     <term>
+      <constant>IntlCalendar::WALLTIME_NEXT_VALID</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para>
        スキップした範囲内の実測時間が夏時間への移行 (開始) を指すことを示す
@@ -706,6 +823,27 @@
   </section>
 <!-- }}} -->
 
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        クラス定数が型付けされました。
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
 
  </partintro>
 

--- a/reference/intl/intlcalendar.xml
+++ b/reference/intl/intlcalendar.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 1f68eecaa7c4c723abe72a5a040ea7b15023a5aa Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <reference xml:id="class.intlcalendar" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/intl/intlchar.xml
+++ b/reference/intl/intlchar.xml
@@ -4022,28 +4022,40 @@
     &reftitle.constants;
     <variablelist>
      <varlistentry xml:id="intlchar.constants.unicode-version">
-      <term><constant>IntlChar::UNICODE_VERSION</constant></term>
+      <term>
+       <constant>IntlChar::UNICODE_VERSION</constant>
+       <type>string</type>
+      </term>
       <listitem>
        <para/>
       </listitem>
      </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.codepoint-min">
-     <term><constant>IntlChar::CODEPOINT_MIN</constant></term>
+     <term>
+      <constant>IntlChar::CODEPOINT_MIN</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.codepoint-max">
-     <term><constant>IntlChar::CODEPOINT_MAX</constant></term>
+     <term>
+      <constant>IntlChar::CODEPOINT_MAX</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.no-numeric-value">
-     <term><constant>IntlChar::NO_NUMERIC_VALUE</constant></term>
+     <term>
+      <constant>IntlChar::NO_NUMERIC_VALUE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para>
        Special value that is returned by
@@ -4054,4613 +4066,6590 @@
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-alphabetic">
-     <term><constant>IntlChar::PROPERTY_ALPHABETIC</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_ALPHABETIC</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-binary-start">
-     <term><constant>IntlChar::PROPERTY_BINARY_START</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_BINARY_START</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-ascii-hex-digit">
-     <term><constant>IntlChar::PROPERTY_ASCII_HEX_DIGIT</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_ASCII_HEX_DIGIT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-bidi-control">
-     <term><constant>IntlChar::PROPERTY_BIDI_CONTROL</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_BIDI_CONTROL</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-bidi-mirrored">
-     <term><constant>IntlChar::PROPERTY_BIDI_MIRRORED</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_BIDI_MIRRORED</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-dash">
-     <term><constant>IntlChar::PROPERTY_DASH</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_DASH</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-default-ignorable-code-point">
-     <term><constant>IntlChar::PROPERTY_DEFAULT_IGNORABLE_CODE_POINT</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_DEFAULT_IGNORABLE_CODE_POINT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-deprecated">
-     <term><constant>IntlChar::PROPERTY_DEPRECATED</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_DEPRECATED</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-diacritic">
-     <term><constant>IntlChar::PROPERTY_DIACRITIC</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_DIACRITIC</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-extender">
-     <term><constant>IntlChar::PROPERTY_EXTENDER</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_EXTENDER</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-full-composition-exclusion">
-     <term><constant>IntlChar::PROPERTY_FULL_COMPOSITION_EXCLUSION</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_FULL_COMPOSITION_EXCLUSION</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-grapheme-base">
-     <term><constant>IntlChar::PROPERTY_GRAPHEME_BASE</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_GRAPHEME_BASE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-grapheme-extend">
-     <term><constant>IntlChar::PROPERTY_GRAPHEME_EXTEND</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_GRAPHEME_EXTEND</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-grapheme-link">
-     <term><constant>IntlChar::PROPERTY_GRAPHEME_LINK</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_GRAPHEME_LINK</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-hex-digit">
-     <term><constant>IntlChar::PROPERTY_HEX_DIGIT</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_HEX_DIGIT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-hyphen">
-     <term><constant>IntlChar::PROPERTY_HYPHEN</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_HYPHEN</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-id-continue">
-     <term><constant>IntlChar::PROPERTY_ID_CONTINUE</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_ID_CONTINUE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-id-start">
-     <term><constant>IntlChar::PROPERTY_ID_START</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_ID_START</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-ideographic">
-     <term><constant>IntlChar::PROPERTY_IDEOGRAPHIC</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_IDEOGRAPHIC</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-ids-binary-operator">
-     <term><constant>IntlChar::PROPERTY_IDS_BINARY_OPERATOR</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_IDS_BINARY_OPERATOR</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-ids-trinary-operator">
-     <term><constant>IntlChar::PROPERTY_IDS_TRINARY_OPERATOR</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_IDS_TRINARY_OPERATOR</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-join-control">
-     <term><constant>IntlChar::PROPERTY_JOIN_CONTROL</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_JOIN_CONTROL</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-logical-order-exception">
-     <term><constant>IntlChar::PROPERTY_LOGICAL_ORDER_EXCEPTION</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_LOGICAL_ORDER_EXCEPTION</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-lowercase">
-     <term><constant>IntlChar::PROPERTY_LOWERCASE</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_LOWERCASE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-math">
-     <term><constant>IntlChar::PROPERTY_MATH</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_MATH</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-noncharacter-code-point">
-     <term><constant>IntlChar::PROPERTY_NONCHARACTER_CODE_POINT</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_NONCHARACTER_CODE_POINT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-quotation-mark">
-     <term><constant>IntlChar::PROPERTY_QUOTATION_MARK</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_QUOTATION_MARK</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-radical">
-     <term><constant>IntlChar::PROPERTY_RADICAL</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_RADICAL</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-soft-dotted">
-     <term><constant>IntlChar::PROPERTY_SOFT_DOTTED</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_SOFT_DOTTED</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-terminal-punctuation">
-     <term><constant>IntlChar::PROPERTY_TERMINAL_PUNCTUATION</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_TERMINAL_PUNCTUATION</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-unified-ideograph">
-     <term><constant>IntlChar::PROPERTY_UNIFIED_IDEOGRAPH</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_UNIFIED_IDEOGRAPH</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-uppercase">
-     <term><constant>IntlChar::PROPERTY_UPPERCASE</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_UPPERCASE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-white-space">
-     <term><constant>IntlChar::PROPERTY_WHITE_SPACE</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_WHITE_SPACE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-xid-continue">
-     <term><constant>IntlChar::PROPERTY_XID_CONTINUE</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_XID_CONTINUE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-xid-start">
-     <term><constant>IntlChar::PROPERTY_XID_START</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_XID_START</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-case-sensitive">
-     <term><constant>IntlChar::PROPERTY_CASE_SENSITIVE</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_CASE_SENSITIVE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-s-term">
-     <term><constant>IntlChar::PROPERTY_S_TERM</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_S_TERM</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-variation-selector">
-     <term><constant>IntlChar::PROPERTY_VARIATION_SELECTOR</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_VARIATION_SELECTOR</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-nfd-inert">
-     <term><constant>IntlChar::PROPERTY_NFD_INERT</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_NFD_INERT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-nfkd-inert">
-     <term><constant>IntlChar::PROPERTY_NFKD_INERT</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_NFKD_INERT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-nfc-inert">
-     <term><constant>IntlChar::PROPERTY_NFC_INERT</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_NFC_INERT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-nfkc-inert">
-     <term><constant>IntlChar::PROPERTY_NFKC_INERT</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_NFKC_INERT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-segment-starter">
-     <term><constant>IntlChar::PROPERTY_SEGMENT_STARTER</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_SEGMENT_STARTER</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-pattern-syntax">
-     <term><constant>IntlChar::PROPERTY_PATTERN_SYNTAX</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_PATTERN_SYNTAX</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-pattern-white-space">
-     <term><constant>IntlChar::PROPERTY_PATTERN_WHITE_SPACE</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_PATTERN_WHITE_SPACE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-posix-alnum">
-     <term><constant>IntlChar::PROPERTY_POSIX_ALNUM</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_POSIX_ALNUM</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-posix-blank">
-     <term><constant>IntlChar::PROPERTY_POSIX_BLANK</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_POSIX_BLANK</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-posix-graph">
-     <term><constant>IntlChar::PROPERTY_POSIX_GRAPH</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_POSIX_GRAPH</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-posix-print">
-     <term><constant>IntlChar::PROPERTY_POSIX_PRINT</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_POSIX_PRINT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-posix-xdigit">
-     <term><constant>IntlChar::PROPERTY_POSIX_XDIGIT</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_POSIX_XDIGIT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-cased">
-     <term><constant>IntlChar::PROPERTY_CASED</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_CASED</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-case-ignorable">
-     <term><constant>IntlChar::PROPERTY_CASE_IGNORABLE</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_CASE_IGNORABLE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-changes-when-lowercased">
-     <term><constant>IntlChar::PROPERTY_CHANGES_WHEN_LOWERCASED</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_CHANGES_WHEN_LOWERCASED</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-changes-when-uppercased">
-     <term><constant>IntlChar::PROPERTY_CHANGES_WHEN_UPPERCASED</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_CHANGES_WHEN_UPPERCASED</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-changes-when-titlecased">
-     <term><constant>IntlChar::PROPERTY_CHANGES_WHEN_TITLECASED</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_CHANGES_WHEN_TITLECASED</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-changes-when-casefolded">
-     <term><constant>IntlChar::PROPERTY_CHANGES_WHEN_CASEFOLDED</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_CHANGES_WHEN_CASEFOLDED</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-changes-when-casemapped">
-     <term><constant>IntlChar::PROPERTY_CHANGES_WHEN_CASEMAPPED</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_CHANGES_WHEN_CASEMAPPED</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-changes-when-nfkc-casefolded">
-     <term><constant>IntlChar::PROPERTY_CHANGES_WHEN_NFKC_CASEFOLDED</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_CHANGES_WHEN_NFKC_CASEFOLDED</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-binary-limit">
-     <term><constant>IntlChar::PROPERTY_BINARY_LIMIT</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_BINARY_LIMIT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-bidi-class">
-     <term><constant>IntlChar::PROPERTY_BIDI_CLASS</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_BIDI_CLASS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-int-start">
-     <term><constant>IntlChar::PROPERTY_INT_START</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_INT_START</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-block">
-     <term><constant>IntlChar::PROPERTY_BLOCK</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_BLOCK</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-canonical-combining-class">
-     <term><constant>IntlChar::PROPERTY_CANONICAL_COMBINING_CLASS</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_CANONICAL_COMBINING_CLASS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-decomposition-type">
-     <term><constant>IntlChar::PROPERTY_DECOMPOSITION_TYPE</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_DECOMPOSITION_TYPE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-east-asian-width">
-     <term><constant>IntlChar::PROPERTY_EAST_ASIAN_WIDTH</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_EAST_ASIAN_WIDTH</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-general-category">
-     <term><constant>IntlChar::PROPERTY_GENERAL_CATEGORY</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_GENERAL_CATEGORY</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-joining-group">
-     <term><constant>IntlChar::PROPERTY_JOINING_GROUP</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_JOINING_GROUP</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-joining-type">
-     <term><constant>IntlChar::PROPERTY_JOINING_TYPE</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_JOINING_TYPE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-line-break">
-     <term><constant>IntlChar::PROPERTY_LINE_BREAK</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_LINE_BREAK</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-numeric-type">
-     <term><constant>IntlChar::PROPERTY_NUMERIC_TYPE</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_NUMERIC_TYPE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-script">
-     <term><constant>IntlChar::PROPERTY_SCRIPT</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_SCRIPT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-hangul-syllable-type">
-     <term><constant>IntlChar::PROPERTY_HANGUL_SYLLABLE_TYPE</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_HANGUL_SYLLABLE_TYPE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-nfd-quick-check">
-     <term><constant>IntlChar::PROPERTY_NFD_QUICK_CHECK</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_NFD_QUICK_CHECK</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-nfkd-quick-check">
-     <term><constant>IntlChar::PROPERTY_NFKD_QUICK_CHECK</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_NFKD_QUICK_CHECK</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-nfc-quick-check">
-     <term><constant>IntlChar::PROPERTY_NFC_QUICK_CHECK</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_NFC_QUICK_CHECK</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-nfkc-quick-check">
-     <term><constant>IntlChar::PROPERTY_NFKC_QUICK_CHECK</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_NFKC_QUICK_CHECK</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-lead-canonical-combining-class">
-     <term><constant>IntlChar::PROPERTY_LEAD_CANONICAL_COMBINING_CLASS</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_LEAD_CANONICAL_COMBINING_CLASS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-trail-canonical-combining-class">
-     <term><constant>IntlChar::PROPERTY_TRAIL_CANONICAL_COMBINING_CLASS</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_TRAIL_CANONICAL_COMBINING_CLASS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-grapheme-cluster-break">
-     <term><constant>IntlChar::PROPERTY_GRAPHEME_CLUSTER_BREAK</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_GRAPHEME_CLUSTER_BREAK</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-sentence-break">
-     <term><constant>IntlChar::PROPERTY_SENTENCE_BREAK</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_SENTENCE_BREAK</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-word-break">
-     <term><constant>IntlChar::PROPERTY_WORD_BREAK</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_WORD_BREAK</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-bidi-paired-bracket-type">
-     <term><constant>IntlChar::PROPERTY_BIDI_PAIRED_BRACKET_TYPE</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_BIDI_PAIRED_BRACKET_TYPE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-int-limit">
-     <term><constant>IntlChar::PROPERTY_INT_LIMIT</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_INT_LIMIT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-general-category-mask">
-     <term><constant>IntlChar::PROPERTY_GENERAL_CATEGORY_MASK</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_GENERAL_CATEGORY_MASK</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-mask-start">
-     <term><constant>IntlChar::PROPERTY_MASK_START</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_MASK_START</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-mask-limit">
-     <term><constant>IntlChar::PROPERTY_MASK_LIMIT</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_MASK_LIMIT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-numeric-value">
-     <term><constant>IntlChar::PROPERTY_NUMERIC_VALUE</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_NUMERIC_VALUE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-double-start">
-     <term><constant>IntlChar::PROPERTY_DOUBLE_START</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_DOUBLE_START</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-double-limit">
-     <term><constant>IntlChar::PROPERTY_DOUBLE_LIMIT</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_DOUBLE_LIMIT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-age">
-     <term><constant>IntlChar::PROPERTY_AGE</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_AGE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-string-start">
-     <term><constant>IntlChar::PROPERTY_STRING_START</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_STRING_START</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-bidi-mirroring-glyph">
-     <term><constant>IntlChar::PROPERTY_BIDI_MIRRORING_GLYPH</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_BIDI_MIRRORING_GLYPH</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-case-folding">
-     <term><constant>IntlChar::PROPERTY_CASE_FOLDING</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_CASE_FOLDING</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-iso-comment">
-     <term><constant>IntlChar::PROPERTY_ISO_COMMENT</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_ISO_COMMENT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-lowercase-mapping">
-     <term><constant>IntlChar::PROPERTY_LOWERCASE_MAPPING</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_LOWERCASE_MAPPING</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-name">
-     <term><constant>IntlChar::PROPERTY_NAME</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_NAME</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-simple-case-folding">
-     <term><constant>IntlChar::PROPERTY_SIMPLE_CASE_FOLDING</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_SIMPLE_CASE_FOLDING</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-simple-lowercase-mapping">
-     <term><constant>IntlChar::PROPERTY_SIMPLE_LOWERCASE_MAPPING</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_SIMPLE_LOWERCASE_MAPPING</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-simple-titlecase-mapping">
-     <term><constant>IntlChar::PROPERTY_SIMPLE_TITLECASE_MAPPING</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_SIMPLE_TITLECASE_MAPPING</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-simple-uppercase-mapping">
-     <term><constant>IntlChar::PROPERTY_SIMPLE_UPPERCASE_MAPPING</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_SIMPLE_UPPERCASE_MAPPING</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-titlecase-mapping">
-     <term><constant>IntlChar::PROPERTY_TITLECASE_MAPPING</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_TITLECASE_MAPPING</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-unicode-1-name">
-     <term><constant>IntlChar::PROPERTY_UNICODE_1_NAME</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_UNICODE_1_NAME</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-uppercase-mapping">
-     <term><constant>IntlChar::PROPERTY_UPPERCASE_MAPPING</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_UPPERCASE_MAPPING</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-bidi-paired-bracket">
-     <term><constant>IntlChar::PROPERTY_BIDI_PAIRED_BRACKET</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_BIDI_PAIRED_BRACKET</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-string-limit">
-     <term><constant>IntlChar::PROPERTY_STRING_LIMIT</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_STRING_LIMIT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-script-extensions">
-     <term><constant>IntlChar::PROPERTY_SCRIPT_EXTENSIONS</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_SCRIPT_EXTENSIONS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-other-property-start">
-     <term><constant>IntlChar::PROPERTY_OTHER_PROPERTY_START</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_OTHER_PROPERTY_START</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-other-property-limit">
-     <term><constant>IntlChar::PROPERTY_OTHER_PROPERTY_LIMIT</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_OTHER_PROPERTY_LIMIT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-invalid-code">
-     <term><constant>IntlChar::PROPERTY_INVALID_CODE</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_INVALID_CODE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-category-unassigned">
-     <term><constant>IntlChar::CHAR_CATEGORY_UNASSIGNED</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_CATEGORY_UNASSIGNED</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-category-general-other-types">
-     <term><constant>IntlChar::CHAR_CATEGORY_GENERAL_OTHER_TYPES</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_CATEGORY_GENERAL_OTHER_TYPES</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-category-uppercase-letter">
-     <term><constant>IntlChar::CHAR_CATEGORY_UPPERCASE_LETTER</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_CATEGORY_UPPERCASE_LETTER</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-category-lowercase-letter">
-     <term><constant>IntlChar::CHAR_CATEGORY_LOWERCASE_LETTER</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_CATEGORY_LOWERCASE_LETTER</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-category-titlecase-letter">
-     <term><constant>IntlChar::CHAR_CATEGORY_TITLECASE_LETTER</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_CATEGORY_TITLECASE_LETTER</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-category-modifier-letter">
-     <term><constant>IntlChar::CHAR_CATEGORY_MODIFIER_LETTER</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_CATEGORY_MODIFIER_LETTER</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-category-other-letter">
-     <term><constant>IntlChar::CHAR_CATEGORY_OTHER_LETTER</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_CATEGORY_OTHER_LETTER</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-category-non-spacing-mark">
-     <term><constant>IntlChar::CHAR_CATEGORY_NON_SPACING_MARK</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_CATEGORY_NON_SPACING_MARK</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-category-enclosing-mark">
-     <term><constant>IntlChar::CHAR_CATEGORY_ENCLOSING_MARK</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_CATEGORY_ENCLOSING_MARK</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-category-combining-spacing-mark">
-     <term><constant>IntlChar::CHAR_CATEGORY_COMBINING_SPACING_MARK</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_CATEGORY_COMBINING_SPACING_MARK</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-category-decimal-digit-number">
-     <term><constant>IntlChar::CHAR_CATEGORY_DECIMAL_DIGIT_NUMBER</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_CATEGORY_DECIMAL_DIGIT_NUMBER</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-category-letter-number">
-     <term><constant>IntlChar::CHAR_CATEGORY_LETTER_NUMBER</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_CATEGORY_LETTER_NUMBER</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-category-other-number">
-     <term><constant>IntlChar::CHAR_CATEGORY_OTHER_NUMBER</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_CATEGORY_OTHER_NUMBER</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-category-space-separator">
-     <term><constant>IntlChar::CHAR_CATEGORY_SPACE_SEPARATOR</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_CATEGORY_SPACE_SEPARATOR</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-category-line-separator">
-     <term><constant>IntlChar::CHAR_CATEGORY_LINE_SEPARATOR</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_CATEGORY_LINE_SEPARATOR</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-category-paragraph-separator">
-     <term><constant>IntlChar::CHAR_CATEGORY_PARAGRAPH_SEPARATOR</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_CATEGORY_PARAGRAPH_SEPARATOR</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-category-control-char">
-     <term><constant>IntlChar::CHAR_CATEGORY_CONTROL_CHAR</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_CATEGORY_CONTROL_CHAR</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-category-format-char">
-     <term><constant>IntlChar::CHAR_CATEGORY_FORMAT_CHAR</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_CATEGORY_FORMAT_CHAR</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-category-private-use-char">
-     <term><constant>IntlChar::CHAR_CATEGORY_PRIVATE_USE_CHAR</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_CATEGORY_PRIVATE_USE_CHAR</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-category-surrogate">
-     <term><constant>IntlChar::CHAR_CATEGORY_SURROGATE</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_CATEGORY_SURROGATE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-category-dash-punctuation">
-     <term><constant>IntlChar::CHAR_CATEGORY_DASH_PUNCTUATION</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_CATEGORY_DASH_PUNCTUATION</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-category-start-punctuation">
-     <term><constant>IntlChar::CHAR_CATEGORY_START_PUNCTUATION</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_CATEGORY_START_PUNCTUATION</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-category-end-punctuation">
-     <term><constant>IntlChar::CHAR_CATEGORY_END_PUNCTUATION</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_CATEGORY_END_PUNCTUATION</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-category-connector-punctuation">
-     <term><constant>IntlChar::CHAR_CATEGORY_CONNECTOR_PUNCTUATION</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_CATEGORY_CONNECTOR_PUNCTUATION</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-category-other-punctuation">
-     <term><constant>IntlChar::CHAR_CATEGORY_OTHER_PUNCTUATION</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_CATEGORY_OTHER_PUNCTUATION</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-category-math-symbol">
-     <term><constant>IntlChar::CHAR_CATEGORY_MATH_SYMBOL</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_CATEGORY_MATH_SYMBOL</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-category-currency-symbol">
-     <term><constant>IntlChar::CHAR_CATEGORY_CURRENCY_SYMBOL</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_CATEGORY_CURRENCY_SYMBOL</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-category-modifier-symbol">
-     <term><constant>IntlChar::CHAR_CATEGORY_MODIFIER_SYMBOL</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_CATEGORY_MODIFIER_SYMBOL</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-category-other-symbol">
-     <term><constant>IntlChar::CHAR_CATEGORY_OTHER_SYMBOL</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_CATEGORY_OTHER_SYMBOL</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-category-initial-punctuation">
-     <term><constant>IntlChar::CHAR_CATEGORY_INITIAL_PUNCTUATION</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_CATEGORY_INITIAL_PUNCTUATION</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-category-final-punctuation">
-     <term><constant>IntlChar::CHAR_CATEGORY_FINAL_PUNCTUATION</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_CATEGORY_FINAL_PUNCTUATION</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-category-char-category-count">
-     <term><constant>IntlChar::CHAR_CATEGORY_CHAR_CATEGORY_COUNT</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_CATEGORY_CHAR_CATEGORY_COUNT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-direction-left-to-right">
-     <term><constant>IntlChar::CHAR_DIRECTION_LEFT_TO_RIGHT</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_DIRECTION_LEFT_TO_RIGHT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-direction-right-to-left">
-     <term><constant>IntlChar::CHAR_DIRECTION_RIGHT_TO_LEFT</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_DIRECTION_RIGHT_TO_LEFT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-direction-european-number">
-     <term><constant>IntlChar::CHAR_DIRECTION_EUROPEAN_NUMBER</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_DIRECTION_EUROPEAN_NUMBER</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-direction-european-number-separator">
-     <term><constant>IntlChar::CHAR_DIRECTION_EUROPEAN_NUMBER_SEPARATOR</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_DIRECTION_EUROPEAN_NUMBER_SEPARATOR</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-direction-european-number-terminator">
-     <term><constant>IntlChar::CHAR_DIRECTION_EUROPEAN_NUMBER_TERMINATOR</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_DIRECTION_EUROPEAN_NUMBER_TERMINATOR</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-direction-arabic-number">
-     <term><constant>IntlChar::CHAR_DIRECTION_ARABIC_NUMBER</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_DIRECTION_ARABIC_NUMBER</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-direction-common-number-separator">
-     <term><constant>IntlChar::CHAR_DIRECTION_COMMON_NUMBER_SEPARATOR</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_DIRECTION_COMMON_NUMBER_SEPARATOR</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-direction-block-separator">
-     <term><constant>IntlChar::CHAR_DIRECTION_BLOCK_SEPARATOR</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_DIRECTION_BLOCK_SEPARATOR</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-direction-segment-separator">
-     <term><constant>IntlChar::CHAR_DIRECTION_SEGMENT_SEPARATOR</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_DIRECTION_SEGMENT_SEPARATOR</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-direction-white-space-neutral">
-     <term><constant>IntlChar::CHAR_DIRECTION_WHITE_SPACE_NEUTRAL</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_DIRECTION_WHITE_SPACE_NEUTRAL</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-direction-other-neutral">
-     <term><constant>IntlChar::CHAR_DIRECTION_OTHER_NEUTRAL</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_DIRECTION_OTHER_NEUTRAL</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-direction-left-to-right-embedding">
-     <term><constant>IntlChar::CHAR_DIRECTION_LEFT_TO_RIGHT_EMBEDDING</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_DIRECTION_LEFT_TO_RIGHT_EMBEDDING</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-direction-left-to-right-override">
-     <term><constant>IntlChar::CHAR_DIRECTION_LEFT_TO_RIGHT_OVERRIDE</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_DIRECTION_LEFT_TO_RIGHT_OVERRIDE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-direction-right-to-left-arabic">
-     <term><constant>IntlChar::CHAR_DIRECTION_RIGHT_TO_LEFT_ARABIC</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_DIRECTION_RIGHT_TO_LEFT_ARABIC</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-direction-right-to-left-embedding">
-     <term><constant>IntlChar::CHAR_DIRECTION_RIGHT_TO_LEFT_EMBEDDING</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_DIRECTION_RIGHT_TO_LEFT_EMBEDDING</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-direction-right-to-left-override">
-     <term><constant>IntlChar::CHAR_DIRECTION_RIGHT_TO_LEFT_OVERRIDE</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_DIRECTION_RIGHT_TO_LEFT_OVERRIDE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-direction-pop-directional-format">
-     <term><constant>IntlChar::CHAR_DIRECTION_POP_DIRECTIONAL_FORMAT</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_DIRECTION_POP_DIRECTIONAL_FORMAT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-direction-dir-non-spacing-mark">
-     <term><constant>IntlChar::CHAR_DIRECTION_DIR_NON_SPACING_MARK</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_DIRECTION_DIR_NON_SPACING_MARK</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-direction-boundary-neutral">
-     <term><constant>IntlChar::CHAR_DIRECTION_BOUNDARY_NEUTRAL</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_DIRECTION_BOUNDARY_NEUTRAL</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-direction-first-strong-isolate">
-     <term><constant>IntlChar::CHAR_DIRECTION_FIRST_STRONG_ISOLATE</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_DIRECTION_FIRST_STRONG_ISOLATE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-direction-left-to-right-isolate">
-     <term><constant>IntlChar::CHAR_DIRECTION_LEFT_TO_RIGHT_ISOLATE</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_DIRECTION_LEFT_TO_RIGHT_ISOLATE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-direction-right-to-left-isolate">
-     <term><constant>IntlChar::CHAR_DIRECTION_RIGHT_TO_LEFT_ISOLATE</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_DIRECTION_RIGHT_TO_LEFT_ISOLATE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-direction-pop-directional-isolate">
-     <term><constant>IntlChar::CHAR_DIRECTION_POP_DIRECTIONAL_ISOLATE</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_DIRECTION_POP_DIRECTIONAL_ISOLATE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-direction-char-direction-count">
-     <term><constant>IntlChar::CHAR_DIRECTION_CHAR_DIRECTION_COUNT</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_DIRECTION_CHAR_DIRECTION_COUNT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-no-block">
-     <term><constant>IntlChar::BLOCK_CODE_NO_BLOCK</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_NO_BLOCK</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-basic-latin">
-     <term><constant>IntlChar::BLOCK_CODE_BASIC_LATIN</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_BASIC_LATIN</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-latin-1-supplement">
-     <term><constant>IntlChar::BLOCK_CODE_LATIN_1_SUPPLEMENT</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_LATIN_1_SUPPLEMENT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-latin-extended-a">
-     <term><constant>IntlChar::BLOCK_CODE_LATIN_EXTENDED_A</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_LATIN_EXTENDED_A</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-latin-extended-b">
-     <term><constant>IntlChar::BLOCK_CODE_LATIN_EXTENDED_B</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_LATIN_EXTENDED_B</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-ipa-extensions">
-     <term><constant>IntlChar::BLOCK_CODE_IPA_EXTENSIONS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_IPA_EXTENSIONS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-spacing-modifier-letters">
-     <term><constant>IntlChar::BLOCK_CODE_SPACING_MODIFIER_LETTERS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_SPACING_MODIFIER_LETTERS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-combining-diacritical-marks">
-     <term><constant>IntlChar::BLOCK_CODE_COMBINING_DIACRITICAL_MARKS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_COMBINING_DIACRITICAL_MARKS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-greek">
-     <term><constant>IntlChar::BLOCK_CODE_GREEK</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_GREEK</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-cyrillic">
-     <term><constant>IntlChar::BLOCK_CODE_CYRILLIC</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_CYRILLIC</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-armenian">
-     <term><constant>IntlChar::BLOCK_CODE_ARMENIAN</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_ARMENIAN</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-hebrew">
-     <term><constant>IntlChar::BLOCK_CODE_HEBREW</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_HEBREW</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-arabic">
-     <term><constant>IntlChar::BLOCK_CODE_ARABIC</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_ARABIC</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-syriac">
-     <term><constant>IntlChar::BLOCK_CODE_SYRIAC</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_SYRIAC</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-thaana">
-     <term><constant>IntlChar::BLOCK_CODE_THAANA</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_THAANA</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-devanagari">
-     <term><constant>IntlChar::BLOCK_CODE_DEVANAGARI</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_DEVANAGARI</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-bengali">
-     <term><constant>IntlChar::BLOCK_CODE_BENGALI</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_BENGALI</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-gurmukhi">
-     <term><constant>IntlChar::BLOCK_CODE_GURMUKHI</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_GURMUKHI</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-gujarati">
-     <term><constant>IntlChar::BLOCK_CODE_GUJARATI</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_GUJARATI</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-oriya">
-     <term><constant>IntlChar::BLOCK_CODE_ORIYA</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_ORIYA</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-tamil">
-     <term><constant>IntlChar::BLOCK_CODE_TAMIL</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_TAMIL</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-telugu">
-     <term><constant>IntlChar::BLOCK_CODE_TELUGU</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_TELUGU</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-kannada">
-     <term><constant>IntlChar::BLOCK_CODE_KANNADA</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_KANNADA</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-malayalam">
-     <term><constant>IntlChar::BLOCK_CODE_MALAYALAM</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_MALAYALAM</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-sinhala">
-     <term><constant>IntlChar::BLOCK_CODE_SINHALA</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_SINHALA</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-thai">
-     <term><constant>IntlChar::BLOCK_CODE_THAI</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_THAI</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-lao">
-     <term><constant>IntlChar::BLOCK_CODE_LAO</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_LAO</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-tibetan">
-     <term><constant>IntlChar::BLOCK_CODE_TIBETAN</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_TIBETAN</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-myanmar">
-     <term><constant>IntlChar::BLOCK_CODE_MYANMAR</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_MYANMAR</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-georgian">
-     <term><constant>IntlChar::BLOCK_CODE_GEORGIAN</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_GEORGIAN</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-hangul-jamo">
-     <term><constant>IntlChar::BLOCK_CODE_HANGUL_JAMO</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_HANGUL_JAMO</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-ethiopic">
-     <term><constant>IntlChar::BLOCK_CODE_ETHIOPIC</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_ETHIOPIC</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-cherokee">
-     <term><constant>IntlChar::BLOCK_CODE_CHEROKEE</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_CHEROKEE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-unified-canadian-aboriginal-syllabics">
-     <term><constant>IntlChar::BLOCK_CODE_UNIFIED_CANADIAN_ABORIGINAL_SYLLABICS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_UNIFIED_CANADIAN_ABORIGINAL_SYLLABICS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-ogham">
-     <term><constant>IntlChar::BLOCK_CODE_OGHAM</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_OGHAM</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-runic">
-     <term><constant>IntlChar::BLOCK_CODE_RUNIC</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_RUNIC</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-khmer">
-     <term><constant>IntlChar::BLOCK_CODE_KHMER</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_KHMER</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-mongolian">
-     <term><constant>IntlChar::BLOCK_CODE_MONGOLIAN</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_MONGOLIAN</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-latin-extended-additional">
-     <term><constant>IntlChar::BLOCK_CODE_LATIN_EXTENDED_ADDITIONAL</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_LATIN_EXTENDED_ADDITIONAL</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-greek-extended">
-     <term><constant>IntlChar::BLOCK_CODE_GREEK_EXTENDED</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_GREEK_EXTENDED</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-general-punctuation">
-     <term><constant>IntlChar::BLOCK_CODE_GENERAL_PUNCTUATION</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_GENERAL_PUNCTUATION</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-superscripts-and-subscripts">
-     <term><constant>IntlChar::BLOCK_CODE_SUPERSCRIPTS_AND_SUBSCRIPTS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_SUPERSCRIPTS_AND_SUBSCRIPTS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-currency-symbols">
-     <term><constant>IntlChar::BLOCK_CODE_CURRENCY_SYMBOLS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_CURRENCY_SYMBOLS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-combining-marks-for-symbols">
-     <term><constant>IntlChar::BLOCK_CODE_COMBINING_MARKS_FOR_SYMBOLS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_COMBINING_MARKS_FOR_SYMBOLS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-letterlike-symbols">
-     <term><constant>IntlChar::BLOCK_CODE_LETTERLIKE_SYMBOLS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_LETTERLIKE_SYMBOLS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-number-forms">
-     <term><constant>IntlChar::BLOCK_CODE_NUMBER_FORMS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_NUMBER_FORMS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-arrows">
-     <term><constant>IntlChar::BLOCK_CODE_ARROWS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_ARROWS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-mathematical-operators">
-     <term><constant>IntlChar::BLOCK_CODE_MATHEMATICAL_OPERATORS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_MATHEMATICAL_OPERATORS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-miscellaneous-technical">
-     <term><constant>IntlChar::BLOCK_CODE_MISCELLANEOUS_TECHNICAL</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_MISCELLANEOUS_TECHNICAL</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-control-pictures">
-     <term><constant>IntlChar::BLOCK_CODE_CONTROL_PICTURES</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_CONTROL_PICTURES</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-optical-character-recognition">
-     <term><constant>IntlChar::BLOCK_CODE_OPTICAL_CHARACTER_RECOGNITION</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_OPTICAL_CHARACTER_RECOGNITION</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-enclosed-alphanumerics">
-     <term><constant>IntlChar::BLOCK_CODE_ENCLOSED_ALPHANUMERICS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_ENCLOSED_ALPHANUMERICS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-box-drawing">
-     <term><constant>IntlChar::BLOCK_CODE_BOX_DRAWING</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_BOX_DRAWING</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-block-elements">
-     <term><constant>IntlChar::BLOCK_CODE_BLOCK_ELEMENTS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_BLOCK_ELEMENTS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-geometric-shapes">
-     <term><constant>IntlChar::BLOCK_CODE_GEOMETRIC_SHAPES</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_GEOMETRIC_SHAPES</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-miscellaneous-symbols">
-     <term><constant>IntlChar::BLOCK_CODE_MISCELLANEOUS_SYMBOLS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_MISCELLANEOUS_SYMBOLS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-dingbats">
-     <term><constant>IntlChar::BLOCK_CODE_DINGBATS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_DINGBATS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-braille-patterns">
-     <term><constant>IntlChar::BLOCK_CODE_BRAILLE_PATTERNS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_BRAILLE_PATTERNS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-cjk-radicals-supplement">
-     <term><constant>IntlChar::BLOCK_CODE_CJK_RADICALS_SUPPLEMENT</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_CJK_RADICALS_SUPPLEMENT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-kangxi-radicals">
-     <term><constant>IntlChar::BLOCK_CODE_KANGXI_RADICALS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_KANGXI_RADICALS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-ideographic-description-characters">
-     <term><constant>IntlChar::BLOCK_CODE_IDEOGRAPHIC_DESCRIPTION_CHARACTERS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_IDEOGRAPHIC_DESCRIPTION_CHARACTERS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-cjk-symbols-and-punctuation">
-     <term><constant>IntlChar::BLOCK_CODE_CJK_SYMBOLS_AND_PUNCTUATION</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_CJK_SYMBOLS_AND_PUNCTUATION</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-hiragana">
-     <term><constant>IntlChar::BLOCK_CODE_HIRAGANA</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_HIRAGANA</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-katakana">
-     <term><constant>IntlChar::BLOCK_CODE_KATAKANA</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_KATAKANA</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-bopomofo">
-     <term><constant>IntlChar::BLOCK_CODE_BOPOMOFO</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_BOPOMOFO</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-hangul-compatibility-jamo">
-     <term><constant>IntlChar::BLOCK_CODE_HANGUL_COMPATIBILITY_JAMO</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_HANGUL_COMPATIBILITY_JAMO</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-kanbun">
-     <term><constant>IntlChar::BLOCK_CODE_KANBUN</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_KANBUN</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-bopomofo-extended">
-     <term><constant>IntlChar::BLOCK_CODE_BOPOMOFO_EXTENDED</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_BOPOMOFO_EXTENDED</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-enclosed-cjk-letters-and-months">
-     <term><constant>IntlChar::BLOCK_CODE_ENCLOSED_CJK_LETTERS_AND_MONTHS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_ENCLOSED_CJK_LETTERS_AND_MONTHS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-cjk-compatibility">
-     <term><constant>IntlChar::BLOCK_CODE_CJK_COMPATIBILITY</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_CJK_COMPATIBILITY</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-cjk-unified-ideographs-extension-a">
-     <term><constant>IntlChar::BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_A</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_A</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-cjk-unified-ideographs">
-     <term><constant>IntlChar::BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-yi-syllables">
-     <term><constant>IntlChar::BLOCK_CODE_YI_SYLLABLES</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_YI_SYLLABLES</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-yi-radicals">
-     <term><constant>IntlChar::BLOCK_CODE_YI_RADICALS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_YI_RADICALS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-hangul-syllables">
-     <term><constant>IntlChar::BLOCK_CODE_HANGUL_SYLLABLES</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_HANGUL_SYLLABLES</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-high-surrogates">
-     <term><constant>IntlChar::BLOCK_CODE_HIGH_SURROGATES</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_HIGH_SURROGATES</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-high-private-use-surrogates">
-     <term><constant>IntlChar::BLOCK_CODE_HIGH_PRIVATE_USE_SURROGATES</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_HIGH_PRIVATE_USE_SURROGATES</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-low-surrogates">
-     <term><constant>IntlChar::BLOCK_CODE_LOW_SURROGATES</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_LOW_SURROGATES</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-private-use-area">
-     <term><constant>IntlChar::BLOCK_CODE_PRIVATE_USE_AREA</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_PRIVATE_USE_AREA</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-private-use">
-     <term><constant>IntlChar::BLOCK_CODE_PRIVATE_USE</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_PRIVATE_USE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-cjk-compatibility-ideographs">
-     <term><constant>IntlChar::BLOCK_CODE_CJK_COMPATIBILITY_IDEOGRAPHS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_CJK_COMPATIBILITY_IDEOGRAPHS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-alphabetic-presentation-forms">
-     <term><constant>IntlChar::BLOCK_CODE_ALPHABETIC_PRESENTATION_FORMS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_ALPHABETIC_PRESENTATION_FORMS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-arabic-presentation-forms-a">
-     <term><constant>IntlChar::BLOCK_CODE_ARABIC_PRESENTATION_FORMS_A</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_ARABIC_PRESENTATION_FORMS_A</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-combining-half-marks">
-     <term><constant>IntlChar::BLOCK_CODE_COMBINING_HALF_MARKS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_COMBINING_HALF_MARKS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-cjk-compatibility-forms">
-     <term><constant>IntlChar::BLOCK_CODE_CJK_COMPATIBILITY_FORMS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_CJK_COMPATIBILITY_FORMS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-small-form-variants">
-     <term><constant>IntlChar::BLOCK_CODE_SMALL_FORM_VARIANTS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_SMALL_FORM_VARIANTS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-arabic-presentation-forms-b">
-     <term><constant>IntlChar::BLOCK_CODE_ARABIC_PRESENTATION_FORMS_B</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_ARABIC_PRESENTATION_FORMS_B</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-specials">
-     <term><constant>IntlChar::BLOCK_CODE_SPECIALS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_SPECIALS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-halfwidth-and-fullwidth-forms">
-     <term><constant>IntlChar::BLOCK_CODE_HALFWIDTH_AND_FULLWIDTH_FORMS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_HALFWIDTH_AND_FULLWIDTH_FORMS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-old-italic">
-     <term><constant>IntlChar::BLOCK_CODE_OLD_ITALIC</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_OLD_ITALIC</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-gothic">
-     <term><constant>IntlChar::BLOCK_CODE_GOTHIC</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_GOTHIC</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-deseret">
-     <term><constant>IntlChar::BLOCK_CODE_DESERET</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_DESERET</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-byzantine-musical-symbols">
-     <term><constant>IntlChar::BLOCK_CODE_BYZANTINE_MUSICAL_SYMBOLS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_BYZANTINE_MUSICAL_SYMBOLS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-musical-symbols">
-     <term><constant>IntlChar::BLOCK_CODE_MUSICAL_SYMBOLS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_MUSICAL_SYMBOLS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-mathematical-alphanumeric-symbols">
-     <term><constant>IntlChar::BLOCK_CODE_MATHEMATICAL_ALPHANUMERIC_SYMBOLS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_MATHEMATICAL_ALPHANUMERIC_SYMBOLS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-cjk-unified-ideographs-extension-b">
-     <term><constant>IntlChar::BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_B</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_B</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-cjk-compatibility-ideographs-supplement">
-     <term><constant>IntlChar::BLOCK_CODE_CJK_COMPATIBILITY_IDEOGRAPHS_SUPPLEMENT</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_CJK_COMPATIBILITY_IDEOGRAPHS_SUPPLEMENT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-tags">
-     <term><constant>IntlChar::BLOCK_CODE_TAGS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_TAGS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-cyrillic-supplement">
-     <term><constant>IntlChar::BLOCK_CODE_CYRILLIC_SUPPLEMENT</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_CYRILLIC_SUPPLEMENT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-cyrillic-supplementary">
-     <term><constant>IntlChar::BLOCK_CODE_CYRILLIC_SUPPLEMENTARY</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_CYRILLIC_SUPPLEMENTARY</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-tagalog">
-     <term><constant>IntlChar::BLOCK_CODE_TAGALOG</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_TAGALOG</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-hanunoo">
-     <term><constant>IntlChar::BLOCK_CODE_HANUNOO</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_HANUNOO</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-buhid">
-     <term><constant>IntlChar::BLOCK_CODE_BUHID</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_BUHID</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-tagbanwa">
-     <term><constant>IntlChar::BLOCK_CODE_TAGBANWA</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_TAGBANWA</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-miscellaneous-mathematical-symbols-a">
-     <term><constant>IntlChar::BLOCK_CODE_MISCELLANEOUS_MATHEMATICAL_SYMBOLS_A</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_MISCELLANEOUS_MATHEMATICAL_SYMBOLS_A</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-supplemental-arrows-a">
-     <term><constant>IntlChar::BLOCK_CODE_SUPPLEMENTAL_ARROWS_A</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_SUPPLEMENTAL_ARROWS_A</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-supplemental-arrows-b">
-     <term><constant>IntlChar::BLOCK_CODE_SUPPLEMENTAL_ARROWS_B</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_SUPPLEMENTAL_ARROWS_B</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-miscellaneous-mathematical-symbols-b">
-     <term><constant>IntlChar::BLOCK_CODE_MISCELLANEOUS_MATHEMATICAL_SYMBOLS_B</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_MISCELLANEOUS_MATHEMATICAL_SYMBOLS_B</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-supplemental-mathematical-operators">
-     <term><constant>IntlChar::BLOCK_CODE_SUPPLEMENTAL_MATHEMATICAL_OPERATORS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_SUPPLEMENTAL_MATHEMATICAL_OPERATORS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-katakana-phonetic-extensions">
-     <term><constant>IntlChar::BLOCK_CODE_KATAKANA_PHONETIC_EXTENSIONS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_KATAKANA_PHONETIC_EXTENSIONS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-variation-selectors">
-     <term><constant>IntlChar::BLOCK_CODE_VARIATION_SELECTORS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_VARIATION_SELECTORS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-supplementary-private-use-area-a">
-     <term><constant>IntlChar::BLOCK_CODE_SUPPLEMENTARY_PRIVATE_USE_AREA_A</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_SUPPLEMENTARY_PRIVATE_USE_AREA_A</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-supplementary-private-use-area-b">
-     <term><constant>IntlChar::BLOCK_CODE_SUPPLEMENTARY_PRIVATE_USE_AREA_B</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_SUPPLEMENTARY_PRIVATE_USE_AREA_B</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-limbu">
-     <term><constant>IntlChar::BLOCK_CODE_LIMBU</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_LIMBU</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-tai-le">
-     <term><constant>IntlChar::BLOCK_CODE_TAI_LE</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_TAI_LE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-khmer-symbols">
-     <term><constant>IntlChar::BLOCK_CODE_KHMER_SYMBOLS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_KHMER_SYMBOLS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-phonetic-extensions">
-     <term><constant>IntlChar::BLOCK_CODE_PHONETIC_EXTENSIONS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_PHONETIC_EXTENSIONS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-miscellaneous-symbols-and-arrows">
-     <term><constant>IntlChar::BLOCK_CODE_MISCELLANEOUS_SYMBOLS_AND_ARROWS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_MISCELLANEOUS_SYMBOLS_AND_ARROWS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-yijing-hexagram-symbols">
-     <term><constant>IntlChar::BLOCK_CODE_YIJING_HEXAGRAM_SYMBOLS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_YIJING_HEXAGRAM_SYMBOLS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-linear-b-syllabary">
-     <term><constant>IntlChar::BLOCK_CODE_LINEAR_B_SYLLABARY</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_LINEAR_B_SYLLABARY</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-linear-b-ideograms">
-     <term><constant>IntlChar::BLOCK_CODE_LINEAR_B_IDEOGRAMS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_LINEAR_B_IDEOGRAMS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-aegean-numbers">
-     <term><constant>IntlChar::BLOCK_CODE_AEGEAN_NUMBERS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_AEGEAN_NUMBERS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-ugaritic">
-     <term><constant>IntlChar::BLOCK_CODE_UGARITIC</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_UGARITIC</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-shavian">
-     <term><constant>IntlChar::BLOCK_CODE_SHAVIAN</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_SHAVIAN</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-osmanya">
-     <term><constant>IntlChar::BLOCK_CODE_OSMANYA</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_OSMANYA</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-cypriot-syllabary">
-     <term><constant>IntlChar::BLOCK_CODE_CYPRIOT_SYLLABARY</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_CYPRIOT_SYLLABARY</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-tai-xuan-jing-symbols">
-     <term><constant>IntlChar::BLOCK_CODE_TAI_XUAN_JING_SYMBOLS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_TAI_XUAN_JING_SYMBOLS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-variation-selectors-supplement">
-     <term><constant>IntlChar::BLOCK_CODE_VARIATION_SELECTORS_SUPPLEMENT</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_VARIATION_SELECTORS_SUPPLEMENT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-ancient-greek-musical-notation">
-     <term><constant>IntlChar::BLOCK_CODE_ANCIENT_GREEK_MUSICAL_NOTATION</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_ANCIENT_GREEK_MUSICAL_NOTATION</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-ancient-greek-numbers">
-     <term><constant>IntlChar::BLOCK_CODE_ANCIENT_GREEK_NUMBERS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_ANCIENT_GREEK_NUMBERS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-arabic-supplement">
-     <term><constant>IntlChar::BLOCK_CODE_ARABIC_SUPPLEMENT</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_ARABIC_SUPPLEMENT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-buginese">
-     <term><constant>IntlChar::BLOCK_CODE_BUGINESE</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_BUGINESE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-cjk-strokes">
-     <term><constant>IntlChar::BLOCK_CODE_CJK_STROKES</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_CJK_STROKES</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-combining-diacritical-marks-supplement">
-     <term><constant>IntlChar::BLOCK_CODE_COMBINING_DIACRITICAL_MARKS_SUPPLEMENT</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_COMBINING_DIACRITICAL_MARKS_SUPPLEMENT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-coptic">
-     <term><constant>IntlChar::BLOCK_CODE_COPTIC</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_COPTIC</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-ethiopic-extended">
-     <term><constant>IntlChar::BLOCK_CODE_ETHIOPIC_EXTENDED</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_ETHIOPIC_EXTENDED</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-ethiopic-supplement">
-     <term><constant>IntlChar::BLOCK_CODE_ETHIOPIC_SUPPLEMENT</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_ETHIOPIC_SUPPLEMENT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-georgian-supplement">
-     <term><constant>IntlChar::BLOCK_CODE_GEORGIAN_SUPPLEMENT</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_GEORGIAN_SUPPLEMENT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-glagolitic">
-     <term><constant>IntlChar::BLOCK_CODE_GLAGOLITIC</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_GLAGOLITIC</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-kharoshthi">
-     <term><constant>IntlChar::BLOCK_CODE_KHAROSHTHI</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_KHAROSHTHI</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-modifier-tone-letters">
-     <term><constant>IntlChar::BLOCK_CODE_MODIFIER_TONE_LETTERS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_MODIFIER_TONE_LETTERS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-new-tai-lue">
-     <term><constant>IntlChar::BLOCK_CODE_NEW_TAI_LUE</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_NEW_TAI_LUE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-old-persian">
-     <term><constant>IntlChar::BLOCK_CODE_OLD_PERSIAN</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_OLD_PERSIAN</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-phonetic-extensions-supplement">
-     <term><constant>IntlChar::BLOCK_CODE_PHONETIC_EXTENSIONS_SUPPLEMENT</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_PHONETIC_EXTENSIONS_SUPPLEMENT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-supplemental-punctuation">
-     <term><constant>IntlChar::BLOCK_CODE_SUPPLEMENTAL_PUNCTUATION</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_SUPPLEMENTAL_PUNCTUATION</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-syloti-nagri">
-     <term><constant>IntlChar::BLOCK_CODE_SYLOTI_NAGRI</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_SYLOTI_NAGRI</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-tifinagh">
-     <term><constant>IntlChar::BLOCK_CODE_TIFINAGH</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_TIFINAGH</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-vertical-forms">
-     <term><constant>IntlChar::BLOCK_CODE_VERTICAL_FORMS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_VERTICAL_FORMS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-nko">
-     <term><constant>IntlChar::BLOCK_CODE_NKO</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_NKO</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-balinese">
-     <term><constant>IntlChar::BLOCK_CODE_BALINESE</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_BALINESE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-latin-extended-c">
-     <term><constant>IntlChar::BLOCK_CODE_LATIN_EXTENDED_C</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_LATIN_EXTENDED_C</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-latin-extended-d">
-     <term><constant>IntlChar::BLOCK_CODE_LATIN_EXTENDED_D</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_LATIN_EXTENDED_D</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-phags-pa">
-     <term><constant>IntlChar::BLOCK_CODE_PHAGS_PA</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_PHAGS_PA</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-phoenician">
-     <term><constant>IntlChar::BLOCK_CODE_PHOENICIAN</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_PHOENICIAN</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-cuneiform">
-     <term><constant>IntlChar::BLOCK_CODE_CUNEIFORM</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_CUNEIFORM</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-cuneiform-numbers-and-punctuation">
-     <term><constant>IntlChar::BLOCK_CODE_CUNEIFORM_NUMBERS_AND_PUNCTUATION</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_CUNEIFORM_NUMBERS_AND_PUNCTUATION</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-counting-rod-numerals">
-     <term><constant>IntlChar::BLOCK_CODE_COUNTING_ROD_NUMERALS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_COUNTING_ROD_NUMERALS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-sundanese">
-     <term><constant>IntlChar::BLOCK_CODE_SUNDANESE</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_SUNDANESE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-lepcha">
-     <term><constant>IntlChar::BLOCK_CODE_LEPCHA</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_LEPCHA</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-ol-chiki">
-     <term><constant>IntlChar::BLOCK_CODE_OL_CHIKI</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_OL_CHIKI</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-cyrillic-extended-a">
-     <term><constant>IntlChar::BLOCK_CODE_CYRILLIC_EXTENDED_A</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_CYRILLIC_EXTENDED_A</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-vai">
-     <term><constant>IntlChar::BLOCK_CODE_VAI</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_VAI</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-cyrillic-extended-b">
-     <term><constant>IntlChar::BLOCK_CODE_CYRILLIC_EXTENDED_B</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_CYRILLIC_EXTENDED_B</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-saurashtra">
-     <term><constant>IntlChar::BLOCK_CODE_SAURASHTRA</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_SAURASHTRA</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-kayah-li">
-     <term><constant>IntlChar::BLOCK_CODE_KAYAH_LI</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_KAYAH_LI</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-rejang">
-     <term><constant>IntlChar::BLOCK_CODE_REJANG</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_REJANG</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-cham">
-     <term><constant>IntlChar::BLOCK_CODE_CHAM</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_CHAM</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-ancient-symbols">
-     <term><constant>IntlChar::BLOCK_CODE_ANCIENT_SYMBOLS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_ANCIENT_SYMBOLS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-phaistos-disc">
-     <term><constant>IntlChar::BLOCK_CODE_PHAISTOS_DISC</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_PHAISTOS_DISC</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-lycian">
-     <term><constant>IntlChar::BLOCK_CODE_LYCIAN</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_LYCIAN</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-carian">
-     <term><constant>IntlChar::BLOCK_CODE_CARIAN</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_CARIAN</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-lydian">
-     <term><constant>IntlChar::BLOCK_CODE_LYDIAN</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_LYDIAN</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-mahjong-tiles">
-     <term><constant>IntlChar::BLOCK_CODE_MAHJONG_TILES</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_MAHJONG_TILES</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-domino-tiles">
-     <term><constant>IntlChar::BLOCK_CODE_DOMINO_TILES</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_DOMINO_TILES</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-samaritan">
-     <term><constant>IntlChar::BLOCK_CODE_SAMARITAN</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_SAMARITAN</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-unified-canadian-aboriginal-syllabics-extended">
-     <term><constant>IntlChar::BLOCK_CODE_UNIFIED_CANADIAN_ABORIGINAL_SYLLABICS_EXTENDED</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_UNIFIED_CANADIAN_ABORIGINAL_SYLLABICS_EXTENDED</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-tai-tham">
-     <term><constant>IntlChar::BLOCK_CODE_TAI_THAM</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_TAI_THAM</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-vedic-extensions">
-     <term><constant>IntlChar::BLOCK_CODE_VEDIC_EXTENSIONS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_VEDIC_EXTENSIONS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-lisu">
-     <term><constant>IntlChar::BLOCK_CODE_LISU</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_LISU</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-bamum">
-     <term><constant>IntlChar::BLOCK_CODE_BAMUM</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_BAMUM</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-common-indic-number-forms">
-     <term><constant>IntlChar::BLOCK_CODE_COMMON_INDIC_NUMBER_FORMS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_COMMON_INDIC_NUMBER_FORMS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-devanagari-extended">
-     <term><constant>IntlChar::BLOCK_CODE_DEVANAGARI_EXTENDED</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_DEVANAGARI_EXTENDED</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-hangul-jamo-extended-a">
-     <term><constant>IntlChar::BLOCK_CODE_HANGUL_JAMO_EXTENDED_A</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_HANGUL_JAMO_EXTENDED_A</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-javanese">
-     <term><constant>IntlChar::BLOCK_CODE_JAVANESE</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_JAVANESE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-myanmar-extended-a">
-     <term><constant>IntlChar::BLOCK_CODE_MYANMAR_EXTENDED_A</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_MYANMAR_EXTENDED_A</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-tai-viet">
-     <term><constant>IntlChar::BLOCK_CODE_TAI_VIET</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_TAI_VIET</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-meetei-mayek">
-     <term><constant>IntlChar::BLOCK_CODE_MEETEI_MAYEK</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_MEETEI_MAYEK</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-hangul-jamo-extended-b">
-     <term><constant>IntlChar::BLOCK_CODE_HANGUL_JAMO_EXTENDED_B</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_HANGUL_JAMO_EXTENDED_B</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-imperial-aramaic">
-     <term><constant>IntlChar::BLOCK_CODE_IMPERIAL_ARAMAIC</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_IMPERIAL_ARAMAIC</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-old-south-arabian">
-     <term><constant>IntlChar::BLOCK_CODE_OLD_SOUTH_ARABIAN</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_OLD_SOUTH_ARABIAN</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-avestan">
-     <term><constant>IntlChar::BLOCK_CODE_AVESTAN</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_AVESTAN</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-inscriptional-parthian">
-     <term><constant>IntlChar::BLOCK_CODE_INSCRIPTIONAL_PARTHIAN</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_INSCRIPTIONAL_PARTHIAN</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-inscriptional-pahlavi">
-     <term><constant>IntlChar::BLOCK_CODE_INSCRIPTIONAL_PAHLAVI</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_INSCRIPTIONAL_PAHLAVI</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-old-turkic">
-     <term><constant>IntlChar::BLOCK_CODE_OLD_TURKIC</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_OLD_TURKIC</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-rumi-numeral-symbols">
-     <term><constant>IntlChar::BLOCK_CODE_RUMI_NUMERAL_SYMBOLS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_RUMI_NUMERAL_SYMBOLS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-kaithi">
-     <term><constant>IntlChar::BLOCK_CODE_KAITHI</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_KAITHI</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-egyptian-hieroglyphs">
-     <term><constant>IntlChar::BLOCK_CODE_EGYPTIAN_HIEROGLYPHS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_EGYPTIAN_HIEROGLYPHS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-enclosed-alphanumeric-supplement">
-     <term><constant>IntlChar::BLOCK_CODE_ENCLOSED_ALPHANUMERIC_SUPPLEMENT</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_ENCLOSED_ALPHANUMERIC_SUPPLEMENT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-enclosed-ideographic-supplement">
-     <term><constant>IntlChar::BLOCK_CODE_ENCLOSED_IDEOGRAPHIC_SUPPLEMENT</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_ENCLOSED_IDEOGRAPHIC_SUPPLEMENT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-cjk-unified-ideographs-extension-c">
-     <term><constant>IntlChar::BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_C</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_C</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-mandaic">
-     <term><constant>IntlChar::BLOCK_CODE_MANDAIC</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_MANDAIC</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-batak">
-     <term><constant>IntlChar::BLOCK_CODE_BATAK</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_BATAK</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-ethiopic-extended-a">
-     <term><constant>IntlChar::BLOCK_CODE_ETHIOPIC_EXTENDED_A</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_ETHIOPIC_EXTENDED_A</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-brahmi">
-     <term><constant>IntlChar::BLOCK_CODE_BRAHMI</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_BRAHMI</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-bamum-supplement">
-     <term><constant>IntlChar::BLOCK_CODE_BAMUM_SUPPLEMENT</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_BAMUM_SUPPLEMENT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-kana-supplement">
-     <term><constant>IntlChar::BLOCK_CODE_KANA_SUPPLEMENT</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_KANA_SUPPLEMENT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-playing-cards">
-     <term><constant>IntlChar::BLOCK_CODE_PLAYING_CARDS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_PLAYING_CARDS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-miscellaneous-symbols-and-pictographs">
-     <term><constant>IntlChar::BLOCK_CODE_MISCELLANEOUS_SYMBOLS_AND_PICTOGRAPHS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_MISCELLANEOUS_SYMBOLS_AND_PICTOGRAPHS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-emoticons">
-     <term><constant>IntlChar::BLOCK_CODE_EMOTICONS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_EMOTICONS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-transport-and-map-symbols">
-     <term><constant>IntlChar::BLOCK_CODE_TRANSPORT_AND_MAP_SYMBOLS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_TRANSPORT_AND_MAP_SYMBOLS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-alchemical-symbols">
-     <term><constant>IntlChar::BLOCK_CODE_ALCHEMICAL_SYMBOLS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_ALCHEMICAL_SYMBOLS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-cjk-unified-ideographs-extension-d">
-     <term><constant>IntlChar::BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_D</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_D</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-arabic-extended-a">
-     <term><constant>IntlChar::BLOCK_CODE_ARABIC_EXTENDED_A</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_ARABIC_EXTENDED_A</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-arabic-mathematical-alphabetic-symbols">
-     <term><constant>IntlChar::BLOCK_CODE_ARABIC_MATHEMATICAL_ALPHABETIC_SYMBOLS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_ARABIC_MATHEMATICAL_ALPHABETIC_SYMBOLS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-chakma">
-     <term><constant>IntlChar::BLOCK_CODE_CHAKMA</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_CHAKMA</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-meetei-mayek-extensions">
-     <term><constant>IntlChar::BLOCK_CODE_MEETEI_MAYEK_EXTENSIONS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_MEETEI_MAYEK_EXTENSIONS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-meroitic-cursive">
-     <term><constant>IntlChar::BLOCK_CODE_MEROITIC_CURSIVE</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_MEROITIC_CURSIVE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-meroitic-hieroglyphs">
-     <term><constant>IntlChar::BLOCK_CODE_MEROITIC_HIEROGLYPHS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_MEROITIC_HIEROGLYPHS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-miao">
-     <term><constant>IntlChar::BLOCK_CODE_MIAO</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_MIAO</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-sharada">
-     <term><constant>IntlChar::BLOCK_CODE_SHARADA</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_SHARADA</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-sora-sompeng">
-     <term><constant>IntlChar::BLOCK_CODE_SORA_SOMPENG</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_SORA_SOMPENG</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-sundanese-supplement">
-     <term><constant>IntlChar::BLOCK_CODE_SUNDANESE_SUPPLEMENT</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_SUNDANESE_SUPPLEMENT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-takri">
-     <term><constant>IntlChar::BLOCK_CODE_TAKRI</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_TAKRI</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-bassa-vah">
-     <term><constant>IntlChar::BLOCK_CODE_BASSA_VAH</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_BASSA_VAH</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-caucasian-albanian">
-     <term><constant>IntlChar::BLOCK_CODE_CAUCASIAN_ALBANIAN</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_CAUCASIAN_ALBANIAN</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-coptic-epact-numbers">
-     <term><constant>IntlChar::BLOCK_CODE_COPTIC_EPACT_NUMBERS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_COPTIC_EPACT_NUMBERS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-combining-diacritical-marks-extended">
-     <term><constant>IntlChar::BLOCK_CODE_COMBINING_DIACRITICAL_MARKS_EXTENDED</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_COMBINING_DIACRITICAL_MARKS_EXTENDED</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-duployan">
-     <term><constant>IntlChar::BLOCK_CODE_DUPLOYAN</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_DUPLOYAN</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-elbasan">
-     <term><constant>IntlChar::BLOCK_CODE_ELBASAN</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_ELBASAN</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-geometric-shapes-extended">
-     <term><constant>IntlChar::BLOCK_CODE_GEOMETRIC_SHAPES_EXTENDED</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_GEOMETRIC_SHAPES_EXTENDED</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-grantha">
-     <term><constant>IntlChar::BLOCK_CODE_GRANTHA</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_GRANTHA</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-khojki">
-     <term><constant>IntlChar::BLOCK_CODE_KHOJKI</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_KHOJKI</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-khudawadi">
-     <term><constant>IntlChar::BLOCK_CODE_KHUDAWADI</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_KHUDAWADI</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-latin-extended-e">
-     <term><constant>IntlChar::BLOCK_CODE_LATIN_EXTENDED_E</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_LATIN_EXTENDED_E</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-linear-a">
-     <term><constant>IntlChar::BLOCK_CODE_LINEAR_A</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_LINEAR_A</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-mahajani">
-     <term><constant>IntlChar::BLOCK_CODE_MAHAJANI</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_MAHAJANI</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-manichaean">
-     <term><constant>IntlChar::BLOCK_CODE_MANICHAEAN</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_MANICHAEAN</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-mende-kikakui">
-     <term><constant>IntlChar::BLOCK_CODE_MENDE_KIKAKUI</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_MENDE_KIKAKUI</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-modi">
-     <term><constant>IntlChar::BLOCK_CODE_MODI</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_MODI</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-mro">
-     <term><constant>IntlChar::BLOCK_CODE_MRO</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_MRO</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-myanmar-extended-b">
-     <term><constant>IntlChar::BLOCK_CODE_MYANMAR_EXTENDED_B</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_MYANMAR_EXTENDED_B</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-nabataean">
-     <term><constant>IntlChar::BLOCK_CODE_NABATAEAN</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_NABATAEAN</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-old-north-arabian">
-     <term><constant>IntlChar::BLOCK_CODE_OLD_NORTH_ARABIAN</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_OLD_NORTH_ARABIAN</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-old-permic">
-     <term><constant>IntlChar::BLOCK_CODE_OLD_PERMIC</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_OLD_PERMIC</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-ornamental-dingbats">
-     <term><constant>IntlChar::BLOCK_CODE_ORNAMENTAL_DINGBATS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_ORNAMENTAL_DINGBATS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-pahawh-hmong">
-     <term><constant>IntlChar::BLOCK_CODE_PAHAWH_HMONG</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_PAHAWH_HMONG</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-palmyrene">
-     <term><constant>IntlChar::BLOCK_CODE_PALMYRENE</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_PALMYRENE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-pau-cin-hau">
-     <term><constant>IntlChar::BLOCK_CODE_PAU_CIN_HAU</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_PAU_CIN_HAU</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-psalter-pahlavi">
-     <term><constant>IntlChar::BLOCK_CODE_PSALTER_PAHLAVI</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_PSALTER_PAHLAVI</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-shorthand-format-controls">
-     <term><constant>IntlChar::BLOCK_CODE_SHORTHAND_FORMAT_CONTROLS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_SHORTHAND_FORMAT_CONTROLS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-siddham">
-     <term><constant>IntlChar::BLOCK_CODE_SIDDHAM</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_SIDDHAM</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-sinhala-archaic-numbers">
-     <term><constant>IntlChar::BLOCK_CODE_SINHALA_ARCHAIC_NUMBERS</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_SINHALA_ARCHAIC_NUMBERS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-supplemental-arrows-c">
-     <term><constant>IntlChar::BLOCK_CODE_SUPPLEMENTAL_ARROWS_C</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_SUPPLEMENTAL_ARROWS_C</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-tirhuta">
-     <term><constant>IntlChar::BLOCK_CODE_TIRHUTA</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_TIRHUTA</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-warang-citi">
-     <term><constant>IntlChar::BLOCK_CODE_WARANG_CITI</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_WARANG_CITI</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-count">
-     <term><constant>IntlChar::BLOCK_CODE_COUNT</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_COUNT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.block-code-invalid-code">
-     <term><constant>IntlChar::BLOCK_CODE_INVALID_CODE</constant></term>
+     <term>
+      <constant>IntlChar::BLOCK_CODE_INVALID_CODE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.bpt-none">
-     <term><constant>IntlChar::BPT_NONE</constant></term>
+     <term>
+      <constant>IntlChar::BPT_NONE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.bpt-open">
-     <term><constant>IntlChar::BPT_OPEN</constant></term>
+     <term>
+      <constant>IntlChar::BPT_OPEN</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.bpt-close">
-     <term><constant>IntlChar::BPT_CLOSE</constant></term>
+     <term>
+      <constant>IntlChar::BPT_CLOSE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.bpt-count">
-     <term><constant>IntlChar::BPT_COUNT</constant></term>
+     <term>
+      <constant>IntlChar::BPT_COUNT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.ea-neutral">
-     <term><constant>IntlChar::EA_NEUTRAL</constant></term>
+     <term>
+      <constant>IntlChar::EA_NEUTRAL</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.ea-ambiguous">
-     <term><constant>IntlChar::EA_AMBIGUOUS</constant></term>
+     <term>
+      <constant>IntlChar::EA_AMBIGUOUS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.ea-halfwidth">
-     <term><constant>IntlChar::EA_HALFWIDTH</constant></term>
+     <term>
+      <constant>IntlChar::EA_HALFWIDTH</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.ea-fullwidth">
-     <term><constant>IntlChar::EA_FULLWIDTH</constant></term>
+     <term>
+      <constant>IntlChar::EA_FULLWIDTH</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.ea-narrow">
-     <term><constant>IntlChar::EA_NARROW</constant></term>
+     <term>
+      <constant>IntlChar::EA_NARROW</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.ea-wide">
-     <term><constant>IntlChar::EA_WIDE</constant></term>
+     <term>
+      <constant>IntlChar::EA_WIDE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.ea-count">
-     <term><constant>IntlChar::EA_COUNT</constant></term>
+     <term>
+      <constant>IntlChar::EA_COUNT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.unicode-char-name">
-     <term><constant>IntlChar::UNICODE_CHAR_NAME</constant></term>
+     <term>
+      <constant>IntlChar::UNICODE_CHAR_NAME</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.unicode-10-char-name">
-     <term><constant>IntlChar::UNICODE_10_CHAR_NAME</constant></term>
+     <term>
+      <constant>IntlChar::UNICODE_10_CHAR_NAME</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.extended-char-name">
-     <term><constant>IntlChar::EXTENDED_CHAR_NAME</constant></term>
+     <term>
+      <constant>IntlChar::EXTENDED_CHAR_NAME</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-name-alias">
-     <term><constant>IntlChar::CHAR_NAME_ALIAS</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_NAME_ALIAS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.char-name-choice-count">
-     <term><constant>IntlChar::CHAR_NAME_CHOICE_COUNT</constant></term>
+     <term>
+      <constant>IntlChar::CHAR_NAME_CHOICE_COUNT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.short-property-name">
-     <term><constant>IntlChar::SHORT_PROPERTY_NAME</constant></term>
+     <term>
+      <constant>IntlChar::SHORT_PROPERTY_NAME</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.long-property-name">
-     <term><constant>IntlChar::LONG_PROPERTY_NAME</constant></term>
+     <term>
+      <constant>IntlChar::LONG_PROPERTY_NAME</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.property-name-choice-count">
-     <term><constant>IntlChar::PROPERTY_NAME_CHOICE_COUNT</constant></term>
+     <term>
+      <constant>IntlChar::PROPERTY_NAME_CHOICE_COUNT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.dt-none">
-     <term><constant>IntlChar::DT_NONE</constant></term>
+     <term>
+      <constant>IntlChar::DT_NONE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.dt-canonical">
-     <term><constant>IntlChar::DT_CANONICAL</constant></term>
+     <term>
+      <constant>IntlChar::DT_CANONICAL</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.dt-compat">
-     <term><constant>IntlChar::DT_COMPAT</constant></term>
+     <term>
+      <constant>IntlChar::DT_COMPAT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.dt-circle">
-     <term><constant>IntlChar::DT_CIRCLE</constant></term>
+     <term>
+      <constant>IntlChar::DT_CIRCLE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.dt-final">
-     <term><constant>IntlChar::DT_FINAL</constant></term>
+     <term>
+      <constant>IntlChar::DT_FINAL</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.dt-font">
-     <term><constant>IntlChar::DT_FONT</constant></term>
+     <term>
+      <constant>IntlChar::DT_FONT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.dt-fraction">
-     <term><constant>IntlChar::DT_FRACTION</constant></term>
+     <term>
+      <constant>IntlChar::DT_FRACTION</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.dt-initial">
-     <term><constant>IntlChar::DT_INITIAL</constant></term>
+     <term>
+      <constant>IntlChar::DT_INITIAL</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.dt-isolated">
-     <term><constant>IntlChar::DT_ISOLATED</constant></term>
+     <term>
+      <constant>IntlChar::DT_ISOLATED</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.dt-medial">
-     <term><constant>IntlChar::DT_MEDIAL</constant></term>
+     <term>
+      <constant>IntlChar::DT_MEDIAL</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.dt-narrow">
-     <term><constant>IntlChar::DT_NARROW</constant></term>
+     <term>
+      <constant>IntlChar::DT_NARROW</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.dt-nobreak">
-     <term><constant>IntlChar::DT_NOBREAK</constant></term>
+     <term>
+      <constant>IntlChar::DT_NOBREAK</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.dt-small">
-     <term><constant>IntlChar::DT_SMALL</constant></term>
+     <term>
+      <constant>IntlChar::DT_SMALL</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.dt-square">
-     <term><constant>IntlChar::DT_SQUARE</constant></term>
+     <term>
+      <constant>IntlChar::DT_SQUARE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.dt-sub">
-     <term><constant>IntlChar::DT_SUB</constant></term>
+     <term>
+      <constant>IntlChar::DT_SUB</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.dt-super">
-     <term><constant>IntlChar::DT_SUPER</constant></term>
+     <term>
+      <constant>IntlChar::DT_SUPER</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.dt-vertical">
-     <term><constant>IntlChar::DT_VERTICAL</constant></term>
+     <term>
+      <constant>IntlChar::DT_VERTICAL</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.dt-wide">
-     <term><constant>IntlChar::DT_WIDE</constant></term>
+     <term>
+      <constant>IntlChar::DT_WIDE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.dt-count">
-     <term><constant>IntlChar::DT_COUNT</constant></term>
+     <term>
+      <constant>IntlChar::DT_COUNT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jt-non-joining">
-     <term><constant>IntlChar::JT_NON_JOINING</constant></term>
+     <term>
+      <constant>IntlChar::JT_NON_JOINING</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jt-join-causing">
-     <term><constant>IntlChar::JT_JOIN_CAUSING</constant></term>
+     <term>
+      <constant>IntlChar::JT_JOIN_CAUSING</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jt-dual-joining">
-     <term><constant>IntlChar::JT_DUAL_JOINING</constant></term>
+     <term>
+      <constant>IntlChar::JT_DUAL_JOINING</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jt-left-joining">
-     <term><constant>IntlChar::JT_LEFT_JOINING</constant></term>
+     <term>
+      <constant>IntlChar::JT_LEFT_JOINING</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jt-right-joining">
-     <term><constant>IntlChar::JT_RIGHT_JOINING</constant></term>
+     <term>
+      <constant>IntlChar::JT_RIGHT_JOINING</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jt-transparent">
-     <term><constant>IntlChar::JT_TRANSPARENT</constant></term>
+     <term>
+      <constant>IntlChar::JT_TRANSPARENT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jt-count">
-     <term><constant>IntlChar::JT_COUNT</constant></term>
+     <term>
+      <constant>IntlChar::JT_COUNT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-no-joining-group">
-     <term><constant>IntlChar::JG_NO_JOINING_GROUP</constant></term>
+     <term>
+      <constant>IntlChar::JG_NO_JOINING_GROUP</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-ain">
-     <term><constant>IntlChar::JG_AIN</constant></term>
+     <term>
+      <constant>IntlChar::JG_AIN</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-alaph">
-     <term><constant>IntlChar::JG_ALAPH</constant></term>
+     <term>
+      <constant>IntlChar::JG_ALAPH</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-alef">
-     <term><constant>IntlChar::JG_ALEF</constant></term>
+     <term>
+      <constant>IntlChar::JG_ALEF</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-beh">
-     <term><constant>IntlChar::JG_BEH</constant></term>
+     <term>
+      <constant>IntlChar::JG_BEH</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-beth">
-     <term><constant>IntlChar::JG_BETH</constant></term>
+     <term>
+      <constant>IntlChar::JG_BETH</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-dal">
-     <term><constant>IntlChar::JG_DAL</constant></term>
+     <term>
+      <constant>IntlChar::JG_DAL</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-dalath-rish">
-     <term><constant>IntlChar::JG_DALATH_RISH</constant></term>
+     <term>
+      <constant>IntlChar::JG_DALATH_RISH</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-e">
-     <term><constant>IntlChar::JG_E</constant></term>
+     <term>
+      <constant>IntlChar::JG_E</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-feh">
-     <term><constant>IntlChar::JG_FEH</constant></term>
+     <term>
+      <constant>IntlChar::JG_FEH</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-final-semkath">
-     <term><constant>IntlChar::JG_FINAL_SEMKATH</constant></term>
+     <term>
+      <constant>IntlChar::JG_FINAL_SEMKATH</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-gaf">
-     <term><constant>IntlChar::JG_GAF</constant></term>
+     <term>
+      <constant>IntlChar::JG_GAF</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-gamal">
-     <term><constant>IntlChar::JG_GAMAL</constant></term>
+     <term>
+      <constant>IntlChar::JG_GAMAL</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-hah">
-     <term><constant>IntlChar::JG_HAH</constant></term>
+     <term>
+      <constant>IntlChar::JG_HAH</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-teh-marbuta-goal">
-     <term><constant>IntlChar::JG_TEH_MARBUTA_GOAL</constant></term>
+     <term>
+      <constant>IntlChar::JG_TEH_MARBUTA_GOAL</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-hamza-on-heh-goal">
-     <term><constant>IntlChar::JG_HAMZA_ON_HEH_GOAL</constant></term>
+     <term>
+      <constant>IntlChar::JG_HAMZA_ON_HEH_GOAL</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-he">
-     <term><constant>IntlChar::JG_HE</constant></term>
+     <term>
+      <constant>IntlChar::JG_HE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-heh">
-     <term><constant>IntlChar::JG_HEH</constant></term>
+     <term>
+      <constant>IntlChar::JG_HEH</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-heh-goal">
-     <term><constant>IntlChar::JG_HEH_GOAL</constant></term>
+     <term>
+      <constant>IntlChar::JG_HEH_GOAL</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-heth">
-     <term><constant>IntlChar::JG_HETH</constant></term>
+     <term>
+      <constant>IntlChar::JG_HETH</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-kaf">
-     <term><constant>IntlChar::JG_KAF</constant></term>
+     <term>
+      <constant>IntlChar::JG_KAF</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-kaph">
-     <term><constant>IntlChar::JG_KAPH</constant></term>
+     <term>
+      <constant>IntlChar::JG_KAPH</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-knotted-heh">
-     <term><constant>IntlChar::JG_KNOTTED_HEH</constant></term>
+     <term>
+      <constant>IntlChar::JG_KNOTTED_HEH</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-lam">
-     <term><constant>IntlChar::JG_LAM</constant></term>
+     <term>
+      <constant>IntlChar::JG_LAM</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-lamadh">
-     <term><constant>IntlChar::JG_LAMADH</constant></term>
+     <term>
+      <constant>IntlChar::JG_LAMADH</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-meem">
-     <term><constant>IntlChar::JG_MEEM</constant></term>
+     <term>
+      <constant>IntlChar::JG_MEEM</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-mim">
-     <term><constant>IntlChar::JG_MIM</constant></term>
+     <term>
+      <constant>IntlChar::JG_MIM</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-noon">
-     <term><constant>IntlChar::JG_NOON</constant></term>
+     <term>
+      <constant>IntlChar::JG_NOON</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-nun">
-     <term><constant>IntlChar::JG_NUN</constant></term>
+     <term>
+      <constant>IntlChar::JG_NUN</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-pe">
-     <term><constant>IntlChar::JG_PE</constant></term>
+     <term>
+      <constant>IntlChar::JG_PE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-qaf">
-     <term><constant>IntlChar::JG_QAF</constant></term>
+     <term>
+      <constant>IntlChar::JG_QAF</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-qaph">
-     <term><constant>IntlChar::JG_QAPH</constant></term>
+     <term>
+      <constant>IntlChar::JG_QAPH</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-reh">
-     <term><constant>IntlChar::JG_REH</constant></term>
+     <term>
+      <constant>IntlChar::JG_REH</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-reversed-pe">
-     <term><constant>IntlChar::JG_REVERSED_PE</constant></term>
+     <term>
+      <constant>IntlChar::JG_REVERSED_PE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-sad">
-     <term><constant>IntlChar::JG_SAD</constant></term>
+     <term>
+      <constant>IntlChar::JG_SAD</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-sadhe">
-     <term><constant>IntlChar::JG_SADHE</constant></term>
+     <term>
+      <constant>IntlChar::JG_SADHE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-seen">
-     <term><constant>IntlChar::JG_SEEN</constant></term>
+     <term>
+      <constant>IntlChar::JG_SEEN</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-semkath">
-     <term><constant>IntlChar::JG_SEMKATH</constant></term>
+     <term>
+      <constant>IntlChar::JG_SEMKATH</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-shin">
-     <term><constant>IntlChar::JG_SHIN</constant></term>
+     <term>
+      <constant>IntlChar::JG_SHIN</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-swash-kaf">
-     <term><constant>IntlChar::JG_SWASH_KAF</constant></term>
+     <term>
+      <constant>IntlChar::JG_SWASH_KAF</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-syriac-waw">
-     <term><constant>IntlChar::JG_SYRIAC_WAW</constant></term>
+     <term>
+      <constant>IntlChar::JG_SYRIAC_WAW</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-tah">
-     <term><constant>IntlChar::JG_TAH</constant></term>
+     <term>
+      <constant>IntlChar::JG_TAH</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-taw">
-     <term><constant>IntlChar::JG_TAW</constant></term>
+     <term>
+      <constant>IntlChar::JG_TAW</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-teh-marbuta">
-     <term><constant>IntlChar::JG_TEH_MARBUTA</constant></term>
+     <term>
+      <constant>IntlChar::JG_TEH_MARBUTA</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-teth">
-     <term><constant>IntlChar::JG_TETH</constant></term>
+     <term>
+      <constant>IntlChar::JG_TETH</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-waw">
-     <term><constant>IntlChar::JG_WAW</constant></term>
+     <term>
+      <constant>IntlChar::JG_WAW</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-yeh">
-     <term><constant>IntlChar::JG_YEH</constant></term>
+     <term>
+      <constant>IntlChar::JG_YEH</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-yeh-barree">
-     <term><constant>IntlChar::JG_YEH_BARREE</constant></term>
+     <term>
+      <constant>IntlChar::JG_YEH_BARREE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-yeh-with-tail">
-     <term><constant>IntlChar::JG_YEH_WITH_TAIL</constant></term>
+     <term>
+      <constant>IntlChar::JG_YEH_WITH_TAIL</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-yudh">
-     <term><constant>IntlChar::JG_YUDH</constant></term>
+     <term>
+      <constant>IntlChar::JG_YUDH</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-yudh-he">
-     <term><constant>IntlChar::JG_YUDH_HE</constant></term>
+     <term>
+      <constant>IntlChar::JG_YUDH_HE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-zain">
-     <term><constant>IntlChar::JG_ZAIN</constant></term>
+     <term>
+      <constant>IntlChar::JG_ZAIN</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-fe">
-     <term><constant>IntlChar::JG_FE</constant></term>
+     <term>
+      <constant>IntlChar::JG_FE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-khaph">
-     <term><constant>IntlChar::JG_KHAPH</constant></term>
+     <term>
+      <constant>IntlChar::JG_KHAPH</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-zhain">
-     <term><constant>IntlChar::JG_ZHAIN</constant></term>
+     <term>
+      <constant>IntlChar::JG_ZHAIN</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-burushaski-yeh-barree">
-     <term><constant>IntlChar::JG_BURUSHASKI_YEH_BARREE</constant></term>
+     <term>
+      <constant>IntlChar::JG_BURUSHASKI_YEH_BARREE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-farsi-yeh">
-     <term><constant>IntlChar::JG_FARSI_YEH</constant></term>
+     <term>
+      <constant>IntlChar::JG_FARSI_YEH</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-nya">
-     <term><constant>IntlChar::JG_NYA</constant></term>
+     <term>
+      <constant>IntlChar::JG_NYA</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-rohingya-yeh">
-     <term><constant>IntlChar::JG_ROHINGYA_YEH</constant></term>
+     <term>
+      <constant>IntlChar::JG_ROHINGYA_YEH</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-manichaean-aleph">
-     <term><constant>IntlChar::JG_MANICHAEAN_ALEPH</constant></term>
+     <term>
+      <constant>IntlChar::JG_MANICHAEAN_ALEPH</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-manichaean-ayin">
-     <term><constant>IntlChar::JG_MANICHAEAN_AYIN</constant></term>
+     <term>
+      <constant>IntlChar::JG_MANICHAEAN_AYIN</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-manichaean-beth">
-     <term><constant>IntlChar::JG_MANICHAEAN_BETH</constant></term>
+     <term>
+      <constant>IntlChar::JG_MANICHAEAN_BETH</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-manichaean-daleth">
-     <term><constant>IntlChar::JG_MANICHAEAN_DALETH</constant></term>
+     <term>
+      <constant>IntlChar::JG_MANICHAEAN_DALETH</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-manichaean-dhamedh">
-     <term><constant>IntlChar::JG_MANICHAEAN_DHAMEDH</constant></term>
+     <term>
+      <constant>IntlChar::JG_MANICHAEAN_DHAMEDH</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-manichaean-five">
-     <term><constant>IntlChar::JG_MANICHAEAN_FIVE</constant></term>
+     <term>
+      <constant>IntlChar::JG_MANICHAEAN_FIVE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-manichaean-gimel">
-     <term><constant>IntlChar::JG_MANICHAEAN_GIMEL</constant></term>
+     <term>
+      <constant>IntlChar::JG_MANICHAEAN_GIMEL</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-manichaean-heth">
-     <term><constant>IntlChar::JG_MANICHAEAN_HETH</constant></term>
+     <term>
+      <constant>IntlChar::JG_MANICHAEAN_HETH</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-manichaean-hundred">
-     <term><constant>IntlChar::JG_MANICHAEAN_HUNDRED</constant></term>
+     <term>
+      <constant>IntlChar::JG_MANICHAEAN_HUNDRED</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-manichaean-kaph">
-     <term><constant>IntlChar::JG_MANICHAEAN_KAPH</constant></term>
+     <term>
+      <constant>IntlChar::JG_MANICHAEAN_KAPH</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-manichaean-lamedh">
-     <term><constant>IntlChar::JG_MANICHAEAN_LAMEDH</constant></term>
+     <term>
+      <constant>IntlChar::JG_MANICHAEAN_LAMEDH</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-manichaean-mem">
-     <term><constant>IntlChar::JG_MANICHAEAN_MEM</constant></term>
+     <term>
+      <constant>IntlChar::JG_MANICHAEAN_MEM</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-manichaean-nun">
-     <term><constant>IntlChar::JG_MANICHAEAN_NUN</constant></term>
+     <term>
+      <constant>IntlChar::JG_MANICHAEAN_NUN</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-manichaean-one">
-     <term><constant>IntlChar::JG_MANICHAEAN_ONE</constant></term>
+     <term>
+      <constant>IntlChar::JG_MANICHAEAN_ONE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-manichaean-pe">
-     <term><constant>IntlChar::JG_MANICHAEAN_PE</constant></term>
+     <term>
+      <constant>IntlChar::JG_MANICHAEAN_PE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-manichaean-qoph">
-     <term><constant>IntlChar::JG_MANICHAEAN_QOPH</constant></term>
+     <term>
+      <constant>IntlChar::JG_MANICHAEAN_QOPH</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-manichaean-resh">
-     <term><constant>IntlChar::JG_MANICHAEAN_RESH</constant></term>
+     <term>
+      <constant>IntlChar::JG_MANICHAEAN_RESH</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-manichaean-sadhe">
-     <term><constant>IntlChar::JG_MANICHAEAN_SADHE</constant></term>
+     <term>
+      <constant>IntlChar::JG_MANICHAEAN_SADHE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-manichaean-samekh">
-     <term><constant>IntlChar::JG_MANICHAEAN_SAMEKH</constant></term>
+     <term>
+      <constant>IntlChar::JG_MANICHAEAN_SAMEKH</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-manichaean-taw">
-     <term><constant>IntlChar::JG_MANICHAEAN_TAW</constant></term>
+     <term>
+      <constant>IntlChar::JG_MANICHAEAN_TAW</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-manichaean-ten">
-     <term><constant>IntlChar::JG_MANICHAEAN_TEN</constant></term>
+     <term>
+      <constant>IntlChar::JG_MANICHAEAN_TEN</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-manichaean-teth">
-     <term><constant>IntlChar::JG_MANICHAEAN_TETH</constant></term>
+     <term>
+      <constant>IntlChar::JG_MANICHAEAN_TETH</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-manichaean-thamedh">
-     <term><constant>IntlChar::JG_MANICHAEAN_THAMEDH</constant></term>
+     <term>
+      <constant>IntlChar::JG_MANICHAEAN_THAMEDH</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-manichaean-twenty">
-     <term><constant>IntlChar::JG_MANICHAEAN_TWENTY</constant></term>
+     <term>
+      <constant>IntlChar::JG_MANICHAEAN_TWENTY</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-manichaean-waw">
-     <term><constant>IntlChar::JG_MANICHAEAN_WAW</constant></term>
+     <term>
+      <constant>IntlChar::JG_MANICHAEAN_WAW</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-manichaean-yodh">
-     <term><constant>IntlChar::JG_MANICHAEAN_YODH</constant></term>
+     <term>
+      <constant>IntlChar::JG_MANICHAEAN_YODH</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-manichaean-zayin">
-     <term><constant>IntlChar::JG_MANICHAEAN_ZAYIN</constant></term>
+     <term>
+      <constant>IntlChar::JG_MANICHAEAN_ZAYIN</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-straight-waw">
-     <term><constant>IntlChar::JG_STRAIGHT_WAW</constant></term>
+     <term>
+      <constant>IntlChar::JG_STRAIGHT_WAW</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.jg-count">
-     <term><constant>IntlChar::JG_COUNT</constant></term>
+     <term>
+      <constant>IntlChar::JG_COUNT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.gcb-other">
-     <term><constant>IntlChar::GCB_OTHER</constant></term>
+     <term>
+      <constant>IntlChar::GCB_OTHER</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.gcb-control">
-     <term><constant>IntlChar::GCB_CONTROL</constant></term>
+     <term>
+      <constant>IntlChar::GCB_CONTROL</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.gcb-cr">
-     <term><constant>IntlChar::GCB_CR</constant></term>
+     <term>
+      <constant>IntlChar::GCB_CR</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.gcb-extend">
-     <term><constant>IntlChar::GCB_EXTEND</constant></term>
+     <term>
+      <constant>IntlChar::GCB_EXTEND</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.gcb-l">
-     <term><constant>IntlChar::GCB_L</constant></term>
+     <term>
+      <constant>IntlChar::GCB_L</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.gcb-lf">
-     <term><constant>IntlChar::GCB_LF</constant></term>
+     <term>
+      <constant>IntlChar::GCB_LF</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.gcb-lv">
-     <term><constant>IntlChar::GCB_LV</constant></term>
+     <term>
+      <constant>IntlChar::GCB_LV</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.gcb-lvt">
-     <term><constant>IntlChar::GCB_LVT</constant></term>
+     <term>
+      <constant>IntlChar::GCB_LVT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.gcb-t">
-     <term><constant>IntlChar::GCB_T</constant></term>
+     <term>
+      <constant>IntlChar::GCB_T</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.gcb-v">
-     <term><constant>IntlChar::GCB_V</constant></term>
+     <term>
+      <constant>IntlChar::GCB_V</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.gcb-spacing-mark">
-     <term><constant>IntlChar::GCB_SPACING_MARK</constant></term>
+     <term>
+      <constant>IntlChar::GCB_SPACING_MARK</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.gcb-prepend">
-     <term><constant>IntlChar::GCB_PREPEND</constant></term>
+     <term>
+      <constant>IntlChar::GCB_PREPEND</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.gcb-regional-indicator">
-     <term><constant>IntlChar::GCB_REGIONAL_INDICATOR</constant></term>
+     <term>
+      <constant>IntlChar::GCB_REGIONAL_INDICATOR</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.gcb-count">
-     <term><constant>IntlChar::GCB_COUNT</constant></term>
+     <term>
+      <constant>IntlChar::GCB_COUNT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.wb-other">
-     <term><constant>IntlChar::WB_OTHER</constant></term>
+     <term>
+      <constant>IntlChar::WB_OTHER</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.wb-aletter">
-     <term><constant>IntlChar::WB_ALETTER</constant></term>
+     <term>
+      <constant>IntlChar::WB_ALETTER</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.wb-format">
-     <term><constant>IntlChar::WB_FORMAT</constant></term>
+     <term>
+      <constant>IntlChar::WB_FORMAT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.wb-katakana">
-     <term><constant>IntlChar::WB_KATAKANA</constant></term>
+     <term>
+      <constant>IntlChar::WB_KATAKANA</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.wb-midletter">
-     <term><constant>IntlChar::WB_MIDLETTER</constant></term>
+     <term>
+      <constant>IntlChar::WB_MIDLETTER</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.wb-midnum">
-     <term><constant>IntlChar::WB_MIDNUM</constant></term>
+     <term>
+      <constant>IntlChar::WB_MIDNUM</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.wb-numeric">
-     <term><constant>IntlChar::WB_NUMERIC</constant></term>
+     <term>
+      <constant>IntlChar::WB_NUMERIC</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.wb-extendnumlet">
-     <term><constant>IntlChar::WB_EXTENDNUMLET</constant></term>
+     <term>
+      <constant>IntlChar::WB_EXTENDNUMLET</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.wb-cr">
-     <term><constant>IntlChar::WB_CR</constant></term>
+     <term>
+      <constant>IntlChar::WB_CR</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.wb-extend">
-     <term><constant>IntlChar::WB_EXTEND</constant></term>
+     <term>
+      <constant>IntlChar::WB_EXTEND</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.wb-lf">
-     <term><constant>IntlChar::WB_LF</constant></term>
+     <term>
+      <constant>IntlChar::WB_LF</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.wb-midnumlet">
-     <term><constant>IntlChar::WB_MIDNUMLET</constant></term>
+     <term>
+      <constant>IntlChar::WB_MIDNUMLET</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.wb-newline">
-     <term><constant>IntlChar::WB_NEWLINE</constant></term>
+     <term>
+      <constant>IntlChar::WB_NEWLINE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.wb-regional-indicator">
-     <term><constant>IntlChar::WB_REGIONAL_INDICATOR</constant></term>
+     <term>
+      <constant>IntlChar::WB_REGIONAL_INDICATOR</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.wb-hebrew-letter">
-     <term><constant>IntlChar::WB_HEBREW_LETTER</constant></term>
+     <term>
+      <constant>IntlChar::WB_HEBREW_LETTER</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.wb-single-quote">
-     <term><constant>IntlChar::WB_SINGLE_QUOTE</constant></term>
+     <term>
+      <constant>IntlChar::WB_SINGLE_QUOTE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.wb-double-quote">
-     <term><constant>IntlChar::WB_DOUBLE_QUOTE</constant></term>
+     <term>
+      <constant>IntlChar::WB_DOUBLE_QUOTE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.wb-count">
-     <term><constant>IntlChar::WB_COUNT</constant></term>
+     <term>
+      <constant>IntlChar::WB_COUNT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.sb-other">
-     <term><constant>IntlChar::SB_OTHER</constant></term>
+     <term>
+      <constant>IntlChar::SB_OTHER</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.sb-aterm">
-     <term><constant>IntlChar::SB_ATERM</constant></term>
+     <term>
+      <constant>IntlChar::SB_ATERM</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.sb-close">
-     <term><constant>IntlChar::SB_CLOSE</constant></term>
+     <term>
+      <constant>IntlChar::SB_CLOSE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.sb-format">
-     <term><constant>IntlChar::SB_FORMAT</constant></term>
+     <term>
+      <constant>IntlChar::SB_FORMAT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.sb-lower">
-     <term><constant>IntlChar::SB_LOWER</constant></term>
+     <term>
+      <constant>IntlChar::SB_LOWER</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.sb-numeric">
-     <term><constant>IntlChar::SB_NUMERIC</constant></term>
+     <term>
+      <constant>IntlChar::SB_NUMERIC</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.sb-oletter">
-     <term><constant>IntlChar::SB_OLETTER</constant></term>
+     <term>
+      <constant>IntlChar::SB_OLETTER</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.sb-sep">
-     <term><constant>IntlChar::SB_SEP</constant></term>
+     <term>
+      <constant>IntlChar::SB_SEP</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.sb-sp">
-     <term><constant>IntlChar::SB_SP</constant></term>
+     <term>
+      <constant>IntlChar::SB_SP</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.sb-sterm">
-     <term><constant>IntlChar::SB_STERM</constant></term>
+     <term>
+      <constant>IntlChar::SB_STERM</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.sb-upper">
-     <term><constant>IntlChar::SB_UPPER</constant></term>
+     <term>
+      <constant>IntlChar::SB_UPPER</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.sb-cr">
-     <term><constant>IntlChar::SB_CR</constant></term>
+     <term>
+      <constant>IntlChar::SB_CR</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.sb-extend">
-     <term><constant>IntlChar::SB_EXTEND</constant></term>
+     <term>
+      <constant>IntlChar::SB_EXTEND</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.sb-lf">
-     <term><constant>IntlChar::SB_LF</constant></term>
+     <term>
+      <constant>IntlChar::SB_LF</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.sb-scontinue">
-     <term><constant>IntlChar::SB_SCONTINUE</constant></term>
+     <term>
+      <constant>IntlChar::SB_SCONTINUE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.sb-count">
-     <term><constant>IntlChar::SB_COUNT</constant></term>
+     <term>
+      <constant>IntlChar::SB_COUNT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.lb-unknown">
-     <term><constant>IntlChar::LB_UNKNOWN</constant></term>
+     <term>
+      <constant>IntlChar::LB_UNKNOWN</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.lb-ambiguous">
-     <term><constant>IntlChar::LB_AMBIGUOUS</constant></term>
+     <term>
+      <constant>IntlChar::LB_AMBIGUOUS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.lb-alphabetic">
-     <term><constant>IntlChar::LB_ALPHABETIC</constant></term>
+     <term>
+      <constant>IntlChar::LB_ALPHABETIC</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.lb-break-both">
-     <term><constant>IntlChar::LB_BREAK_BOTH</constant></term>
+     <term>
+      <constant>IntlChar::LB_BREAK_BOTH</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.lb-break-after">
-     <term><constant>IntlChar::LB_BREAK_AFTER</constant></term>
+     <term>
+      <constant>IntlChar::LB_BREAK_AFTER</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.lb-break-before">
-     <term><constant>IntlChar::LB_BREAK_BEFORE</constant></term>
+     <term>
+      <constant>IntlChar::LB_BREAK_BEFORE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.lb-mandatory-break">
-     <term><constant>IntlChar::LB_MANDATORY_BREAK</constant></term>
+     <term>
+      <constant>IntlChar::LB_MANDATORY_BREAK</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.lb-contingent-break">
-     <term><constant>IntlChar::LB_CONTINGENT_BREAK</constant></term>
+     <term>
+      <constant>IntlChar::LB_CONTINGENT_BREAK</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.lb-close-punctuation">
-     <term><constant>IntlChar::LB_CLOSE_PUNCTUATION</constant></term>
+     <term>
+      <constant>IntlChar::LB_CLOSE_PUNCTUATION</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.lb-combining-mark">
-     <term><constant>IntlChar::LB_COMBINING_MARK</constant></term>
+     <term>
+      <constant>IntlChar::LB_COMBINING_MARK</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.lb-carriage-return">
-     <term><constant>IntlChar::LB_CARRIAGE_RETURN</constant></term>
+     <term>
+      <constant>IntlChar::LB_CARRIAGE_RETURN</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.lb-exclamation">
-     <term><constant>IntlChar::LB_EXCLAMATION</constant></term>
+     <term>
+      <constant>IntlChar::LB_EXCLAMATION</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.lb-glue">
-     <term><constant>IntlChar::LB_GLUE</constant></term>
+     <term>
+      <constant>IntlChar::LB_GLUE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.lb-hyphen">
-     <term><constant>IntlChar::LB_HYPHEN</constant></term>
+     <term>
+      <constant>IntlChar::LB_HYPHEN</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.lb-ideographic">
-     <term><constant>IntlChar::LB_IDEOGRAPHIC</constant></term>
+     <term>
+      <constant>IntlChar::LB_IDEOGRAPHIC</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.lb-inseparable">
-     <term><constant>IntlChar::LB_INSEPARABLE</constant></term>
+     <term>
+      <constant>IntlChar::LB_INSEPARABLE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.lb-inseperable">
-     <term><constant>IntlChar::LB_INSEPERABLE</constant></term>
+     <term>
+      <constant>IntlChar::LB_INSEPERABLE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.lb-infix-numeric">
-     <term><constant>IntlChar::LB_INFIX_NUMERIC</constant></term>
+     <term>
+      <constant>IntlChar::LB_INFIX_NUMERIC</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.lb-line-feed">
-     <term><constant>IntlChar::LB_LINE_FEED</constant></term>
+     <term>
+      <constant>IntlChar::LB_LINE_FEED</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.lb-nonstarter">
-     <term><constant>IntlChar::LB_NONSTARTER</constant></term>
+     <term>
+      <constant>IntlChar::LB_NONSTARTER</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.lb-numeric">
-     <term><constant>IntlChar::LB_NUMERIC</constant></term>
+     <term>
+      <constant>IntlChar::LB_NUMERIC</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.lb-open-punctuation">
-     <term><constant>IntlChar::LB_OPEN_PUNCTUATION</constant></term>
+     <term>
+      <constant>IntlChar::LB_OPEN_PUNCTUATION</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.lb-postfix-numeric">
-     <term><constant>IntlChar::LB_POSTFIX_NUMERIC</constant></term>
+     <term>
+      <constant>IntlChar::LB_POSTFIX_NUMERIC</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.lb-prefix-numeric">
-     <term><constant>IntlChar::LB_PREFIX_NUMERIC</constant></term>
+     <term>
+      <constant>IntlChar::LB_PREFIX_NUMERIC</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.lb-quotation">
-     <term><constant>IntlChar::LB_QUOTATION</constant></term>
+     <term>
+      <constant>IntlChar::LB_QUOTATION</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.lb-complex-context">
-     <term><constant>IntlChar::LB_COMPLEX_CONTEXT</constant></term>
+     <term>
+      <constant>IntlChar::LB_COMPLEX_CONTEXT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.lb-surrogate">
-     <term><constant>IntlChar::LB_SURROGATE</constant></term>
+     <term>
+      <constant>IntlChar::LB_SURROGATE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.lb-space">
-     <term><constant>IntlChar::LB_SPACE</constant></term>
+     <term>
+      <constant>IntlChar::LB_SPACE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.lb-break-symbols">
-     <term><constant>IntlChar::LB_BREAK_SYMBOLS</constant></term>
+     <term>
+      <constant>IntlChar::LB_BREAK_SYMBOLS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.lb-zwspace">
-     <term><constant>IntlChar::LB_ZWSPACE</constant></term>
+     <term>
+      <constant>IntlChar::LB_ZWSPACE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.lb-next-line">
-     <term><constant>IntlChar::LB_NEXT_LINE</constant></term>
+     <term>
+      <constant>IntlChar::LB_NEXT_LINE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.lb-word-joiner">
-     <term><constant>IntlChar::LB_WORD_JOINER</constant></term>
+     <term>
+      <constant>IntlChar::LB_WORD_JOINER</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.lb-h2">
-     <term><constant>IntlChar::LB_H2</constant></term>
+     <term>
+      <constant>IntlChar::LB_H2</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.lb-h3">
-     <term><constant>IntlChar::LB_H3</constant></term>
+     <term>
+      <constant>IntlChar::LB_H3</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.lb-jl">
-     <term><constant>IntlChar::LB_JL</constant></term>
+     <term>
+      <constant>IntlChar::LB_JL</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.lb-jt">
-     <term><constant>IntlChar::LB_JT</constant></term>
+     <term>
+      <constant>IntlChar::LB_JT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.lb-jv">
-     <term><constant>IntlChar::LB_JV</constant></term>
+     <term>
+      <constant>IntlChar::LB_JV</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.lb-close-parenthesis">
-     <term><constant>IntlChar::LB_CLOSE_PARENTHESIS</constant></term>
+     <term>
+      <constant>IntlChar::LB_CLOSE_PARENTHESIS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.lb-conditional-japanese-starter">
-     <term><constant>IntlChar::LB_CONDITIONAL_JAPANESE_STARTER</constant></term>
+     <term>
+      <constant>IntlChar::LB_CONDITIONAL_JAPANESE_STARTER</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.lb-hebrew-letter">
-     <term><constant>IntlChar::LB_HEBREW_LETTER</constant></term>
+     <term>
+      <constant>IntlChar::LB_HEBREW_LETTER</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.lb-regional-indicator">
-     <term><constant>IntlChar::LB_REGIONAL_INDICATOR</constant></term>
+     <term>
+      <constant>IntlChar::LB_REGIONAL_INDICATOR</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.lb-count">
-     <term><constant>IntlChar::LB_COUNT</constant></term>
+     <term>
+      <constant>IntlChar::LB_COUNT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.nt-none">
-     <term><constant>IntlChar::NT_NONE</constant></term>
+     <term>
+      <constant>IntlChar::NT_NONE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.nt-decimal">
-     <term><constant>IntlChar::NT_DECIMAL</constant></term>
+     <term>
+      <constant>IntlChar::NT_DECIMAL</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.nt-digit">
-     <term><constant>IntlChar::NT_DIGIT</constant></term>
+     <term>
+      <constant>IntlChar::NT_DIGIT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.nt-numeric">
-     <term><constant>IntlChar::NT_NUMERIC</constant></term>
+     <term>
+      <constant>IntlChar::NT_NUMERIC</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.nt-count">
-     <term><constant>IntlChar::NT_COUNT</constant></term>
+     <term>
+      <constant>IntlChar::NT_COUNT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.hst-not-applicable">
-     <term><constant>IntlChar::HST_NOT_APPLICABLE</constant></term>
+     <term>
+      <constant>IntlChar::HST_NOT_APPLICABLE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.hst-leading-jamo">
-     <term><constant>IntlChar::HST_LEADING_JAMO</constant></term>
+     <term>
+      <constant>IntlChar::HST_LEADING_JAMO</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.hst-vowel-jamo">
-     <term><constant>IntlChar::HST_VOWEL_JAMO</constant></term>
+     <term>
+      <constant>IntlChar::HST_VOWEL_JAMO</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.hst-trailing-jamo">
-     <term><constant>IntlChar::HST_TRAILING_JAMO</constant></term>
+     <term>
+      <constant>IntlChar::HST_TRAILING_JAMO</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.hst-lv-syllable">
-     <term><constant>IntlChar::HST_LV_SYLLABLE</constant></term>
+     <term>
+      <constant>IntlChar::HST_LV_SYLLABLE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.hst-lvt-syllable">
-     <term><constant>IntlChar::HST_LVT_SYLLABLE</constant></term>
+     <term>
+      <constant>IntlChar::HST_LVT_SYLLABLE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.hst-count">
-     <term><constant>IntlChar::HST_COUNT</constant></term>
+     <term>
+      <constant>IntlChar::HST_COUNT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.fold-case-default">
-     <term><constant>IntlChar::FOLD_CASE_DEFAULT</constant></term>
+     <term>
+      <constant>IntlChar::FOLD_CASE_DEFAULT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlchar.constants.fold-case-exclude-special-i">
-     <term><constant>IntlChar::FOLD_CASE_EXCLUDE_SPECIAL_I</constant></term>
+     <term>
+      <constant>IntlChar::FOLD_CASE_EXCLUDE_SPECIAL_I</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
@@ -8683,6 +10672,12 @@
        </row>
       </thead>
       <tbody>
+       <row>
+        <entry>8.4.0</entry>
+        <entry>
+         クラス定数が型付けされました。
+        </entry>
+       </row>
        <row>
         <entry>7.0.6</entry>
         <entry>

--- a/reference/intl/intlchar.xml
+++ b/reference/intl/intlchar.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 1f68eecaa7c4c723abe72a5a040ea7b15023a5aa Maintainer: mumumu Status: ready -->
 <reference xml:id="class.intlchar" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>IntlChar クラス</title>

--- a/reference/intl/intlpartsiterator.xml
+++ b/reference/intl/intlpartsiterator.xml
@@ -83,21 +83,30 @@
    <variablelist>
 
     <varlistentry xml:id="intlpartsiterator.constants.key-sequential">
-     <term><constant>IntlPartsIterator::KEY_SEQUENTIAL</constant></term>
+     <term>
+      <constant>IntlPartsIterator::KEY_SEQUENTIAL</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlpartsiterator.constants.key-left">
-     <term><constant>IntlPartsIterator::KEY_LEFT</constant></term>
+     <term>
+      <constant>IntlPartsIterator::KEY_LEFT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intlpartsiterator.constants.key-right">
-     <term><constant>IntlPartsIterator::KEY_RIGHT</constant></term>
+     <term>
+      <constant>IntlPartsIterator::KEY_RIGHT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
@@ -107,6 +116,27 @@
   </section>
 <!-- }}} -->
 
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        クラス定数が型付けされました。
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
 
  </partintro>
 

--- a/reference/intl/intlpartsiterator.xml
+++ b/reference/intl/intlpartsiterator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 1f68eecaa7c4c723abe72a5a040ea7b15023a5aa Maintainer: mumumu Status: ready -->
 <reference xml:id="class.intlpartsiterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>IntlPartsIterator クラス</title>

--- a/reference/intl/intltimezone.xml
+++ b/reference/intl/intltimezone.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 1f68eecaa7c4c723abe72a5a040ea7b15023a5aa Maintainer: takagi Status: ready -->
 <reference xml:id="class.intltimezone" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>IntlTimeZone クラス</title>

--- a/reference/intl/intltimezone.xml
+++ b/reference/intl/intltimezone.xml
@@ -111,82 +111,137 @@
    &reftitle.constants;
    <variablelist>
     <varlistentry xml:id="intltimezone.constants.display-short">
-     <term><constant>IntlTimeZone::DISPLAY_SHORT</constant></term>
+     <term>
+      <constant>IntlTimeZone::DISPLAY_SHORT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intltimezone.constants.display-long">
-     <term><constant>IntlTimeZone::DISPLAY_LONG</constant></term>
+     <term>
+      <constant>IntlTimeZone::DISPLAY_LONG</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intltimezone.constants.display-short-generic">
-     <term><constant>IntlTimeZone::DISPLAY_SHORT_GENERIC</constant></term>
+     <term>
+      <constant>IntlTimeZone::DISPLAY_SHORT_GENERIC</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intltimezone.constants.display-long-generic">
-     <term><constant>IntlTimeZone::DISPLAY_LONG_GENERIC</constant></term>
+     <term>
+      <constant>IntlTimeZone::DISPLAY_LONG_GENERIC</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intltimezone.constants.display-short-gmt">
-     <term><constant>IntlTimeZone::DISPLAY_SHORT_GMT</constant></term>
+     <term>
+      <constant>IntlTimeZone::DISPLAY_SHORT_GMT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intltimezone.constants.display-long-gmt">
-     <term><constant>IntlTimeZone::DISPLAY_LONG_GMT</constant></term>
+     <term>
+      <constant>IntlTimeZone::DISPLAY_LONG_GMT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intltimezone.constants.display-short-commonly-used">
-     <term><constant>IntlTimeZone::DISPLAY_SHORT_COMMONLY_USED</constant></term>
+     <term>
+      <constant>IntlTimeZone::DISPLAY_SHORT_COMMONLY_USED</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intltimezone.constants.display-generic-location">
-     <term><constant>IntlTimeZone::DISPLAY_GENERIC_LOCATION</constant></term>
+     <term>
+      <constant>IntlTimeZone::DISPLAY_GENERIC_LOCATION</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intltimezone.constants.type-any">
-     <term><constant>IntlTimeZone::TYPE_ANY</constant></term>
+     <term>
+      <constant>IntlTimeZone::TYPE_ANY</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intltimezone.constants.type-canonical">
-     <term><constant>IntlTimeZone::TYPE_CANONICAL</constant></term>
+     <term>
+      <constant>IntlTimeZone::TYPE_CANONICAL</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="intltimezone.constants.type-canonical-location">
-     <term><constant>IntlTimeZone::TYPE_CANONICAL_LOCATION</constant></term>
+     <term>
+      <constant>IntlTimeZone::TYPE_CANONICAL_LOCATION</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
    </variablelist>
+  </section>
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        クラス定数が型付けされました。
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
  </partintro>
 

--- a/reference/intl/locale-constants.xml
+++ b/reference/intl/locale-constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 89562618e93396020a5120a8d8c466ae6457cc77 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 1f68eecaa7c4c723abe72a5a040ea7b15023a5aa Maintainer: takagi Status: ready -->
 <section xml:id="intl.locale-constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
  <para>

--- a/reference/intl/locale-constants.xml
+++ b/reference/intl/locale-constants.xml
@@ -8,6 +8,7 @@
    <varlistentry xml:id="locale.constants.default-locale">
     <term>
      <constant>Locale::DEFAULT_LOCALE</constant>
+     <type>null</type>
     </term>
     <listitem>
      <simpara>
@@ -26,6 +27,7 @@
    <varlistentry xml:id="locale.constants.actual-locale">
     <term>
      <constant>Locale::ACTUAL_LOCALE</constant>
+     <type>int</type>
     </term>
     <listitem>
      <simpara>これは、データが実際にやってくる元のロケールです。</simpara>
@@ -35,6 +37,7 @@
    <varlistentry xml:id="locale.constants.valid-locale">
     <term>
      <constant>Locale::VALID_LOCALE</constant>
+     <type>int</type>
     </term>
     <listitem>
      <simpara>これは、ICU がサポートする最も明確なロケールです。</simpara>
@@ -53,6 +56,7 @@
     <varlistentry xml:id="locale.constants.lang-tag">
      <term>
       <constant>Locale::LANG_TAG</constant>
+      <type>string</type>
      </term>
      <listitem>
       <simpara>言語サブタグ</simpara>
@@ -62,6 +66,7 @@
     <varlistentry xml:id="locale.constants.extlang-tag">
      <term>
       <constant>Locale::EXTLANG_TAG</constant>
+      <type>string</type>
      </term>
      <listitem>
       <simpara>拡張言語サブタグ</simpara>
@@ -71,6 +76,7 @@
     <varlistentry xml:id="locale.constants.script-tag">
      <term>
       <constant>Locale::SCRIPT_TAG</constant>
+      <type>string</type>
      </term>
      <listitem>
       <simpara>文字サブタグ</simpara>
@@ -79,6 +85,7 @@
     <varlistentry xml:id="locale.constants.region-tag">
      <term>
       <constant>Locale::REGION_TAG</constant>
+      <type>string</type>
      </term>
      <listitem>
       <simpara>地域サブタグ</simpara>
@@ -88,6 +95,7 @@
     <varlistentry xml:id="locale.constants.variant-tag">
      <term>
       <constant>Locale::VARIANT_TAG</constant>
+      <type>string</type>
      </term>
      <listitem>
       <simpara>変化形サブタグ</simpara>
@@ -97,6 +105,7 @@
     <varlistentry xml:id="locale.constants.grandfathered-lang-tag">
      <term>
       <constant>Locale::GRANDFATHERED_LANG_TAG</constant>
+      <type>string</type>
      </term>
      <listitem>
       <simpara>先祖言語 (Grandfathered Language) サブタグ</simpara>
@@ -106,6 +115,7 @@
     <varlistentry xml:id="locale.constants.private-tag">
      <term>
       <constant>Locale::PRIVATE_TAG</constant>
+      <type>string</type>
      </term>
      <listitem>
       <simpara>プライベートサブタグ</simpara>

--- a/reference/intl/locale.xml
+++ b/reference/intl/locale.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 1f68eecaa7c4c723abe72a5a040ea7b15023a5aa Maintainer: takagi Status: ready -->
 <reference xml:id="class.locale" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>Locale クラス</title>
  <titleabbrev>Locale</titleabbrev>

--- a/reference/intl/locale.xml
+++ b/reference/intl/locale.xml
@@ -169,6 +169,28 @@
     </simplelist>
    </para>
   </section>
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        クラス定数が型付けされました。
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
  </partintro>
 
  &reference.intl.entities.locale;

--- a/reference/intl/normalizer-constants.xml
+++ b/reference/intl/normalizer-constants.xml
@@ -10,6 +10,7 @@
    <varlistentry xml:id="normalizer.constants.form-c">
     <term>
      <constant>Normalizer::FORM_C</constant>
+     <type>int</type>
     </term>
     <listitem>
      <simpara>
@@ -22,6 +23,7 @@
    <varlistentry xml:id="normalizer.constants.form-d">
     <term>
      <constant>Normalizer::FORM_D</constant>
+     <type>int</type>
     </term>
     <listitem>
      <simpara>Normalization Form D (NFD) - Canonical Decomposition</simpara>
@@ -29,7 +31,10 @@
    </varlistentry>
 
    <varlistentry xml:id="normalizer.constants.nfd">
-    <term><constant>Normalizer::NFD</constant></term>
+    <term>
+     <constant>Normalizer::NFD</constant>
+     <type>int</type>
+    </term>
     <listitem>
      <para/>
     </listitem>
@@ -38,6 +43,7 @@
    <varlistentry xml:id="normalizer.constants.form-kc">
     <term>
      <constant>Normalizer::FORM_KC</constant>
+     <type>int</type>
     </term>
     <listitem>
      <simpara>
@@ -48,14 +54,20 @@
    </varlistentry>
 
    <varlistentry xml:id="normalizer.constants.nfkc">
-    <term><constant>Normalizer::NFKC</constant></term>
+    <term>
+     <constant>Normalizer::NFKC</constant>
+     <type>int</type>
+    </term>
     <listitem>
      <para/>
     </listitem>
    </varlistentry>
 
    <varlistentry xml:id="normalizer.constants.form-kc-cf">
-    <term><constant>Normalizer::FORM_KC_CF</constant></term>
+    <term>
+     <constant>Normalizer::FORM_KC_CF</constant>
+     <type>int</type>
+    </term>
     <listitem>
      <para/>
     </listitem>
@@ -64,6 +76,7 @@
    <varlistentry xml:id="normalizer.constants.form-kd">
     <term>
      <constant>Normalizer::FORM_KD</constant>
+     <type>int</type>
     </term>
     <listitem>
      <simpara>
@@ -73,21 +86,30 @@
    </varlistentry>
 
    <varlistentry xml:id="normalizer.constants.nfkd">
-    <term><constant>Normalizer::NFKD</constant></term>
+    <term>
+     <constant>Normalizer::NFKD</constant>
+     <type>int</type>
+    </term>
     <listitem>
      <para/>
     </listitem>
    </varlistentry>
 
    <varlistentry xml:id="normalizer.constants.nfc">
-    <term><constant>Normalizer::NFC</constant></term>
+    <term>
+     <constant>Normalizer::NFC</constant>
+     <type>int</type>
+    </term>
     <listitem>
      <para/>
     </listitem>
    </varlistentry>
 
    <varlistentry xml:id="normalizer.constants.nfkc-cf">
-    <term><constant>Normalizer::NFKC_CF</constant></term>
+    <term>
+     <constant>Normalizer::NFKC_CF</constant>
+     <type>int</type>
+    </term>
     <listitem>
      <para/>
     </listitem>

--- a/reference/intl/normalizer-constants.xml
+++ b/reference/intl/normalizer-constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 6e6c154057b6d96518de039f40ff1e4feb44b04f Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 1f68eecaa7c4c723abe72a5a040ea7b15023a5aa Maintainer: takagi Status: ready -->
 <section xml:id="intl.normalizer-constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.constants;
 

--- a/reference/intl/normalizer.xml
+++ b/reference/intl/normalizer.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 1f68eecaa7c4c723abe72a5a040ea7b15023a5aa Maintainer: takagi Status: ready -->
 <reference xml:id="class.normalizer" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>Normalizer クラス</title>
  <titleabbrev>Normalizer</titleabbrev>

--- a/reference/intl/normalizer.xml
+++ b/reference/intl/normalizer.xml
@@ -175,6 +175,12 @@
      </thead>
      <tbody>
       <row>
+       <entry>8.4.0</entry>
+       <entry>
+        クラス定数が型付けされました。
+       </entry>
+      </row>
+      <row>
        <entry>8.0.0</entry>
        <entry>
         <constant>Normalizer::NONE</constant> が削除されました。

--- a/reference/intl/numberformatter-constants.xml
+++ b/reference/intl/numberformatter-constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 89562618e93396020a5120a8d8c466ae6457cc77 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 1f68eecaa7c4c723abe72a5a040ea7b15023a5aa Maintainer: takagi Status: ready -->
 <!-- CREDITS: mumumu -->
 <section xml:id="intl.numberformatter-constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.constants;

--- a/reference/intl/numberformatter-constants.xml
+++ b/reference/intl/numberformatter-constants.xml
@@ -14,6 +14,7 @@
     <varlistentry xml:id="numberformatter.constants.pattern-decimal">
      <term>
       <constant>NumberFormatter::PATTERN_DECIMAL</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>パターンで定義する十進形式</simpara>
@@ -23,6 +24,7 @@
     <varlistentry xml:id="numberformatter.constants.decimal">
      <term>
       <constant>NumberFormatter::DECIMAL</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>十進形式</simpara>
@@ -32,6 +34,7 @@
     <varlistentry xml:id="numberformatter.constants.currency">
      <term>
       <constant>NumberFormatter::CURRENCY</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>通貨形式</simpara>
@@ -41,6 +44,7 @@
     <varlistentry xml:id="numberformatter.constants.percent">
      <term>
       <constant>NumberFormatter::PERCENT</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>パーセント形式</simpara>
@@ -50,6 +54,7 @@
     <varlistentry xml:id="numberformatter.constants.scientific">
      <term>
       <constant>NumberFormatter::SCIENTIFIC</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>科学形式</simpara>
@@ -59,6 +64,7 @@
     <varlistentry xml:id="numberformatter.constants.spellout">
      <term>
       <constant>NumberFormatter::SPELLOUT</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>ルールベースの省略しない形式</simpara>
@@ -68,6 +74,7 @@
     <varlistentry xml:id="numberformatter.constants.ordinal">
      <term>
       <constant>NumberFormatter::ORDINAL</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>ルールベースの序数形式</simpara>
@@ -77,6 +84,7 @@
     <varlistentry xml:id="numberformatter.constants.duration">
      <term>
       <constant>NumberFormatter::DURATION</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>ルールベースの連続形式</simpara>
@@ -86,6 +94,7 @@
     <varlistentry xml:id="numberformatter.constants.pattern-rulebased">
      <term>
       <constant>NumberFormatter::PATTERN_RULEBASED</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>パターンで定義するルールベースの形式</simpara>
@@ -95,6 +104,7 @@
     <varlistentry xml:id="numberformatter.constants.currency-accounting">
      <term>
       <constant>NumberFormatter::CURRENCY_ACCOUNTING</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>
@@ -109,6 +119,7 @@
     <varlistentry xml:id="numberformatter.constants.default-style">
      <term>
       <constant>NumberFormatter::DEFAULT_STYLE</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>そのロケールのデフォルトの形式</simpara>
@@ -118,6 +129,7 @@
     <varlistentry xml:id="numberformatter.constants.ignore">
      <term>
       <constant>NumberFormatter::IGNORE</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>PATTERN_DECIMAL のエイリアス</simpara>
@@ -138,6 +150,7 @@
     <varlistentry xml:id="numberformatter.constants.type-default">
      <term>
       <constant>NumberFormatter::TYPE_DEFAULT</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>変数の型に由来する型</simpara>
@@ -147,6 +160,7 @@
     <varlistentry xml:id="numberformatter.constants.type-int32">
      <term>
       <constant>NumberFormatter::TYPE_INT32</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>32 ビット整数値としてフォーマット/パースする</simpara>
@@ -156,6 +170,7 @@
     <varlistentry xml:id="numberformatter.constants.type-int64">
      <term>
       <constant>NumberFormatter::TYPE_INT64</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>64 ビット整数値としてフォーマット/パースする</simpara>
@@ -165,6 +180,7 @@
     <varlistentry xml:id="numberformatter.constants.type-double">
      <term>
       <constant>NumberFormatter::TYPE_DOUBLE</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>浮動小数点数値としてフォーマット/パースする</simpara>
@@ -174,6 +190,7 @@
     <varlistentry xml:id="numberformatter.constants.type-currency">
      <term>
       <constant>NumberFormatter::TYPE_CURRENCY</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>通貨値としてフォーマット/パースする。PHP 8.3.0 以降は非推奨</simpara>
@@ -194,6 +211,7 @@
     <varlistentry xml:id="numberformatter.constants.parse-int-only">
      <term>
       <constant>NumberFormatter::PARSE_INT_ONLY</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>整数値のみをパースする</simpara>
@@ -203,6 +221,7 @@
     <varlistentry xml:id="numberformatter.constants.grouping-used">
      <term>
       <constant>NumberFormatter::GROUPING_USED</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>グループ区切り文字を使用する</simpara>
@@ -212,6 +231,7 @@
     <varlistentry xml:id="numberformatter.constants.decimal-always-shown">
      <term>
       <constant>NumberFormatter::DECIMAL_ALWAYS_SHOWN</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>常に小数点を表示する</simpara>
@@ -221,6 +241,7 @@
     <varlistentry xml:id="numberformatter.constants.max-integer-digits">
      <term>
       <constant>NumberFormatter::MAX_INTEGER_DIGITS</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>整数部の最大桁数</simpara>
@@ -230,6 +251,7 @@
     <varlistentry xml:id="numberformatter.constants.min-integer-digits">
      <term>
       <constant>NumberFormatter::MIN_INTEGER_DIGITS</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>整数部の最小桁数</simpara>
@@ -239,6 +261,7 @@
     <varlistentry xml:id="numberformatter.constants.integer-digits">
      <term>
       <constant>NumberFormatter::INTEGER_DIGITS</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>整数部の桁数</simpara>
@@ -248,6 +271,7 @@
     <varlistentry xml:id="numberformatter.constants.max-fraction-digits">
      <term>
       <constant>NumberFormatter::MAX_FRACTION_DIGITS</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>小数部の最大桁数</simpara>
@@ -257,6 +281,7 @@
     <varlistentry xml:id="numberformatter.constants.min-fraction-digits">
      <term>
       <constant>NumberFormatter::MIN_FRACTION_DIGITS</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>小数部の最小桁数</simpara>
@@ -266,6 +291,7 @@
     <varlistentry xml:id="numberformatter.constants.fraction-digits">
      <term>
       <constant>NumberFormatter::FRACTION_DIGITS</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>小数部の桁数</simpara>
@@ -275,6 +301,7 @@
     <varlistentry xml:id="numberformatter.constants.multiplier">
      <term>
       <constant>NumberFormatter::MULTIPLIER</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>乗数</simpara>
@@ -284,6 +311,7 @@
     <varlistentry xml:id="numberformatter.constants.grouping-size">
      <term>
       <constant>NumberFormatter::GROUPING_SIZE</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>グループ化のサイズ</simpara>
@@ -293,6 +321,7 @@
     <varlistentry xml:id="numberformatter.constants.rounding-mode">
      <term>
       <constant>NumberFormatter::ROUNDING_MODE</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>丸めモード</simpara>
@@ -302,6 +331,7 @@
     <varlistentry xml:id="numberformatter.constants.rounding-increment">
      <term>
       <constant>NumberFormatter::ROUNDING_INCREMENT</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>切り上げ</simpara>
@@ -311,6 +341,7 @@
     <varlistentry xml:id="numberformatter.constants.format-width">
      <term>
       <constant>NumberFormatter::FORMAT_WIDTH</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>format() の出力のパディング幅</simpara>
@@ -320,6 +351,7 @@
     <varlistentry xml:id="numberformatter.constants.padding-position">
      <term>
       <constant>NumberFormatter::PADDING_POSITION</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>
@@ -332,6 +364,7 @@
     <varlistentry xml:id="numberformatter.constants.secondary-grouping-size">
      <term>
       <constant>NumberFormatter::SECONDARY_GROUPING_SIZE</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>第二段階のグループ化のサイズ</simpara>
@@ -341,6 +374,7 @@
     <varlistentry xml:id="numberformatter.constants.significant-digits-used">
      <term>
       <constant>NumberFormatter::SIGNIFICANT_DIGITS_USED</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>有効数字を使用する</simpara>
@@ -350,6 +384,7 @@
     <varlistentry xml:id="numberformatter.constants.min-significant-digits">
      <term>
       <constant>NumberFormatter::MIN_SIGNIFICANT_DIGITS</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>有効数字の最小桁数</simpara>
@@ -359,6 +394,7 @@
     <varlistentry xml:id="numberformatter.constants.max-significant-digits">
      <term>
       <constant>NumberFormatter::MAX_SIGNIFICANT_DIGITS</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>有効数字の最大桁数</simpara>
@@ -368,6 +404,7 @@
     <varlistentry xml:id="numberformatter.constants.lenient-parse">
      <term>
       <constant>NumberFormatter::LENIENT_PARSE</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>ルールベースのフォーマットで使用する Lenient パースモード</simpara>
@@ -387,6 +424,7 @@
     <varlistentry xml:id="numberformatter.constants.positive-prefix">
      <term>
       <constant>NumberFormatter::POSITIVE_PREFIX</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>正の数のプレフィックス</simpara>
@@ -396,6 +434,7 @@
     <varlistentry xml:id="numberformatter.constants.positive-suffix">
      <term>
       <constant>NumberFormatter::POSITIVE_SUFFIX</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>正の数のサフィックス</simpara>
@@ -405,6 +444,7 @@
     <varlistentry xml:id="numberformatter.constants.negative-prefix">
      <term>
       <constant>NumberFormatter::NEGATIVE_PREFIX</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>負の数のプレフィックス</simpara>
@@ -414,6 +454,7 @@
     <varlistentry xml:id="numberformatter.constants.negative-suffix">
      <term>
       <constant>NumberFormatter::NEGATIVE_SUFFIX</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>負の数のサフィックス</simpara>
@@ -423,6 +464,7 @@
     <varlistentry xml:id="numberformatter.constants.padding-character">
      <term>
       <constant>NumberFormatter::PADDING_CHARACTER</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>余白を埋める際に使用する文字</simpara>
@@ -432,6 +474,7 @@
     <varlistentry xml:id="numberformatter.constants.currency-code">
      <term>
       <constant>NumberFormatter::CURRENCY_CODE</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>ISO 通貨コード</simpara>
@@ -441,6 +484,7 @@
     <varlistentry xml:id="numberformatter.constants.default-ruleset">
      <term>
       <constant>NumberFormatter::DEFAULT_RULESET</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>
@@ -453,6 +497,7 @@
     <varlistentry xml:id="numberformatter.constants.public-rulesets">
      <term>
       <constant>NumberFormatter::PUBLIC_RULESETS</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>
@@ -479,6 +524,7 @@
     <varlistentry xml:id="numberformatter.constants.decimal-separator-symbol">
      <term>
       <constant>NumberFormatter::DECIMAL_SEPARATOR_SYMBOL</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>小数点</simpara>
@@ -488,6 +534,7 @@
     <varlistentry xml:id="numberformatter.constants.grouping-separator-symbol">
      <term>
       <constant>NumberFormatter::GROUPING_SEPARATOR_SYMBOL</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>グループ区切り文字</simpara>
@@ -497,6 +544,7 @@
     <varlistentry xml:id="numberformatter.constants.pattern-separator-symbol">
      <term>
       <constant>NumberFormatter::PATTERN_SEPARATOR_SYMBOL</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>パターン区切り文字</simpara>
@@ -506,6 +554,7 @@
     <varlistentry xml:id="numberformatter.constants.percent-symbol">
      <term>
       <constant>NumberFormatter::PERCENT_SYMBOL</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>パーセント記号</simpara>
@@ -515,6 +564,7 @@
     <varlistentry xml:id="numberformatter.constants.zero-digit-symbol">
      <term>
       <constant>NumberFormatter::ZERO_DIGIT_SYMBOL</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>ゼロ</simpara>
@@ -524,6 +574,7 @@
     <varlistentry xml:id="numberformatter.constants.digit-symbol">
      <term>
       <constant>NumberFormatter::DIGIT_SYMBOL</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>パターン内で数字を表す文字</simpara>
@@ -533,6 +584,7 @@
     <varlistentry xml:id="numberformatter.constants.minus-sign-symbol">
      <term>
       <constant>NumberFormatter::MINUS_SIGN_SYMBOL</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>マイナス記号</simpara>
@@ -542,6 +594,7 @@
     <varlistentry xml:id="numberformatter.constants.plus-sign-symbol">
      <term>
       <constant>NumberFormatter::PLUS_SIGN_SYMBOL</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>プラス記号</simpara>
@@ -551,6 +604,7 @@
     <varlistentry xml:id="numberformatter.constants.currency-symbol">
      <term>
       <constant>NumberFormatter::CURRENCY_SYMBOL</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>通貨記号</simpara>
@@ -560,6 +614,7 @@
     <varlistentry xml:id="numberformatter.constants.intl-currency-symbol">
      <term>
       <constant>NumberFormatter::INTL_CURRENCY_SYMBOL</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>国際通貨記号</simpara>
@@ -569,6 +624,7 @@
     <varlistentry xml:id="numberformatter.constants.monetary-separator-symbol">
      <term>
       <constant>NumberFormatter::MONETARY_SEPARATOR_SYMBOL</constant>
+      <type>int</type>
     </term>
      <listitem>
       <simpara>金額の区切り文字</simpara>
@@ -578,6 +634,7 @@
     <varlistentry xml:id="numberformatter.constants.exponential-symbol">
      <term>
       <constant>NumberFormatter::EXPONENTIAL_SYMBOL</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>指数記号</simpara>
@@ -587,6 +644,7 @@
     <varlistentry xml:id="numberformatter.constants.permill-symbol">
      <term>
       <constant>NumberFormatter::PERMILL_SYMBOL</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>パーミル記号</simpara>
@@ -596,6 +654,7 @@
     <varlistentry xml:id="numberformatter.constants.pad-escape-symbol">
      <term>
       <constant>NumberFormatter::PAD_ESCAPE_SYMBOL</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>パディング文字のエスケープ記号</simpara>
@@ -605,6 +664,7 @@
     <varlistentry xml:id="numberformatter.constants.infinity-symbol">
      <term>
       <constant>NumberFormatter::INFINITY_SYMBOL</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>無限大記号</simpara>
@@ -614,6 +674,7 @@
     <varlistentry xml:id="numberformatter.constants.nan-symbol">
      <term>
       <constant>NumberFormatter::NAN_SYMBOL</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>非数値記号</simpara>
@@ -623,6 +684,7 @@
     <varlistentry xml:id="numberformatter.constants.significant-digit-symbol">
      <term>
       <constant>NumberFormatter::SIGNIFICANT_DIGIT_SYMBOL</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>有効数字記号</simpara>
@@ -632,6 +694,7 @@
     <varlistentry xml:id="numberformatter.constants.monetary-grouping-separator-symbol">
      <term>
       <constant>NumberFormatter::MONETARY_GROUPING_SEPARATOR_SYMBOL</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>金額のグループ区切り文字</simpara>
@@ -652,6 +715,7 @@
     <varlistentry xml:id="numberformatter.constants.round-ceiling">
      <term>
       <constant>NumberFormatter::ROUND_CEILING</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>正の無限大に向けて丸めるモード</simpara>
@@ -661,6 +725,7 @@
     <varlistentry xml:id="numberformatter.constants.round-down">
      <term>
       <constant>NumberFormatter::ROUND_DOWN</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>ゼロに向けて丸めるモード</simpara>
@@ -670,6 +735,7 @@
     <varlistentry xml:id="numberformatter.constants.round-floor">
      <term>
       <constant>NumberFormatter::ROUND_FLOOR</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>負の無限大に向けて丸めるモード</simpara>
@@ -679,6 +745,7 @@
     <varlistentry xml:id="numberformatter.constants.round-halfdown">
      <term>
       <constant>NumberFormatter::ROUND_HALFDOWN</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>
@@ -691,6 +758,7 @@
     <varlistentry xml:id="numberformatter.constants.round-halfeven">
      <term>
       <constant>NumberFormatter::ROUND_HALFEVEN</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>
@@ -703,6 +771,7 @@
     <varlistentry xml:id="numberformatter.constants.round-halfup">
      <term>
       <constant>NumberFormatter::ROUND_HALFUP</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>
@@ -715,6 +784,7 @@
     <varlistentry xml:id="numberformatter.constants.round-up">
      <term>
       <constant>NumberFormatter::ROUND_UP</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>ゼロから離れる方向に丸めるモード</simpara>
@@ -735,6 +805,7 @@
     <varlistentry xml:id="numberformatter.constants.pad-after-prefix">
      <term>
       <constant>NumberFormatter::PAD_AFTER_PREFIX</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>プレフィックスの後にパディング文字を入れる</simpara>
@@ -744,6 +815,7 @@
     <varlistentry xml:id="numberformatter.constants.pad-after-suffix">
      <term>
       <constant>NumberFormatter::PAD_AFTER_SUFFIX</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>サフィックスの後にパディング文字を入れる</simpara>
@@ -753,6 +825,7 @@
     <varlistentry xml:id="numberformatter.constants.pad-before-prefix">
      <term>
       <constant>NumberFormatter::PAD_BEFORE_PREFIX</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>プレフィックスの前にパディング文字を入れる</simpara>
@@ -762,6 +835,7 @@
     <varlistentry xml:id="numberformatter.constants.pad-before-suffix">
      <term>
       <constant>NumberFormatter::PAD_BEFORE_SUFFIX</constant>
+      <type>int</type>
      </term>
      <listitem>
       <simpara>サフィックスの前にパディング文字を入れる</simpara>

--- a/reference/intl/numberformatter.xml
+++ b/reference/intl/numberformatter.xml
@@ -557,6 +557,28 @@
     </simplelist>
    </para>
   </section>
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        クラス定数が型付けされました。
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
  </partintro>
 
  &reference.intl.entities.numberformatter;

--- a/reference/intl/numberformatter.xml
+++ b/reference/intl/numberformatter.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 1f68eecaa7c4c723abe72a5a040ea7b15023a5aa Maintainer: takagi Status: ready -->
 <reference xml:id="class.numberformatter" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>NumberFormatter クラス</title>
  <titleabbrev>NumberFormatter</titleabbrev>

--- a/reference/intl/spoofchecker.xml
+++ b/reference/intl/spoofchecker.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 1cf6bcae736d6c7390c90849b869474e40b9a292 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 1f68eecaa7c4c723abe72a5a040ea7b15023a5aa Maintainer: mumumu Status: ready -->
 <reference xml:id="class.spoofchecker" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>Spoofchecker クラス</title>

--- a/reference/intl/spoofchecker.xml
+++ b/reference/intl/spoofchecker.xml
@@ -146,105 +146,150 @@
    &reftitle.constants;
    <variablelist>
     <varlistentry xml:id="spoofchecker.constants.single-script-confusable">
-     <term><constant>Spoofchecker::SINGLE_SCRIPT_CONFUSABLE</constant></term>
+     <term>
+      <constant>Spoofchecker::SINGLE_SCRIPT_CONFUSABLE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="spoofchecker.constants.mixed-script-confusable">
-     <term><constant>Spoofchecker::MIXED_SCRIPT_CONFUSABLE</constant></term>
+     <term>
+      <constant>Spoofchecker::MIXED_SCRIPT_CONFUSABLE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="spoofchecker.constants.whole-script-confusable">
-     <term><constant>Spoofchecker::WHOLE_SCRIPT_CONFUSABLE</constant></term>
+     <term>
+      <constant>Spoofchecker::WHOLE_SCRIPT_CONFUSABLE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="spoofchecker.constants.any-case">
-     <term><constant>Spoofchecker::ANY_CASE</constant></term>
+     <term>
+      <constant>Spoofchecker::ANY_CASE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="spoofchecker.constants.single-script">
-     <term><constant>Spoofchecker::SINGLE_SCRIPT</constant></term>
+     <term>
+      <constant>Spoofchecker::SINGLE_SCRIPT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="spoofchecker.constants.invisible">
-     <term><constant>Spoofchecker::INVISIBLE</constant></term>
+     <term>
+      <constant>Spoofchecker::INVISIBLE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="spoofchecker.constants.char-limit">
-     <term><constant>Spoofchecker::CHAR_LIMIT</constant></term>
+     <term>
+      <constant>Spoofchecker::CHAR_LIMIT</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="spoofchecker.constants.ascii">
-     <term><constant>Spoofchecker::ASCII</constant></term>
+     <term>
+      <constant>Spoofchecker::ASCII</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="spoofchecker.constants.highly-restrictive">
-     <term><constant>Spoofchecker::HIGHLY_RESTRICTIVE</constant></term>
+     <term>
+      <constant>Spoofchecker::HIGHLY_RESTRICTIVE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="spoofchecker.constants.moderately-restrictive">
-     <term><constant>Spoofchecker::MODERATELY_RESTRICTIVE</constant></term>
+     <term>
+      <constant>Spoofchecker::MODERATELY_RESTRICTIVE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="spoofchecker.constants.minimally-restrictive">
-     <term><constant>Spoofchecker::MINIMALLY_RESTRICTIVE</constant></term>
+     <term>
+      <constant>Spoofchecker::MINIMALLY_RESTRICTIVE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="spoofchecker.constants.unrestrictive">
-     <term><constant>Spoofchecker::UNRESTRICTIVE</constant></term>
+     <term>
+      <constant>Spoofchecker::UNRESTRICTIVE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="spoofchecker.constants.single-script-restrictive">
-     <term><constant>Spoofchecker::SINGLE_SCRIPT_RESTRICTIVE</constant></term>
+     <term>
+      <constant>Spoofchecker::SINGLE_SCRIPT_RESTRICTIVE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="spoofchecker.constants.mixed-numbers">
-     <term><constant>Spoofchecker::MIXED_NUMBERS</constant></term>
+     <term>
+      <constant>Spoofchecker::MIXED_NUMBERS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="spoofchecker.constants.hidden-overlay">
-     <term><constant>Spoofchecker::HIDDEN_OVERLAY</constant></term>
+     <term>
+      <constant>Spoofchecker::HIDDEN_OVERLAY</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
@@ -263,6 +308,12 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       クラス定数が型付けされました。
+      </entry>
+     </row>
      <row>
       <entry>7.3.0</entry>
       <entry>

--- a/reference/intl/transliterator.xml
+++ b/reference/intl/transliterator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 1f68eecaa7c4c723abe72a5a040ea7b15023a5aa Maintainer: takagi Status: ready -->
 <reference xml:id="class.transliterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>Transliterator クラス</title>
  <titleabbrev>Transliterator</titleabbrev>

--- a/reference/intl/transliterator.xml
+++ b/reference/intl/transliterator.xml
@@ -81,14 +81,20 @@
    <variablelist>
 
     <varlistentry xml:id="transliterator.constants.forward">
-     <term><constant>Transliterator::FORWARD</constant></term>
+     <term>
+      <constant>Transliterator::FORWARD</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="transliterator.constants.reverse">
-     <term><constant>Transliterator::REVERSE</constant></term>
+     <term>
+      <constant>Transliterator::REVERSE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
@@ -108,6 +114,12 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        クラス定数が型付けされました。
+       </entry>
+      </row>
       <row>
        <entry>8.2.0</entry>
        <entry>

--- a/reference/intl/uconverter.xml
+++ b/reference/intl/uconverter.xml
@@ -292,287 +292,410 @@
    <variablelist>
 
     <varlistentry xml:id="uconverter.constants.reason-unassigned">
-     <term><constant>UConverter::REASON_UNASSIGNED</constant></term>
+     <term>
+      <constant>UConverter::REASON_UNASSIGNED</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="uconverter.constants.reason-illegal">
-     <term><constant>UConverter::REASON_ILLEGAL</constant></term>
+     <term>
+      <constant>UConverter::REASON_ILLEGAL</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="uconverter.constants.reason-irregular">
-     <term><constant>UConverter::REASON_IRREGULAR</constant></term>
+     <term>
+      <constant>UConverter::REASON_IRREGULAR</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="uconverter.constants.reason-reset">
-     <term><constant>UConverter::REASON_RESET</constant></term>
+     <term>
+      <constant>UConverter::REASON_RESET</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="uconverter.constants.reason-close">
-     <term><constant>UConverter::REASON_CLOSE</constant></term>
+     <term>
+      <constant>UConverter::REASON_CLOSE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="uconverter.constants.reason-clone">
-     <term><constant>UConverter::REASON_CLONE</constant></term>
+     <term>
+      <constant>UConverter::REASON_CLONE</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="uconverter.constants.unsupported-converter">
-     <term><constant>UConverter::UNSUPPORTED_CONVERTER</constant></term>
+     <term>
+      <constant>UConverter::UNSUPPORTED_CONVERTER</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="uconverter.constants.sbcs">
-     <term><constant>UConverter::SBCS</constant></term>
+     <term>
+      <constant>UConverter::SBCS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="uconverter.constants.dbcs">
-     <term><constant>UConverter::DBCS</constant></term>
+     <term>
+      <constant>UConverter::DBCS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="uconverter.constants.mbcs">
-     <term><constant>UConverter::MBCS</constant></term>
+     <term>
+      <constant>UConverter::MBCS</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="uconverter.constants.latin-1">
-     <term><constant>UConverter::LATIN_1</constant></term>
+     <term>
+      <constant>UConverter::LATIN_1</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="uconverter.constants.utf8">
-     <term><constant>UConverter::UTF8</constant></term>
+     <term>
+      <constant>UConverter::UTF8</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="uconverter.constants.utf16-bigendian">
-     <term><constant>UConverter::UTF16_BigEndian</constant></term>
+     <term>
+      <constant>UConverter::UTF16_BigEndian</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="uconverter.constants.utf16-littleendian">
-     <term><constant>UConverter::UTF16_LittleEndian</constant></term>
+     <term>
+      <constant>UConverter::UTF16_LittleEndian</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="uconverter.constants.utf32-bigendian">
-     <term><constant>UConverter::UTF32_BigEndian</constant></term>
+     <term>
+      <constant>UConverter::UTF32_BigEndian</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="uconverter.constants.utf32-littleendian">
-     <term><constant>UConverter::UTF32_LittleEndian</constant></term>
+     <term>
+      <constant>UConverter::UTF32_LittleEndian</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="uconverter.constants.ebcdic-stateful">
-     <term><constant>UConverter::EBCDIC_STATEFUL</constant></term>
+     <term>
+      <constant>UConverter::EBCDIC_STATEFUL</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="uconverter.constants.iso-2022">
-     <term><constant>UConverter::ISO_2022</constant></term>
+     <term>
+      <constant>UConverter::ISO_2022</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="uconverter.constants.lmbcs-1">
-     <term><constant>UConverter::LMBCS_1</constant></term>
+     <term>
+      <constant>UConverter::LMBCS_1</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="uconverter.constants.lmbcs-2">
-     <term><constant>UConverter::LMBCS_2</constant></term>
+     <term>
+      <constant>UConverter::LMBCS_2</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="uconverter.constants.lmbcs-3">
-     <term><constant>UConverter::LMBCS_3</constant></term>
+     <term>
+      <constant>UConverter::LMBCS_3</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="uconverter.constants.lmbcs-4">
-     <term><constant>UConverter::LMBCS_4</constant></term>
+     <term>
+      <constant>UConverter::LMBCS_4</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="uconverter.constants.lmbcs-5">
-     <term><constant>UConverter::LMBCS_5</constant></term>
+     <term>
+      <constant>UConverter::LMBCS_5</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="uconverter.constants.lmbcs-6">
-     <term><constant>UConverter::LMBCS_6</constant></term>
+     <term>
+      <constant>UConverter::LMBCS_6</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="uconverter.constants.lmbcs-8">
-     <term><constant>UConverter::LMBCS_8</constant></term>
+     <term>
+      <constant>UConverter::LMBCS_8</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="uconverter.constants.lmbcs-11">
-     <term><constant>UConverter::LMBCS_11</constant></term>
+     <term>
+      <constant>UConverter::LMBCS_11</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="uconverter.constants.lmbcs-16">
-     <term><constant>UConverter::LMBCS_16</constant></term>
+     <term>
+      <constant>UConverter::LMBCS_16</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="uconverter.constants.lmbcs-17">
-     <term><constant>UConverter::LMBCS_17</constant></term>
+     <term>
+      <constant>UConverter::LMBCS_17</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="uconverter.constants.lmbcs-18">
-     <term><constant>UConverter::LMBCS_18</constant></term>
+     <term>
+      <constant>UConverter::LMBCS_18</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="uconverter.constants.lmbcs-19">
-     <term><constant>UConverter::LMBCS_19</constant></term>
+     <term>
+      <constant>UConverter::LMBCS_19</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="uconverter.constants.lmbcs-last">
-     <term><constant>UConverter::LMBCS_LAST</constant></term>
+     <term>
+      <constant>UConverter::LMBCS_LAST</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="uconverter.constants.hz">
-     <term><constant>UConverter::HZ</constant></term>
+     <term>
+      <constant>UConverter::HZ</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="uconverter.constants.scsu">
-     <term><constant>UConverter::SCSU</constant></term>
+     <term>
+      <constant>UConverter::SCSU</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="uconverter.constants.iscii">
-     <term><constant>UConverter::ISCII</constant></term>
+     <term>
+      <constant>UConverter::ISCII</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="uconverter.constants.us-ascii">
-     <term><constant>UConverter::US_ASCII</constant></term>
+     <term>
+      <constant>UConverter::US_ASCII</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="uconverter.constants.utf7">
-     <term><constant>UConverter::UTF7</constant></term>
+     <term>
+      <constant>UConverter::UTF7</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="uconverter.constants.bocu1">
-     <term><constant>UConverter::BOCU1</constant></term>
+     <term>
+      <constant>UConverter::BOCU1</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="uconverter.constants.utf16">
-     <term><constant>UConverter::UTF16</constant></term>
+     <term>
+      <constant>UConverter::UTF16</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="uconverter.constants.utf32">
-     <term><constant>UConverter::UTF32</constant></term>
+     <term>
+      <constant>UConverter::UTF32</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="uconverter.constants.cesu8">
-     <term><constant>UConverter::CESU8</constant></term>
+     <term>
+      <constant>UConverter::CESU8</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="uconverter.constants.imap-mailbox">
-     <term><constant>UConverter::IMAP_MAILBOX</constant></term>
+     <term>
+      <constant>UConverter::IMAP_MAILBOX</constant>
+      <type>int</type>
+     </term>
      <listitem>
       <para/>
      </listitem>
@@ -582,6 +705,27 @@
   </section>
 <!-- }}} -->
 
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        クラス定数が型付けされました。
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
 
  </partintro>
 

--- a/reference/intl/uconverter.xml
+++ b/reference/intl/uconverter.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 1f68eecaa7c4c723abe72a5a040ea7b15023a5aa Maintainer: mumumu Status: ready -->
 <reference xml:id="class.uconverter" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>UConverter クラス</title>


### PR DESCRIPTION
refs https://github.com/php/doc-ja/issues/150

https://github.com/php/doc-en/pull/4238 の翻訳です
