### PR TITLE
#257 で誤って翻訳がスキップされたコミットを翻訳 (part 2/2)

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1725,6 +1725,28 @@ object</parameter></term><listitem><para>手続き型のみ: <function>date_crea
   <link linkend="libxml.constants">追加の Libxml パラメータ</link> を、ビット演算子の <literal>OR</literal> で指定します。
 </para>'>
 
+<!ENTITY dom.parameter.compliant.options '&dom.parameter.options;
+ <simpara xmlns="http://docbook.org/ns/docbook">
+  <constant>Dom\HTML_NO_DEFAULT_NS</constant> を渡すことで、
+  HTML 名前空間や template 要素の使用を無効化することもできます。
+  このオプションは、及ぼす影響を十分理解している場合に限り使用すべきです。
+</simpara>'>
+
+<!ENTITY dom.parameter.compliant.encoding '<simpara xmlns="http://docbook.org/ns/docbook">
+ ドキュメントが作成されたエンコーディング。
+ 指定されていない場合、最も使用されている可能性の高いエンコーディングを判定しようとします。
+</simpara>'>
+
+<!ENTITY dom.parser.compliant.note.whitespace '<refsect1 role="notes" xmlns="http://docbook.org/ns/docbook">
+ &reftitle.notes;
+ <note>
+  <simpara>
+   <literal>html</literal> タグや <literal>head</literal> タグの中の空白は
+   必ずしも保持されません。インデント等が失われる可能性があります。
+  </simpara>
+ </note>
+</refsect1>'>
+
 <!ENTITY dom.parameters.register_node_ns '<varlistentry xmlns="http://docbook.org/ns/docbook">
  <term><parameter>registerNodeNS</parameter></term>
  <listitem>
@@ -1735,6 +1757,12 @@ object</parameter></term><listitem><para>手続き型のみ: <function>date_crea
   </para>
  </listitem>
 </varlistentry>'>
+
+<!ENTITY dom.parameters.serialize.options '<simpara xmlns="http://docbook.org/ns/docbook">
+ 追加のオプション。
+ <constant>LIBXML_NOEMPTYTAG</constant> と <constant>LIBXML_NOXMLDECL</constant> が指定できます。
+ PHP 8.3.0 より前のバージョンでは、<constant>LIBXML_NOEMPTYTAG</constant> のみサポートされていました。
+</simpara>'>
 
 <!ENTITY dom.errors.hierarchy.parent '<varlistentry xmlns="http://docbook.org/ns/docbook">
  <term><constant>DOM_HIERARCHY_REQUEST_ERR</constant></term>
@@ -1765,6 +1793,27 @@ object</parameter></term><listitem><para>手続き型のみ: <function>date_crea
   </para>
  </listitem>
 </varlistentry>'>
+
+<!ENTITY dom.errors.compliant.wrong_document '<listitem xmlns="http://docbook.org/ns/docbook">
+ <simpara>
+  <parameter>node</parameter> が別のドキュメントのものである場合、
+  エラーコード <constant>Dom\WRONG_DOCUMENT_ERR</constant> を持つ
+  <exceptionname>Dom\DOMException</exceptionname> をスローします。
+ </simpara>
+</listitem>'>
+
+<!ENTITY dom.errors.compliant.common '<listitem xmlns="http://docbook.org/ns/docbook">
+ <simpara>
+  <parameter>options</parameter> が不正なオプションを含む場合、
+  <exceptionname>ValueError</exceptionname> をスローします。
+ </simpara>
+</listitem>
+<listitem>
+ <simpara>
+  <parameter>overrideEncoding</parameter> が未知のエンコーディングである場合、
+  <exceptionname>ValueError</exceptionname> をスローします。
+ </simpara>
+</listitem>'>
 
 <!ENTITY dom.changelog.previous_hierarchy_exception 'これより前のバージョンでは、エラーコード <constant xmlns="http://docbook.org/ns/docbook">DOM_HIERARCHY_REQUEST_ERR</constant> を持つ <classname xmlns="http://docbook.org/ns/docbook">DOMException</classname> がスローされていました。'>
 

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1911,6 +1911,32 @@ object</parameter></term><listitem><para>手続き型のみ: <function>date_crea
   </entry>
  </row>'>
 
