### PR TITLE
#257 で誤って翻訳がスキップされたコミットを翻訳 (part 1/2)

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1640,6 +1640,12 @@ object</parameter></term><listitem><para>手続き型のみ: <function>date_crea
 が使えます。
 </para>'>
 <!ENTITY dom.note.utf8 '<note xmlns="http://docbook.org/ns/docbook"><para>DOM拡張モジュール は UTF-8 エンコーディングを使います。他のエンコーディングを扱う場合は、<function>mb_convert_encoding</function>, <methodname>UConverter::transcode</methodname>, <function>iconv</function> を使ってください。</para></note>'>
+<!ENTITY dom.note.modern.utf8 '<note xmlns="http://docbook.org/ns/docbook">
+ <simpara>
+  DOM拡張モジュールは、メソッドやプロパティで UTF-8 エンコーディングを使います。
+  パースをおこなうメソッドは、エンコーディングを自動的に判別し、呼び出し側でエンコーディングを指定することもできます。
+ </simpara>
+</note>'>
 <!ENTITY dom.note.json '<note xmlns="http://docbook.org/ns/docbook"><para><classname>DOMDocument</classname> オブジェクトに対して <function>json_encode</function> を使うと、結果は空オブジェクトをエンコードしたものになります。</para></note>'>
 <!ENTITY dom.domdocument.html5 '<warning xmlns="http://docbook.org/ns/docbook">
  <simpara>

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1642,20 +1642,24 @@ object</parameter></term><listitem><para>手続き型のみ: <function>date_crea
 <!ENTITY dom.note.utf8 '<note xmlns="http://docbook.org/ns/docbook"><para>DOM拡張モジュール は UTF-8 エンコーディングを使います。他のエンコーディングを扱う場合は、<function>mb_convert_encoding</function>, <methodname>UConverter::transcode</methodname>, <function>iconv</function> を使ってください。</para></note>'>
 <!ENTITY dom.note.json '<note xmlns="http://docbook.org/ns/docbook"><para><classname>DOMDocument</classname> オブジェクトに対して <function>json_encode</function> を使うと、結果は空オブジェクトをエンコードしたものになります。</para></note>'>
 <!ENTITY dom.domdocument.html5 '<warning xmlns="http://docbook.org/ns/docbook">
- <para>
+ <simpara>
+  モダンな HTML をパースしたり処理したりするには、<classname>DOMDocument</classname> の代わりに
+  <classname>Dom\HTMLDocument</classname> を使ってください。
+ </simpara>
+ <simpara>
   この関数は、HTML4 のパーサを使って入力をパースします。モダンなWebブラウザが採用している HTML5 のパースルールとは異なります。入力によっては、このことが原因で異なるDOM構造になるかもしれません。よって、この関数はHTMLを無害化する目的で安全に使えません。
- </para>
- <para>
+ </simpara>
+ <simpara>
   HTML をパースする挙動は、利用している 
   <literal>libxml</literal> のバージョンに依存します。
   特にエッジケースやエラーハンドリングについてそれが当てはまります。
   HTML5 に準拠したパースを行うには、PHP 8.4 で追加される
   <methodname>Dom\HTMLDocument::createFromString</methodname> や
   <methodname>Dom\HTMLDocument::createFromFile</methodname> を使いましょう。
- </para>
- <para>
+ </simpara>
+ <simpara>
   例を挙げましょう。HTML要素によっては、暗黙のうちに親の要素を閉じるものがあります。親要素を自動で閉じるルールは、HTML4 と HTML5 で異なります。よって、<classname>DOMDocument</classname> が表す DOM 構造は Webブラウザ上のそれと異なる可能性があります。このことから、攻撃者がHTMLを壊す攻撃を許す可能性があります。
- </para>
+ </simpara>
 </warning>'>
 
 

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1800,8 +1800,14 @@ object</parameter></term><listitem><para>手続き型のみ: <function>date_crea
 <!ENTITY haru.error '<para xmlns="http://docbook.org/ns/docbook">エラー時に <classname>HaruException</classname> をスローします。</para>'>
 
 <!-- ODBC -->
