### PR TITLE
Move JSON_ERROR_NON_BACKED_ENUM constant

### DIFF
--- a/reference/json/constants.xml
+++ b/reference/json/constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 02b1d42099b98f45609d49fde36d10893ad0a314 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 40e4bf862f9c23ffe871a68baebf31f753d4293b Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <appendix xml:id="json.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.constants;
@@ -141,6 +141,19 @@
     <simpara>
      <function>json_decode</function> に渡された JSON 文字列の中に、
      単一の、ペアになっていない UTF-16 のサロゲートコードポイントが含まれていました。
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.json-error-non-backed-enum">
+   <term>
+    <constant>JSON_ERROR_NON_BACKED_ENUM</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     <function>json_encode</function> に渡される値のうち、
+     シリアライズできなかった Backed Enum でない値を含んでいることを示します。
+     PHP 8.1.0 以降で使用可能です。
     </simpara>
    </listitem>
   </varlistentry>
@@ -368,19 +381,6 @@
      <constant>JSON_PARTIAL_OUTPUT_ON_ERROR</constant> は
      <constant>JSON_THROW_ON_ERROR</constant> よりも優先します。
      PHP 7.3.0 以降で使用可能です。
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.json-error-non-backed-enum">
-   <term>
-    <constant>JSON_ERROR_NON_BACKED_ENUM</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     <function>json_encode</function> に渡される値のうち、
-     シリアライズできなかった Backed Enum でない値を含んでいることを示します。
-     PHP 8.1.0 以降で使用可能です。
     </simpara>
    </listitem>
   </varlistentry>


### PR DESCRIPTION
https://github.com/php/doc-en/pull/4524 の日本語版への反映です。

`JSON_ERROR_NON_BACKED_ENUM`を、エラーを表す定数が並んでいる位置に移動させています。