+<!ENTITY odbc.changelog.credential-params '<row xmlns="http://docbook.org/ns/docbook">
+  <entry>8.4.0</entry>
+  <entry>
+   <parameter>user</parameter> および <parameter>password</parameter> が nullable となりました。
+   また、省略できるようになり、デフォルトでは &null; となるようになりました。
+  </entry>
+ </row>
+ <row xmlns="http://docbook.org/ns/docbook">
+  <entry>8.4.0</entry>
+  <entry>
+   以前のバージョンでは、<parameter>password</parameter> に空文字列を指定した場合、
+   <parameter>dsn</parameter> に対して生成される接続文字列に <literal>pwd</literal> が含まれていませんでした。
+   このバージョンからは、空文字列が値に指定された <literal>pwd</literal> を含んだ状態で生成されるようになりました。
+   以前の挙動に戻したい場合は、<parameter>password</parameter> に &null; を指定してください。
+  </entry>
+ </row>
+ <row xmlns="http://docbook.org/ns/docbook">
+  <entry>8.4.0</entry>
+  <entry>
+   以前のバージョンでは、<parameter>dsn</parameter> に <literal>uid</literal> または <literal>pwd</literal> のいずれかが含まれていると、
+   <parameter>user</parameter> および <parameter>password</parameter> の両方が常に無視されていました。
+   このバージョンからは、<parameter>dsn</parameter> に <literal>uid</literal> が含まれている場合にのみ <parameter>user</parameter> が無視され、
+   <parameter>dsn</parameter> に <literal>pwd</literal> が含まれている場合にのみ <parameter>password</parameter> が無視されるようになりました。
+  </entry>
+ </row>'>
+
 <!ENTITY odbc.changelog.result-param '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.4.0</entry>
  <entry>

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -2638,6 +2638,9 @@ PHP 7.4 以降では <option role="configure">--with-libxml</option>、それよ
 <varname linkend="streamwrapper.props.context">streamWrapper::$context</varname>
 プロパティが更新されます。</para></note>'>
 
+<!ENTITY stream.bucket.param '<parameter>bucket</parameter> は <classname>StreamBucket</classname> のインスタンスを期待するようになりました。これより前のバージョンでは、<classname>stdClass</classname> が期待されていました。'>
+<!ENTITY stream.bucket.return 'この関数は <classname>StreamBucket</classname> のインスタンスを返すようになりました。これより前のバージョンでは、<classname>stdClass</classname> を返していました。'>
+
 <!-- Gmagick -->
 <!ENTITY gmagick.return.success '成功した場合に &true; を返します。'>
 <!ENTITY gmagick.gmagickexception.throw 'エラー時に

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1663,6 +1663,27 @@ object</parameter></term><listitem><para>手続き型のみ: <function>date_crea
  </simpara>
 </warning>'>
 
+<!ENTITY dom.tokenlist.errors '<itemizedlist xmlns="http://docbook.org/ns/docbook">
+ <listitem>
+  <simpara>
+   トークンが NULL バイトを含んでいる場合、
+   <exceptionname>ValueError</exceptionname> をスローします。
+  </simpara>
+ </listitem>
+ <listitem>
+  <simpara>
+   トークンが空文字列である場合、エラーコード <constant>Dom\SYNTAX_ERR</constant> を持つ
+   <exceptionname>Dom\DOMException</exceptionname> をスローします。
+  </simpara>
+ </listitem>
+ <listitem>
+  <simpara>
+   トークンが ASCII の空白文字を含む場合、エラーコード <constant>Dom\INVALID_CHARACTER_ERR</constant> を持つ
+   <exceptionname>Dom\DOMException</exceptionname> をスローします。
+  </simpara>
+ </listitem>
+</itemizedlist>'>
+
 
 
 <!-- Dom Examples -->

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -817,8 +817,9 @@ DLL ファイルを PHP のフォルダから Windows のシステムディレ�
 <!ENTITY standard.changelog.binary-safe-string-comparison '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.2.0</entry>
  <entry>
-  これより前のバージョンで負の数と正の数を返していた場合に、
-  この関数は <literal>-1</literal> と <literal>1</literal> を返すようになりました。
+  この関数は、2つの文字列の長さが等しくない場合に
+  <code>strlen($string1) - strlen($string2)</code> を返すとは限らなくなりました。
+  代わりに、<literal>-1</literal> や <literal>1</literal> を返す可能性があります。
  </entry>
 </row>
 '>
