### PR TITLE
Document FPM memory peak status field を取り込み (#4335)

### DIFF
--- a/reference/fpm/status.xml
+++ b/reference/fpm/status.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 2c4f02dcf9781000405646b9b21f9182aea76496 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: a4429100780d1d0d6ce204c11ad223f6526990ab Maintainer: mumumu Status: ready -->
 
 <sect1 xml:id="fpm.status" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>FPM の情報ページ</title>
@@ -187,6 +187,12 @@
       <entry>
        設定した <literal>request_slowlog_timeout</literal>
        に到達したリクエストの合計
+      </entry>
+     </row>
+     <row>
+      <entry>memory peak</entry>
+      <entry>
+       FPM が起動してからのメモリ使用量の最大値
       </entry>
      </row>
     </tbody>


### PR DESCRIPTION
refs #150

https://github.com/php/doc-en/pull/4335 を取り込みました。