### PR TITLE
[PHP 8.4] intl update part 2 を取り込み (#4207)

### DIFF
--- a/reference/intl/intlcalendar/set.xml
+++ b/reference/intl/intlcalendar/set.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 2ca090342977839edca2f7f4e52305a1b5da6095 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: d3ee29b81082ab9c71853f5c77e7540d0b3cf273 Maintainer: mumumu Status: ready -->
 <refentry xml:id="intlcalendar.set" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>IntlCalendar::set</refname>
@@ -153,21 +153,27 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      &return.type.true;
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &return.type.true;
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       このメソッドは非推奨となりました。
+       代わりに <methodname>IntlCalendar::setDate</methodname> や
+       <methodname>IntlCalendar::setDateTime</methodname> を使用してください。
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/intl/intlgregoriancalendar/construct.xml
+++ b/reference/intl/intlgregoriancalendar/construct.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: d3ee29b81082ab9c71853f5c77e7540d0b3cf273 Maintainer: mumumu Status: ready -->
 
 <refentry xml:id="intlgregoriancalendar.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -106,6 +106,30 @@
     </listitem>
    </varlistentry>
   </variablelist>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       このコンストラクタは非推奨となりました。
+       代わりに <methodname>IntlGregorianCalendar::createFromDate</methodname> や
+       <methodname>IntlGregorianCalendar::createFromDateTime</methodname> を使用してください。
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
 </refentry>


### PR DESCRIPTION
refs #150

https://github.com/php/doc-en/pull/4207 を取り込みました。

英語版の PR で変更された 4ファイルのうち以下の 2ファイルは #288 に含まれているため、この PR では変更していません。

* `reference/intl/numberformatter-constants.xml`
* `reference/intl/numberformatter.xml`