-<!ENTITY odbc.connection.id '<para xmlns="http://docbook.org/ns/docbook">ODBC 接続 ID。詳細は
+<!ENTITY odbc.connection.id '<para xmlns="http://docbook.org/ns/docbook">ODBC 接続オブジェクト。詳細は
 <function>odbc_connect</function> を参照ください。</para>'>
+
+<!ENTITY odbc.result.object 'ODBC 結果オブジェクト'>
+
+<!ENTITY odbc.result.object-return 'ODBC 結果オブジェクトを返します'>
+
+<!ENTITY odbc.result.object-return-falseforfailure '&odbc.result.object-return;。&return.falseforfailure;。'>
 
 <!ENTITY odbc.parameter.catalog 'カタログ(ODBC 2 の用語では &apos;修飾子&apos;)。'>
 
@@ -1812,6 +1818,39 @@ object</parameter></term><listitem><para>手続き型のみ: <function>date_crea
 <literal xmlns="http://docbook.org/ns/docbook">_</literal> はひとつの文字にマッチします。'>
 
 <!ENTITY odbc.result.driver-specific 'ドライバは追加のカラムを返すことが出来ます。'>
+
+<!ENTITY odbc.changelog.connection-param '<row xmlns="http://docbook.org/ns/docbook">
+ <entry>8.4.0</entry>
+ <entry>
+  引数 <parameter>odbc</parameter> は、<classname>Odbc\Connection</classname> クラスのインスタンスを期待するようになりました。
+  これより前のバージョンでは、<type>resource</type> を期待していました。
+ </entry>
+</row>'>
+
+<!ENTITY odbc.changelog.connection-return '&odbc.changelog.connection-param;
+ <row xmlns="http://docbook.org/ns/docbook">
+  <entry>8.4.0</entry>
+  <entry>
+   この関数は <classname>Odbc\Connection</classname> クラスのインスタンスを返すようになりました。
+   これより前のバージョンでは、<type>resource</type> を返していました。
+  </entry>
+ </row>'>
+
+<!ENTITY odbc.changelog.result-param '<row xmlns="http://docbook.org/ns/docbook">
+ <entry>8.4.0</entry>
+ <entry>
+  引数 <parameter>statement</parameter> は、<classname>Odbc\Result</classname> クラスのインスタンスを期待するようになりました。
+  これより前のバージョンでは、<type>resource</type> を期待していました。
+ </entry>
+</row>'>
+
+<!ENTITY odbc.changelog.result-return '<row xmlns="http://docbook.org/ns/docbook">
+ <entry>8.4.0</entry>
+ <entry>
+  この関数は <classname>Odbc\Result</classname> クラスのインスタンスを返すようになりました。
+  これより前のバージョンでは、<type>resource</type> を返していました。
+ </entry>
+</row>'>
 
 <!-- OAUTH -->
 <!ENTITY oauth.callback.error 'コールバック関数をコールできなかったり、

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -2052,6 +2052,10 @@ PECL 拡張モジュールのインストール</link> という章にありま�
 この拡張モジュールは &link.pecl; レポジトリに移動
 されており、以下のバージョン以降 PHP にバンドルされなくなっています。 PHP '>
 
