### PR TITLE
PHP 8.4: Document errors for XSLTProcessor::importStylesheet() を取り込み (#4136)

### DIFF
--- a/reference/xsl/xsltprocessor/importstylesheet.xml
+++ b/reference/xsl/xsltprocessor/importstylesheet.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 07e6a4aaa2d28b6218a362b05e573fb13267358d Maintainer: takagi Status: ready -->
+<!-- EN-Revision: d5ae08740fd16598ce24f7191a06665bf0ad370f Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="xsltprocessor.importstylesheet" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -40,6 +40,38 @@
   <para>
    &return.success;
   </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   <parameter>stylesheet</parameter> が XML オブジェクトでない場合、
+   <exceptionname>TypeError</exceptionname> をスローします。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       <parameter>stylesheet</parameter> が XML オブジェクトでない場合、
+       <exceptionname>ValueError</exceptionname> の代わりに
+       <exceptionname>TypeError</exceptionname> をスローするようになりました。
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
refs #150

https://github.com/php/doc-en/pull/4136 を取り込みました。