### PR TITLE
#278 で誤って翻訳がスキップされたコミットを翻訳

### DIFF
--- a/reference/intl/numberformatter-constants.xml
+++ b/reference/intl/numberformatter-constants.xml
@@ -802,9 +802,9 @@
      </listitem>
     </varlistentry>
 
-    <varlistentry xml:id="numberformatter.constants.round-towards-zero">
+    <varlistentry xml:id="numberformatter.constants.round-toward-zero">
      <term>
-      <constant>NumberFormatter::ROUND_TOWARDS_ZERO</constant>
+      <constant>NumberFormatter::ROUND_TOWARD_ZERO</constant>
      </term>
      <listitem>
       <simpara><constant>NumberFormatter::ROUND_DOWN</constant> &Alias;</simpara>

--- a/reference/intl/numberformatter-constants.xml
+++ b/reference/intl/numberformatter-constants.xml
@@ -712,6 +712,15 @@
    <constant>NumberFormatter::ROUNDING_MODE</constant>
    属性に使用する丸めモードの値です。
    <variablelist>
+    <varlistentry xml:id="numberformatter.constants.round-away-from-zero">
+     <term>
+      <constant>NumberFormatter::ROUND_AWAY_FROM_ZERO</constant>
+     </term>
+     <listitem>
+      <simpara><constant>NumberFormatter::ROUND_UP</constant> &Alias;</simpara>
+     </listitem>
+    </varlistentry>
+
     <varlistentry xml:id="numberformatter.constants.round-ceiling">
      <term>
       <constant>NumberFormatter::ROUND_CEILING</constant>
@@ -768,6 +777,18 @@
      </listitem>
     </varlistentry>
 
+    <varlistentry xml:id="numberformatter.constants.round-halfodd">
+     <term>
+      <constant>NumberFormatter::ROUND_HALFODD</constant>
+     </term>
+     <listitem>
+      <simpara>
+       "一番近いところ" に向けて丸めるモード。
+       両方から等距離にある場合は奇数になるように丸めます。
+      </simpara>
+     </listitem>
+    </varlistentry>
+
     <varlistentry xml:id="numberformatter.constants.round-halfup">
      <term>
       <constant>NumberFormatter::ROUND_HALFUP</constant>
@@ -778,6 +799,15 @@
        "一番近いところ" に向けて丸めるモード。
        両方から等距離にある場合はゼロから離れる方向に丸めます。
       </simpara>
+     </listitem>
+    </varlistentry>
+
+    <varlistentry xml:id="numberformatter.constants.round-towards-zero">
+     <term>
+      <constant>NumberFormatter::ROUND_TOWARDS_ZERO</constant>
+     </term>
+     <listitem>
+      <simpara><constant>NumberFormatter::ROUND_DOWN</constant> &Alias;</simpara>
      </listitem>
     </varlistentry>
 

--- a/reference/intl/numberformatter.xml
+++ b/reference/intl/numberformatter.xml
@@ -137,12 +137,6 @@
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="numberformatter.constants.round-away-from-zero">NumberFormatter::ROUND_AWAY_FROM_ZERO</varname>
-    </fieldsynopsis>
-    <fieldsynopsis>
-     <modifier>public</modifier>
-     <modifier>const</modifier>
-     <type>int</type>
      <varname linkend="numberformatter.constants.round-ceiling">NumberFormatter::ROUND_CEILING</varname>
     </fieldsynopsis>
     <fieldsynopsis>
@@ -161,13 +155,19 @@
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
+     <varname linkend="numberformatter.constants.round-up">NumberFormatter::ROUND_UP</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
      <varname linkend="numberformatter.constants.round-toward-zero">NumberFormatter::ROUND_TOWARD_ZERO</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="numberformatter.constants.round-up">NumberFormatter::ROUND_UP</varname>
+     <varname linkend="numberformatter.constants.round-away-from-zero">NumberFormatter::ROUND_AWAY_FROM_ZERO</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
@@ -179,13 +179,13 @@
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="numberformatter.constants.round-halfdown">NumberFormatter::ROUND_HALFDOWN</varname>
+     <varname linkend="numberformatter.constants.round-halfodd">NumberFormatter::ROUND_HALFODD</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="numberformatter.constants.round-halfodd">NumberFormatter::ROUND_HALFODD</varname>
+     <varname linkend="numberformatter.constants.round-halfdown">NumberFormatter::ROUND_HALFDOWN</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>

--- a/reference/intl/numberformatter.xml
+++ b/reference/intl/numberformatter.xml
@@ -137,6 +137,12 @@
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
+     <varname linkend="numberformatter.constants.round-away-from-zero">NumberFormatter::ROUND_AWAY_FROM_ZERO</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
      <varname linkend="numberformatter.constants.round-ceiling">NumberFormatter::ROUND_CEILING</varname>
     </fieldsynopsis>
     <fieldsynopsis>
@@ -155,6 +161,12 @@
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
+     <varname linkend="numberformatter.constants.round-towards-zero">NumberFormatter::ROUND_TOWARDS_ZERO</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
      <varname linkend="numberformatter.constants.round-up">NumberFormatter::ROUND_UP</varname>
     </fieldsynopsis>
     <fieldsynopsis>
@@ -168,6 +180,12 @@
      <modifier>const</modifier>
      <type>int</type>
      <varname linkend="numberformatter.constants.round-halfdown">NumberFormatter::ROUND_HALFDOWN</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="numberformatter.constants.round-halfodd">NumberFormatter::ROUND_HALFODD</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>

--- a/reference/intl/numberformatter.xml
+++ b/reference/intl/numberformatter.xml
@@ -161,7 +161,7 @@
      <modifier>public</modifier>
      <modifier>const</modifier>
      <type>int</type>
-     <varname linkend="numberformatter.constants.round-towards-zero">NumberFormatter::ROUND_TOWARDS_ZERO</varname>
+     <varname linkend="numberformatter.constants.round-toward-zero">NumberFormatter::ROUND_TOWARD_ZERO</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>


### PR DESCRIPTION
#278 で翻訳されたファイルのうちの 2つ

* `reference/intl/numberformatter-constants.xml`
* `reference/intl/numberformatter.xml`

は、いくつかの英語版のコミットが翻訳されておらず、PR 時点における最新のコミットの翻訳しか反映されていませんでした。適用が漏れていたコミットは以下のとおりです。

* `reference/intl/numberformatter-constants.xml`
    * https://github.com/php/doc-en/commit/d3ee29b81082ab9c71853f5c77e7540d0b3cf273#diff-20915323c50190eb1b6f8226d26aa5bc013d8f6aaa740f62d20b5923870d47f3
    * https://github.com/php/doc-en/commit/9fb67f09452eb6e7ba256ba890506334227b0f75#diff-20915323c50190eb1b6f8226d26aa5bc013d8f6aaa740f62d20b5923870d47f3
* `reference/intl/numberformatter.xml`
    * https://github.com/php/doc-en/commit/d3ee29b81082ab9c71853f5c77e7540d0b3cf273#diff-cde29b7ce728a4314382c031fa54bdda5902f63e0bf8068a3be7cc7e2bb716bc
    * https://github.com/php/doc-en/commit/9fb67f09452eb6e7ba256ba890506334227b0f75#diff-cde29b7ce728a4314382c031fa54bdda5902f63e0bf8068a3be7cc7e2bb716bc
    * https://github.com/php/doc-en/commit/18aa2012f6fa1e5b09733147e02911d16e06d4a1#diff-cde29b7ce728a4314382c031fa54bdda5902f63e0bf8068a3be7cc7e2bb716bc

これらについて翻訳をおこないました。