+<!ENTITY warn.pecl.unmaintained '<warning xmlns="http://docbook.org/ns/docbook">
+ <simpara>この拡張モジュールは、<emphasis>メンテナンスされていません</emphasis>。</simpara>
+</warning>'>
+
 <!-- PGSQL entities -->
 
 <!ENTITY pgsql.parameter.connection '<para xmlns="http://docbook.org/ns/docbook"><classname>PgSql\Connection</classname> クラスのインスタンス。</para>'>

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -4941,7 +4941,7 @@ local: {
    </para>
    <para>
     省略した場合は <constant>FILTER_DEFAULT</constant> を使います。これは
-    <link linkend="filter.filters.sanitize"><constant>FILTER_UNSAFE_RAW</constant></link> と同等です。
+    <constant>FILTER_UNSAFE_RAW</constant> と同等です。
     結果的に、デフォルトでは何もフィルタリングをしません。
    </para>
   </listitem>

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -762,13 +762,7 @@ DLL ファイルを PHP のフォルダから Windows のシステムディレ�
 <!ENTITY style.oop 'オブジェクト指向型'>
 <!ENTITY style.procedural '手続き型'>
 
-<!ENTITY resource '<link xmlns="http://docbook.org/ns/docbook" linkend="language.types.resource">リソース</link>'>
-
-<!ENTITY foreach '<link xmlns="http://docbook.org/ns/docbook" linkend="control-structures.foreach">foreach</link>'>
-
 <!ENTITY match '<link xmlns="http://docbook.org/ns/docbook" linkend="control-structures.match">match</link>'>
-
-<!ENTITY yield '<link xmlns="http://docbook.org/ns/docbook" linkend="control-structures.yield">yield</link>'>
 
 <!ENTITY parameter.context '<literal xmlns="http://docbook.org/ns/docbook">コンテキスト</literal> についての説明は、
 マニュアルの <link xmlns="http://docbook.org/ns/docbook" linkend="context">コンテキスト</link> の節を参照ください。'>

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -2150,6 +2150,12 @@ PHP 8.1.0 以降は、ctype関数 に文字列でない引数を渡すことは�
 <!-- GMP Notes -->
 <!ENTITY gmp.return '<classname xmlns="http://docbook.org/ns/docbook">GMP</classname> オブジェクトを返します。'>
 <!ENTITY gmp.parameter '<para xmlns="http://docbook.org/ns/docbook"><classname>GMP</classname> オブジェクト、整数、あるいは数値に変換可能な数値形式の文字列。</para>'>
+<!ENTITY gmp.parameter '<para xmlns="http://docbook.org/ns/docbook">
+ <classname>GMP</classname> オブジェクト、&integer;、
+ あるいは数値として解釈可能な &string;。
+ 文字列の場合、<function>gmp_init</function> で基数を自動検出するとき
+ (<parameter>base</parameter> に 0 を指定したとき) と同じ方法で解釈されます。
+</para>'>
 
 <!-- MySQLi Notes -->
 <!ENTITY mysqli.result.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>result</parameter></term><listitem>

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -4941,17 +4941,21 @@ local: {
 '>
 
 <!-- filter snippets -->
+<!-- TODO: Remove -->
 <!ENTITY filter.param.filter '
  <varlistentry xmlns="http://docbook.org/ns/docbook">
   <term><parameter>filter</parameter></term>
   <listitem>
    <para>
-    適用するフィルタの ID。<xref linkend="filter.filters" />
-    に、利用できるフィルタの一覧があります。
+    適用するフィルタ。
+    <constant>FILTER_VALIDATE_<replaceable>*</replaceable></constant> 定数の一つを用いた検証フィルタ、
+    <constant>FILTER_SANITIZE_<replaceable>*</replaceable></constant> 定数の一つを用いた除去フィルタ、
+    <constant>FILTER_UNSAFE_RAW</constant>、
+    <constant>FILTER_CALLBACK</constant> を用いたカスタムフィルタのいずれかを指定できます。
    </para>
    <para>
-    省略した場合は <constant>FILTER_DEFAULT</constant> を使います。これは
-    <constant>FILTER_UNSAFE_RAW</constant> と同等です。
+    デフォルトの値は <constant>FILTER_DEFAULT</constant> で、
+    これは <constant>FILTER_UNSAFE_RAW</constant> のエイリアスです。
     結果的に、デフォルトでは何もフィルタリングをしません。
    </para>
   </listitem>


### PR DESCRIPTION
# 概要

#257 で編集されたファイルの一つ `language-snippets.ent` は、`EN-Revision` が `9cd8eb0f11edb4e59fd22f723137bbb91d6ab64f` から `3295741565f760edd22e305bd10e37f243e9e194` に更新されています。

しかし実際には、その間にあるコミットのうち以下で「**反映済**」を付けたコミットしか反映されておらず、`8b502f81f951a1af64396b69823f7a35b7637541` 以降のほとんどのコミットが翻訳されていない状態です。

* [`9cd8eb0f11edb4e59fd22f723137bbb91d6ab64f`](https://github.com/php/doc-en/commit/9cd8eb0f11edb4e59fd22f723137bbb91d6ab64f) (from)
* [`8b502f81f951a1af64396b69823f7a35b7637541`](https://github.com/php/doc-en/commit/8b502f81f951a1af64396b69823f7a35b7637541)
* [`9a5b92a30888d6423db112f07a9b344cf6fc4891`](https://github.com/php/doc-en/commit/9a5b92a30888d6423db112f07a9b344cf6fc4891)
* [`c75f19c74fa3b64abfafd7a35aaa652b07834a5a`](https://github.com/php/doc-en/commit/c75f19c74fa3b64abfafd7a35aaa652b07834a5a)
* **反映済** [`ddb05f8827151e25dd1c3e058f95f6c024bc881b`](https://github.com/php/doc-en/commit/ddb05f8827151e25dd1c3e058f95f6c024bc881b)
* [`53054bf8decc8648cf2e90a493692a161e2371af`](https://github.com/php/doc-en/commit/53054bf8decc8648cf2e90a493692a161e2371af)
* [`ed1aff13602c94f86344bdd7c4fbc31f5a71bf84`](https://github.com/php/doc-en/commit/ed1aff13602c94f86344bdd7c4fbc31f5a71bf84)
* [`bead080a991889bf281d32095f2197e61413ac70`](https://github.com/php/doc-en/commit/bead080a991889bf281d32095f2197e61413ac70)
* [`ebbc5bb97c8c063d31309725c0bb93d21213993b`](https://github.com/php/doc-en/commit/ebbc5bb97c8c063d31309725c0bb93d21213993b)
* [`810229e31c049ee7240aad2be5694fca7901ce60`](https://github.com/php/doc-en/commit/810229e31c049ee7240aad2be5694fca7901ce60)
* [`e93feee2870bb551cd11d625271b7f82da3ccb05`](https://github.com/php/doc-en/commit/e93feee2870bb551cd11d625271b7f82da3ccb05)
* [`9b68bf2b63200534e022bc65e800cae6c75abf26`](https://github.com/php/doc-en/commit/9b68bf2b63200534e022bc65e800cae6c75abf26)
* [`32caa89e81d180f209425159e2be2f243a3e12cc`](https://github.com/php/doc-en/commit/32caa89e81d180f209425159e2be2f243a3e12cc)
* [`ffd2ef754b37526c0b96e94859d57ce06acfbf41`](https://github.com/php/doc-en/commit/ffd2ef754b37526c0b96e94859d57ce06acfbf41)
* [`a8b6f4dd3a23875b066d4e47ea4a4977a63e0655`](https://github.com/php/doc-en/commit/a8b6f4dd3a23875b066d4e47ea4a4977a63e0655)
* [`c39225b6dd23f358824f44f5b8c733517b11830b`](https://github.com/php/doc-en/commit/c39225b6dd23f358824f44f5b8c733517b11830b)
* **反映済** [`3295741565f760edd22e305bd10e37f243e9e194`](https://github.com/php/doc-en/commit/3295741565f760edd22e305bd10e37f243e9e194) (to)

現在の `EN-Revision` の実態に合わせるため、スキップされたコミットを翻訳します。

数が多いので PR を 2つに分ける予定です。これはその1つ目です。今回の翻訳分は以下の通りです。

* [`9cd8eb0f11edb4e59fd22f723137bbb91d6ab64f`](https://github.com/php/doc-en/commit/9cd8eb0f11edb4e59fd22f723137bbb91d6ab64f) (from)
* **ここから** [`8b502f81f951a1af64396b69823f7a35b7637541`](https://github.com/php/doc-en/commit/8b502f81f951a1af64396b69823f7a35b7637541)
* [`9a5b92a30888d6423db112f07a9b344cf6fc4891`](https://github.com/php/doc-en/commit/9a5b92a30888d6423db112f07a9b344cf6fc4891)
* [`c75f19c74fa3b64abfafd7a35aaa652b07834a5a`](https://github.com/php/doc-en/commit/c75f19c74fa3b64abfafd7a35aaa652b07834a5a)
* **反映済** [`ddb05f8827151e25dd1c3e058f95f6c024bc881b`](https://github.com/php/doc-en/commit/ddb05f8827151e25dd1c3e058f95f6c024bc881b)
* [`53054bf8decc8648cf2e90a493692a161e2371af`](https://github.com/php/doc-en/commit/53054bf8decc8648cf2e90a493692a161e2371af)
* [`ed1aff13602c94f86344bdd7c4fbc31f5a71bf84`](https://github.com/php/doc-en/commit/ed1aff13602c94f86344bdd7c4fbc31f5a71bf84)
* [`bead080a991889bf281d32095f2197e61413ac70`](https://github.com/php/doc-en/commit/bead080a991889bf281d32095f2197e61413ac70)
* [`ebbc5bb97c8c063d31309725c0bb93d21213993b`](https://github.com/php/doc-en/commit/ebbc5bb97c8c063d31309725c0bb93d21213993b)
* **ここまで** [`810229e31c049ee7240aad2be5694fca7901ce60`](https://github.com/php/doc-en/commit/810229e31c049ee7240aad2be5694fca7901ce60)
* [`e93feee2870bb551cd11d625271b7f82da3ccb05`](https://github.com/php/doc-en/commit/e93feee2870bb551cd11d625271b7f82da3ccb05)
* [`9b68bf2b63200534e022bc65e800cae6c75abf26`](https://github.com/php/doc-en/commit/9b68bf2b63200534e022bc65e800cae6c75abf26)
* [`32caa89e81d180f209425159e2be2f243a3e12cc`](https://github.com/php/doc-en/commit/32caa89e81d180f209425159e2be2f243a3e12cc)
* [`ffd2ef754b37526c0b96e94859d57ce06acfbf41`](https://github.com/php/doc-en/commit/ffd2ef754b37526c0b96e94859d57ce06acfbf41)
* [`a8b6f4dd3a23875b066d4e47ea4a4977a63e0655`](https://github.com/php/doc-en/commit/a8b6f4dd3a23875b066d4e47ea4a4977a63e0655)
* [`c39225b6dd23f358824f44f5b8c733517b11830b`](https://github.com/php/doc-en/commit/c39225b6dd23f358824f44f5b8c733517b11830b)
* **反映済** [`3295741565f760edd22e305bd10e37f243e9e194`](https://github.com/php/doc-en/commit/3295741565f760edd22e305bd10e37f243e9e194) (to)

# 備考

以下訳の選択等についての備考です。

## [`c75f19c74fa3b64abfafd7a35aaa652b07834a5a`](https://github.com/php/doc-en/commit/c75f19c74fa3b64abfafd7a35aaa652b07834a5a)

```
<!ENTITY gmp.parameter '<para xmlns="http://docbook.org/ns/docbook">
 A <classname>GMP</classname> object, an &integer;,
 or a &string; that can be interpreted as a number following the same logic
 as if the string was used in <function>gmp_init</function> with automatic
 base detection (i.e. when <parameter>base</parameter> is equal to 0).
</para>'>
```

```
<!ENTITY gmp.parameter '<para xmlns="http://docbook.org/ns/docbook">
 <classname>GMP</classname> オブジェクト、&integer;、
 あるいは数値として解釈可能な &string;。
 文字列の場合、<function>gmp_init</function> で基数を自動検出するとき
 (<parameter>base</parameter> に 0 を指定したとき) と同じ方法で解釈されます。
</para>'>
```

原文は "a string" の後ろの that 節で説明を記載する形の 1文で記載されていましたが、日本語でここまで長い節を作ると読みづらいので 2文に分割しました。

## [`53054bf8decc8648cf2e90a493692a161e2371af`](https://github.com/php/doc-en/commit/53054bf8decc8648cf2e90a493692a161e2371af)

```
<!-- TODO: Remove -->
```

は英語版のコメントをそのまま転記したもので、消し忘れではありません。


## [`ed1aff13602c94f86344bdd7c4fbc31f5a71bf84`](https://github.com/php/doc-en/commit/ed1aff13602c94f86344bdd7c4fbc31f5a71bf84)

"ODBC connection object" と "ODBC result object" は、今の https://www.php.net/manual/ja/function.odbc-commit.php や https://www.php.net/manual/ja/function.odbc-fetch-array.php を参考にして「ODBC 接続オブジェクト」「ODBC 結果オブジェクト」としました。