### PR TITLE
array_udiffの説明を更新

### DIFF
--- a/reference/array/functions/array-udiff.xml
+++ b/reference/array/functions/array-udiff.xml
@@ -16,8 +16,8 @@
   </methodsynopsis>
   <para>
    データの比較にコールバック関数を用い、配列の差を計算します。
-   この関数は <function>array_diff</function> と異なり、
-   データの比較に内部関数を利用します。
+   この関数は、データの比較に内部関数を利用する
+   <function>array_diff</function> とは異なります。
   </para>
  </refsect1>
  <refsect1 role="parameters">


### PR DESCRIPTION
`array_udiff`が内部関数を利用するかのような記述になっていたのを修正しています。

参考：[原文](https://www.php.net/manual/en/function.array-udiff.php)