@@ -4954,6 +4955,15 @@ local: {
    これより前のバージョンでは、代わりに &false; を返し、<constant>E_WARNING</constant>
    を発生させていました。
   </para>
+'>
+
+<!ENTITY strings.comparison.return '
+  <simpara xmlns="http://docbook.org/ns/docbook">
+   <parameter>string1</parameter> が <parameter>string2</parameter> より小さければ 0 より小さな値を、
+   <parameter>string1</parameter> が <parameter>string2</parameter> より大きければ 0 より大きな値を、
+   両者が等しければ <literal>0</literal> を返します。
+   返却される値の絶対値に、特に意味はありません。
+  </simpara>
 '>
 
 <!-- filter snippets -->


### PR DESCRIPTION
# 概要

#292 の続きです。主な目的はそちらを参照してください。

今回の翻訳分は以下の通りです。

* [`9cd8eb0f11edb4e59fd22f723137bbb91d6ab64f`](https://github.com/php/doc-en/commit/9cd8eb0f11edb4e59fd22f723137bbb91d6ab64f) (from)
* #292 で反映済 [`8b502f81f951a1af64396b69823f7a35b7637541`](https://github.com/php/doc-en/commit/8b502f81f951a1af64396b69823f7a35b7637541)
* #292 で反映済 [`9a5b92a30888d6423db112f07a9b344cf6fc4891`](https://github.com/php/doc-en/commit/9a5b92a30888d6423db112f07a9b344cf6fc4891)
* #292 で反映済 [`c75f19c74fa3b64abfafd7a35aaa652b07834a5a`](https://github.com/php/doc-en/commit/c75f19c74fa3b64abfafd7a35aaa652b07834a5a)
* #257 で反映済 [`ddb05f8827151e25dd1c3e058f95f6c024bc881b`](https://github.com/php/doc-en/commit/ddb05f8827151e25dd1c3e058f95f6c024bc881b)
* #292 で反映済 [`53054bf8decc8648cf2e90a493692a161e2371af`](https://github.com/php/doc-en/commit/53054bf8decc8648cf2e90a493692a161e2371af)
* #292 で反映済 [`ed1aff13602c94f86344bdd7c4fbc31f5a71bf84`](https://github.com/php/doc-en/commit/ed1aff13602c94f86344bdd7c4fbc31f5a71bf84)
* #292 で反映済 [`bead080a991889bf281d32095f2197e61413ac70`](https://github.com/php/doc-en/commit/bead080a991889bf281d32095f2197e61413ac70)
* #292 で反映済 [`ebbc5bb97c8c063d31309725c0bb93d21213993b`](https://github.com/php/doc-en/commit/ebbc5bb97c8c063d31309725c0bb93d21213993b)
* #292 で反映済 [`810229e31c049ee7240aad2be5694fca7901ce60`](https://github.com/php/doc-en/commit/810229e31c049ee7240aad2be5694fca7901ce60)
* #293 で反映済 [`e93feee2870bb551cd11d625271b7f82da3ccb05`](https://github.com/php/doc-en/commit/e93feee2870bb551cd11d625271b7f82da3ccb05)
* **ここから** [`9b68bf2b63200534e022bc65e800cae6c75abf26`](https://github.com/php/doc-en/commit/9b68bf2b63200534e022bc65e800cae6c75abf26)
* [`32caa89e81d180f209425159e2be2f243a3e12cc`](https://github.com/php/doc-en/commit/32caa89e81d180f209425159e2be2f243a3e12cc)
* [`ffd2ef754b37526c0b96e94859d57ce06acfbf41`](https://github.com/php/doc-en/commit/ffd2ef754b37526c0b96e94859d57ce06acfbf41)
* [`a8b6f4dd3a23875b066d4e47ea4a4977a63e0655`](https://github.com/php/doc-en/commit/a8b6f4dd3a23875b066d4e47ea4a4977a63e0655)
* **ここまで** [`c39225b6dd23f358824f44f5b8c733517b11830b`](https://github.com/php/doc-en/commit/c39225b6dd23f358824f44f5b8c733517b11830b)
* #257 で反映済 [`3295741565f760edd22e305bd10e37f243e9e194`](https://github.com/php/doc-en/commit/3295741565f760edd22e305bd10e37f243e9e194) (to)

# 備考

以下訳の選択等についての備考です。

## [`9b68bf2b63200534e022bc65e800cae6c75abf26`](https://github.com/php/doc-en/commit/9b68bf2b63200534e022bc65e800cae6c75abf26)

> No particular meaning can be reliably inferred from the value aside
> from its sign.

直訳するなら「値の符号以外に、値から確実に読み取れる特別な意味はありません」とでもなると思いますが、自然な日本語にしづらかったのと、「値の符号以外に」が何を含意するかが伝わりにくいと考えたので、以下の訳にしました。

> 返却される値の絶対値に、特に意味はありません。

## [`a8b6f4dd3a23875b066d4e47ea4a4977a63e0655`](https://github.com/php/doc-en/commit/a8b6f4dd3a23875b066d4e47ea4a4977a63e0655)

> Whitespace in the html and head tags
> is not considered significant and may lose formatting.

直訳するなら「html タグや head タグの中の空白は重要とは見なされず、整形が失われる可能性があります」とでもなると思いますが、「重要とは見なされず」や「整形が失われる」が伝わりにくいと思ったので意訳しました。

> html タグや head タグの中の空白は
> 必ずしも保持されません。インデント等が失われる可能性があります。
