### PR TITLE
WIP reference/curl/constants_curl_setopt.xml を新規翻訳

### DIFF
--- a/reference/curl/constants_curl_setopt.xml
+++ b/reference/curl/constants_curl_setopt.xml
@@ -1,0 +1,4682 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 9bbcd47e469474bbee6ab59061d49bbb9266692e Maintainer: nsfisis Status: working -->
+ <variablelist role="constant_list">
+  <title><function>curl_setopt</function></title>
+  <varlistentry xml:id="constant.curlopt-abstract-unix-socket">
+   <term>
+    <constant>CURLOPT_ABSTRACT_UNIX_SOCKET</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Enables the use of an abstract Unix domain socket instead of
+     establishing a TCP connection to a host and sets the path to
+     the given <type>string</type>. This option shares the same semantics
+     as <constant>CURLOPT_UNIX_SOCKET_PATH</constant>. These two options
+     share the same storage and therefore only one of them can be set
+     per handle.
+     Available as of PHP 7.3.0 and cURL 7.53.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-accept-encoding">
+   <term>
+    <constant>CURLOPT_ACCEPT_ENCODING</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Sets a <type>string</type> with the contents
+     of the <literal>Accept-Encoding:</literal> header sent in an HTTP request.
+     Set to &null; to disable sending the <literal>Accept-Encoding:</literal> header.
+     Defaults to &null;.
+     Available as of cURL 7.21.6.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-accepttimeout-ms">
+   <term>
+    <constant>CURLOPT_ACCEPTTIMEOUT_MS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     The maximum number of milliseconds to wait for a server
+     to connect back to cURL when an active FTP connection is used.
+     This option accepts any value that can be cast to a valid <type>int</type>.
+     Defaults to <literal>60000</literal> milliseconds.
+     Available as of cURL 7.24.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-address-scope">
+   <term>
+    <constant>CURLOPT_ADDRESS_SCOPE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     The scope id value to use when connecting to IPv6 addresses.
+     This option accepts any value that can be cast to a valid <type>int</type>.
+     Defaults to <literal>0</literal>.
+     Available as of cURL 7.19.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-altsvc">
+   <term>
+    <constant>CURLOPT_ALTSVC</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Pass a <type>string</type> with the filename for cURL to use as the Alt-Svc cache file to read existing cache contents from and
+     possibly also write it back to a after a transfer, unless <constant>CURLALTSVC_READONLYFILE</constant>
+     is set via <constant>CURLOPT_ALTSVC_CTRL</constant>.
+     Available as of PHP 8.2.0 and cURL 7.64.1.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-altsvc-ctrl">
+   <term>
+    <constant>CURLOPT_ALTSVC_CTRL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Populate the bitmask with the correct set of features to instruct cURL how to handle Alt-Svc for the
+     transfers using this handle. cURL only accepts Alt-Svc headers over HTTPS. It will also only complete
+     a request to an alternative origin if that origin is properly hosted over HTTPS.
+     Setting any bit will enable the alt-svc engine.
+     Set to any of the
+     <constant>CURLALTSVC_<replaceable>*</replaceable></constant> constants.
+     Defaults to Alt-Svc handling being disabled.
+     Available as of PHP 8.2.0 and cURL 7.64.1.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-append">
+   <term>
+    <constant>CURLOPT_APPEND</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Setting this option to <literal>1</literal> will cause FTP uploads
+     to append to the remote file instead of overwriting it.
+     Defaults to <literal>0</literal>.
+     Available as of cURL 7.17.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-autoreferer">
+   <term>
+    <constant>CURLOPT_AUTOREFERER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     &true; to automatically set the <literal>Referer:</literal> field in
+     requests where it follows a <literal>Location:</literal> redirect.
+     Defaults to <literal>0</literal>.
+     Available as of cURL 7.1.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-aws-sigv4">
+   <term>
+    <constant>CURLOPT_AWS_SIGV4</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Provides AWS V4 signature authentication on HTTP(S) header as a <type>string</type>.
+     This option overrides any other authentication types that have been set in
+     <constant>CURLOPT_HTTPAUTH</constant>. This method cannot be combined with other authentication types.
+     Available as of PHP 8.2.0 and cURL 7.75.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-binarytransfer">
+   <term>
+    <constant>CURLOPT_BINARYTRANSFER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     This constant is no longer used as of PHP 5.5.0.
+     Deprecated as of PHP 8.4.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-buffersize">
+   <term>
+    <constant>CURLOPT_BUFFERSIZE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     The size of the buffer to use for each read. There is no guarantee
+     this request will be fulfilled, however.
+     This option accepts any value that can be cast to a valid <type>int</type>.
+     Defaults to <constant>CURL_MAX_WRITE_SIZE</constant> (currently, 16kB).
+     Available as of cURL 7.10.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-cainfo">
+   <term>
+    <constant>CURLOPT_CAINFO</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A <type>string</type> with the name of a file holding one or more certificates to verify the
+     peer with. This only makes sense when used in combination with
+     <constant>CURLOPT_SSL_VERIFYPEER</constant>. Might require an absolute path.
+     Available as of cURL 7.4.2.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-cainfo-blob">
+   <term>
+    <constant>CURLOPT_CAINFO_BLOB</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A <type>string</type> with the name of a PEM file holding one or more certificates to verify the
+     peer with. This option overrides <constant>CURLOPT_CAINFO</constant>.
+     Available as of PHP 8.2.0 and cURL 7.77.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-capath">
+   <term>
+    <constant>CURLOPT_CAPATH</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A <type>string</type> with a directory that holds multiple CA certificates.
+     Use this option alongside <constant>CURLOPT_SSL_VERIFYPEER</constant>.
+     Available as of cURL 7.9.8.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ca-cache-timeout">
+   <term>
+    <constant>CURLOPT_CA_CACHE_TIMEOUT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Sets the maximum time in seconds any in memory cached CA certificate store
+     may be kept and reused for new connections.
+     This option accepts any value that can be cast to a valid <type>int</type>.
+     Defaults to <literal>86400</literal> (24 hours).
+     Available as of PHP 8.3.0 and cURL 7.87.0
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-certinfo">
+   <term>
+    <constant>CURLOPT_CERTINFO</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     &true; to output SSL certification information to <constant>STDERR</constant>
+     on secure transfers.
+     Requires <constant>CURLOPT_VERBOSE</constant> to be on to have an effect.
+     Defaults to &false;.
+     Available as of cURL 7.19.1.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-connecttimeout">
+   <term>
+    <constant>CURLOPT_CONNECTTIMEOUT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     The number of seconds to wait while trying to connect. Use 0 to
+     wait indefinitely.
+     This option accepts any value that can be cast to a valid <type>int</type>.
+     Defaults to <literal>300</literal>.
+     Available as of cURL 7.7.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-connecttimeout-ms">
+   <term>
+    <constant>CURLOPT_CONNECTTIMEOUT_MS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     The number of milliseconds to wait while trying to connect.
+     Use <literal>0</literal> to wait indefinitely.
+     If cURL is built to use the standard system name resolver, that
+     portion of the connect will still use full-second resolution for
+     timeouts with a minimum timeout allowed of one second.
+     This option accepts any value that can be cast to a valid <type>int</type>.
+     Defaults to <literal>300000</literal>.
+     Available as of cURL 7.16.2.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-connect-only">
+   <term>
+    <constant>CURLOPT_CONNECT_ONLY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     &true; tells the library to perform all the required proxy authentication
+     and connection setup, but no data transfer. This option is implemented for
+     HTTP, SMTP and POP3.
+     Defaults to &false;.
+     Available as of cURL 7.15.2.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-connect-to">
+   <term>
+    <constant>CURLOPT_CONNECT_TO</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Connect to a specific host and port instead of the URL's host and port.
+     Accepts an <type>array</type> of <type>string</type>s with the format
+     <literal>HOST:PORT:CONNECT-TO-HOST:CONNECT-TO-PORT</literal>.
+     Available as of PHP 7.0.7 and cURL 7.49.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-cookie">
+   <term>
+    <constant>CURLOPT_COOKIE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A <type>string</type> with the contents of the <literal>Cookie: </literal> header to be used in the HTTP request.
+     Note that multiple cookies are separated with a semicolon followed
+     by a space (e.g., <literal>fruit=apple; colour=red</literal>).
+     Available as of cURL 7.1.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-cookiefile">
+   <term>
+    <constant>CURLOPT_COOKIEFILE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A <type>string</type> with the name of the file containing the cookie data.
+     The cookie file can be in Netscape format, or just plain HTTP-style headers dumped into a file.
+     If the name is an empty <type>string</type>, no cookies are loaded, but cookie
+     handling is still enabled.
+     Available as of cURL 7.1.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-cookiejar">
+   <term>
+    <constant>CURLOPT_COOKIEJAR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A <type>string</type> with the name of a file to save all internal cookies to when
+     the handle's destructor is called.
+     Available as of cURL 7.9.0.
+     <warning>
+      <simpara>
+       As of PHP 8.0.0, <function>curl_close</function> is a no-op
+       and does <emphasis>not</emphasis> destroy the handle.
+       If cookies need to be written prior to the handle being automatically
+       destroyed, call <function>unset</function> on the handle.
+      </simpara>
+     </warning>
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-cookielist">
+   <term>
+    <constant>CURLOPT_COOKIELIST</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A cookie <type>string</type> (i.e. a single line in Netscape/Mozilla format, or a regular
+     HTTP-style Set-Cookie header) adds that single cookie to the internal cookie store.
+     <simplelist type="inline">
+      <member>
+       <literal>ALL</literal>
+       erases all cookies held in memory
+      </member>
+      <member>
+       <literal>SESS</literal>
+       erases all session cookies held in memory
+      </member>
+      <member>
+       <literal>FLUSH</literal>
+       writes all known cookies to the file specified by <constant>CURLOPT_COOKIEJAR</constant>
+      </member>
+      <member>
+       <literal>RELOAD</literal>
+       loads all cookies from the files specified by <constant>CURLOPT_COOKIEFILE</constant>
+      </member>
+     </simplelist>.
+     Available as of cURL 7.14.1.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-cookiesession">
+   <term>
+    <constant>CURLOPT_COOKIESESSION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     &true; to mark this as a new cookie "session". It will force cURL
+     to ignore all cookies it is about to load that are "session cookies"
+     from the previous session. By default, cURL always stores and
+     loads all cookies, independent if they are session cookies or not.
+     Session cookies are cookies without expiry date and they are meant
+     to be alive and existing for this "session" only.
+     Available as of cURL 7.9.7.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-crlf">
+   <term>
+    <constant>CURLOPT_CRLF</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     &true; to convert Unix newlines to CRLF newlines
+     on transfers.
+     Available as of cURL 7.1.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-crlfile">
+   <term>
+    <constant>CURLOPT_CRLFILE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Pass a <type>string</type> naming a file with the concatenation of
+     CRL (Certificate Revocation List) (in PEM format)
+     to use in the certificate validation that occurs during the SSL exchange.
+     When cURL is built to use GnuTLS,
+     there is no way to influence the use of CRL passed
+     to help in the verification process.
+     When cURL is built with OpenSSL support,
+     <literal>X509_V_FLAG_CRL_CHECK</literal>
+     and <literal>X509_V_FLAG_CRL_CHECK_ALL</literal> are both set,
+     requiring CRL check against all the elements of the certificate chain
+     if a CRL file is passed.
+     Also note that <constant>CURLOPT_CRLFILE</constant> implies
+     <constant>CURLSSLOPT_NO_PARTIALCHAIN</constant>
+     as of cURL 7.71.0 due to an OpenSSL bug.
+     Available as of cURL 7.19.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-customrequest">
+   <term>
+    <constant>CURLOPT_CUSTOMREQUEST</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A custom request method to use instead of
+     <literal>GET</literal> or <literal>HEAD</literal> when doing
+     a HTTP request. This is useful for doing
+     <literal>DELETE</literal> or other, more obscure HTTP requests.
+     Valid values are things like <literal>GET</literal>,
+     <literal>POST</literal>, <literal>CONNECT</literal> and so on;
+     i.e. Do not enter a whole HTTP request line here. For instance,
+     entering <literal>GET /index.html HTTP/1.0\r\n\r\n</literal>
+     would be incorrect.
+     This option accepts a <type>string</type> or &null;.
+     Available as of cURL 7.1.0.
+     <note>
+      <para>
+       Don't do this without making sure the server supports the custom
+       request method first.
+      </para>
+     </note>
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-default-protocol">
+   <term>
+    <constant>CURLOPT_DEFAULT_PROTOCOL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A <type>string</type> with the default protocol to use if the URL is missing a scheme name.
+     Available as of PHP 7.0.7 and cURL 7.45.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-dirlistonly">
+   <term>
+    <constant>CURLOPT_DIRLISTONLY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Setting this option to <literal>1</literal> will have different effects
+     based on the protocol it is used with.
+     FTP and SFTP based URLs will list only the names of files in a directory.
+     POP3 will list the email message or messages on the POP3 server.
+     For FILE, this option has no effect
+     as directories are always listed in this mode.
+     Using this option with <constant>CURLOPT_WILDCARDMATCH</constant>
+     will prevent the latter from having any effect.
+     Defaults to <literal>0</literal>.
+     Available as of cURL 7.17.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-disallow-username-in-url">
+   <term>
+    <constant>CURLOPT_DISALLOW_USERNAME_IN_URL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     &true; to not allow URLs that include a username.
+     Usernames are allowed by default.
+     Available as of PHP 7.3.0 and cURL 7.61.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-dns-cache-timeout">
+   <term>
+    <constant>CURLOPT_DNS_CACHE_TIMEOUT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     The number of seconds to keep DNS entries in memory. This
+     option is set to <literal>120</literal> (2 minutes) by default.
+     This option accepts any value that can be cast to a valid <type>int</type>.
+     Available as of cURL 7.9.3.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-dns-interface">
+   <term>
+    <constant>CURLOPT_DNS_INTERFACE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set the name of the network interface that the DNS resolver should bind to.
+     This must be an interface name (not an address).
+     This option accepts a <type>string</type> or &null;.
+     Available as of PHP 7.0.7 and cURL 7.33.0
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-dns-local-ip4">
+   <term>
+    <constant>CURLOPT_DNS_LOCAL_IP4</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set the local IPv4 address that the resolver should bind to.
+     The argument should contain a single numerical IPv4 address.
+     This option accepts a <type>string</type> or &null;.
+     Available as of PHP 7.0.7 and cURL 7.33.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-dns-local-ip6">
+   <term>
+    <constant>CURLOPT_DNS_LOCAL_IP6</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set the local IPv6 address that the resolver should bind to.
+     The argument should contain a single numerical IPv6 address.
+     This option accepts a <type>string</type> or &null;.
+     Available as of PHP 7.0.7 and cURL 7.33.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-dns-servers">
+   <term>
+    <constant>CURLOPT_DNS_SERVERS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Pass a <type>string</type> with a comma-separated list of DNS servers to be used
+     instead of the system default
+     (e.g.: <literal>192.168.1.100,192.168.1.101:8080</literal>).
+     Available as of cURL 7.24.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-dns-shuffle-addresses">
+   <term>
+    <constant>CURLOPT_DNS_SHUFFLE_ADDRESSES</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     &true; to shuffle the order of all returned addresses so that they will be used
+     in a random order, when a name is resolved and more than one IP address is returned.
+     This may cause IPv4 to be used before IPv6 or vice versa.
+     Available as of PHP 7.3.0 and cURL 7.60.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-dns-use-global-cache">
+   <term>
+    <constant>CURLOPT_DNS_USE_GLOBAL_CACHE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     &true; to use a global DNS cache. This option is not thread-safe.
+     It is conditionally enabled by default if PHP is built for non-threaded use
+     (CLI, FCGI, Apache2-Prefork, etc.).
+     Available as of cURL 7.9.3 and deprecated as of cURL 7.11.1.
+     As of PHP 8.4, this option no longer has any effect.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-doh-ssl-verifyhost">
+   <term>
+    <constant>CURLOPT_DOH_SSL_VERIFYHOST</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set to <literal>2</literal> to verify the DNS-over-HTTPS server's SSL certificate name fields against the host name.
+     Available as of PHP 8.2.0 and cURL 7.76.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-doh-ssl-verifypeer">
+   <term>
+    <constant>CURLOPT_DOH_SSL_VERIFYPEER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set to <literal>1</literal> to enable and <literal>0</literal> to disable
+     verification of the authenticity of the DNS-over-HTTPS server's SSL certificate.
+     Available as of PHP 8.2.0 and cURL 7.76.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-doh-ssl-verifystatus">
+   <term>
+    <constant>CURLOPT_DOH_SSL_VERIFYSTATUS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set to <literal>1</literal> to enable and <literal>0</literal> to disable
+     the verification of the status of the DNS-over-HTTPS server certificate
+     using the "Certificate Status Request" TLS extension (OCSP stapling).
+     Available as of PHP 8.2.0 and cURL 7.76.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-doh-url">
+   <term>
+    <constant>CURLOPT_DOH_URL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Provides the DNS-over-HTTPS URL.
+     This option accepts a <type>string</type> or &null;.
+     Available as of PHP 8.1.0 and cURL 7.62.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-egdsocket">
+   <term>
+    <constant>CURLOPT_EGDSOCKET</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Like <constant>CURLOPT_RANDOM_FILE</constant>, except a filename
+     to an Entropy Gathering Daemon socket.
+     Available as of cURL 7.7.0 and deprecated as of cURL 7.84.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-encoding">
+   <term>
+    <constant>CURLOPT_ENCODING</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     The contents of the <literal>Accept-Encoding: </literal> header as a <type>string</type>.
+     This enables decoding of the response. Supported encodings are:
+     <simplelist type="inline">
+      <member><literal>identity</literal></member>
+      <member><literal>deflate</literal></member>
+      <member><literal>gzip</literal></member>
+     </simplelist>.
+     If an empty <type>string</type> is set,
+     a header containing all supported encoding types is sent.
+     Available as of cURL 7.10 and deprecated as of cURL 7.21.6.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-expect-100-timeout-ms">
+   <term>
+    <constant>CURLOPT_EXPECT_100_TIMEOUT_MS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     The timeout for <literal>Expect: 100-continue</literal> responses in milliseconds.
+     Defaults to <literal>1000</literal> milliseconds.
+     This option accepts any value that can be cast to a valid <type>int</type>.
+     Available as of PHP 7.0.7 and cURL 7.36.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-failonerror">
+   <term>
+    <constant>CURLOPT_FAILONERROR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     &true; to fail verbosely if the HTTP code returned
+     is greater than or equal to <literal>400</literal>. The default behavior is to return
+     the page normally, ignoring the code.
+     Available as of cURL 7.1.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-file">
+   <term>
+    <constant>CURLOPT_FILE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Accepts a file handle <type>resource</type>
+     to the file that the transfer should be written to.
+     The default is <constant>STDOUT</constant> (the browser window).
+     Available as of cURL 7.1.0 and deprecated as of cURL 7.9.7.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-filetime">
+   <term>
+    <constant>CURLOPT_FILETIME</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set to &true; to attempt to retrieve the modification
+     date of the remote document. This value can be retrieved using
+     the <constant>CURLINFO_FILETIME</constant> option with
+     <function>curl_getinfo</function>.
+     Available as of cURL 7.5.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-fnmatch-function">
+   <term>
+    <constant>CURLOPT_FNMATCH_FUNCTION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Pass a <type>callable</type> that will be used for wildcard matching.
+     The signature of the callback should be:
+     <methodsynopsis>
+      <type>int</type><methodname><replaceable>callback</replaceable></methodname>
+      <methodparam><type>resource</type><parameter>curlHandle</parameter></methodparam>
+      <methodparam><type>string</type><parameter>pattern</parameter></methodparam>
+      <methodparam><type>string</type><parameter>string</parameter></methodparam>
+     </methodsynopsis>
+     <variablelist role="function_parameters">
+      <varlistentry>
+       <term><parameter>curlHandle</parameter></term>
+       <listitem>
+        <simpara>
+         The cURL handle.
+        </simpara>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><parameter>pattern</parameter></term>
+       <listitem>
+        <simpara>
+         The wildcard pattern.
+        </simpara>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><parameter>string</parameter></term>
+       <listitem>
+        <simpara>
+         The <type>string</type> to run the wildcard pattern matching on.
+        </simpara>
+       </listitem>
+      </varlistentry>
+     </variablelist>
+     The callback should return
+     <constant>CURL_FNMATCHFUNC_MATCH</constant> if pattern matches the <type>string</type>,
+     <constant>CURL_FNMATCHFUNC_NOMATCH</constant> if not
+     or <constant>CURL_FNMATCHFUNC_FAIL</constant> if an error occurred.
+     Available as of cURL 7.21.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-followlocation">
+   <term>
+    <constant>CURLOPT_FOLLOWLOCATION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set to &true; to follow any <literal>Location: </literal> header that the server sends as
+     part of the HTTP header.
+     See also <constant>CURLOPT_MAXREDIRS</constant>.
+     This constant is not available when <link xmlns="http://docbook.org/ns/docbook" linkend="ini.open-basedir">open_basedir</link>
+     is enabled.
+     Available as of cURL 7.1.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-forbid-reuse">
+   <term>
+    <constant>CURLOPT_FORBID_REUSE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set to &true; to force the connection to explicitly
+     close when it has finished processing, and not be pooled for reuse.
+     Available as of cURL 7.7.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-fresh-connect">
+   <term>
+    <constant>CURLOPT_FRESH_CONNECT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set to &true; to force the use of a new connection
+     instead of a cached one.
+     Available as of cURL 7.7.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ftpappend">
+   <term>
+    <constant>CURLOPT_FTPAPPEND</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set to &true; to append to the remote file instead of
+     overwriting it.
+     Available as of cURL 7.1.0 and deprecated as of cURL 7.16.4.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ftpascii">
+   <term>
+    <constant>CURLOPT_FTPASCII</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     An alias of
+     <constant>CURLOPT_TRANSFERTEXT</constant>. Use that instead.
+     Available as of cURL 7.1, deprecated as of cURL 7.11.1
+     and last available in cURL 7.15.5.
+     Removed as of PHP 7.3.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ftplistonly">
+   <term>
+    <constant>CURLOPT_FTPLISTONLY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set to &true; to only list the names of an FTP directory.
+     Available as of cURL 7.1.0 and deprecated as of cURL 7.16.4.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ftpport">
+   <term>
+    <constant>CURLOPT_FTPPORT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A <type>string</type> which will be used to get the IP address to use for the FTP <literal>PORT</literal> instruction. The <literal>PORT</literal> instruction tells
+     the remote server to connect to our specified IP address.  The
+     <type>string</type> may be a plain IP address, a hostname,
+     a network interface name (under Unix),
+     or just a plain <literal>-</literal> to use the system's default IP address.
+     This option accepts a <type>string</type> or &null;.
+     Available as of cURL 7.1.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ftpsslauth">
+   <term>
+    <constant>CURLOPT_FTPSSLAUTH</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set the FTP over SSL authentication method (if activated) to any of the
+     <constant>CURLFTPAUTH_<replaceable>*</replaceable></constant> constants.
+     Defaults to <constant>CURLFTPAUTH_DEFAULT</constant>.
+     Available as of cURL 7.12.2.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ftp-account">
+   <term>
+    <constant>CURLOPT_FTP_ACCOUNT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Pass a <type>string</type> that will be sent as account information over FTP
+     (using the <literal>ACCT</literal> command) after username and password has been provided
+     to the server.
+     Set to &null; to disable sending the account information.
+     Defaults to &null;.
+     Available as of cURL 7.13.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ftp-alternative-to-user">
+   <term>
+    <constant>CURLOPT_FTP_ALTERNATIVE_TO_USER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Pass a <type>string</type> that will be used to try to authenticate over FTP
+     if the <literal>USER/PASS</literal> negotiation fails.
+     Available as of cURL 7.15.5.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ftp-create-missing-dirs">
+   <term>
+    <constant>CURLOPT_FTP_CREATE_MISSING_DIRS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set to &true; to create missing directories when an FTP operation
+     encounters a path that currently doesn't exist.
+     Available as of cURL 7.10.7.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ftp-filemethod">
+   <term>
+    <constant>CURLOPT_FTP_FILEMETHOD</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Tell cURL which method to use to reach a file on a FTP(S) server. Possible values are
+     any of the <constant>CURLFTPMETHOD_<replaceable>*</replaceable></constant> constants.
+     Defaults to <constant>CURLFTPMETHOD_MULTICWD</constant>.
+     Available as of cURL 7.15.1.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ftp-response-timeout">
+   <term>
+    <constant>CURLOPT_FTP_RESPONSE_TIMEOUT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A timeout in seconds cURL will wait for a response from an FTP server.
+     This option overrides <constant>CURLOPT_TIMEOUT</constant>.
+     This option accepts any value that can be cast to a valid <type>int</type>.
+     This option name is replaced with <constant>CURLOPT_SERVER_RESPONSE_TIMEOUT</constant>,
+     available as of PHP 8.4.0.
+     Available as of cURL 7.10.8 and deprecated as of cURL 7.85.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ftp-skip-pasv-ip">
+   <term>
+    <constant>CURLOPT_FTP_SKIP_PASV_IP</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     If this option is set to <literal>1</literal>
+     cURL will not use the IP address the server suggests
+     in its 227-response to cURL's <literal>PASV</literal> command
+     but will use the IP address it used for the connection.
+     The port number received from the 227-response will not be ignored by cURL.
+     Defaults to <literal>1</literal> as of cURL 7.74.0
+     and <literal>0</literal> prior to that.
+     Available as of cURL 7.15.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ftp-ssl">
+   <term>
+    <constant>CURLOPT_FTP_SSL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Available as of cURL 7.11.0 and deprecated as of cURL 7.16.4.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ftp-ssl-ccc">
+   <term>
+    <constant>CURLOPT_FTP_SSL_CCC</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     This option makes cURL use CCC (Clear Command Channel)
+     which shuts down the SSL/TLS layer after authenticating
+     making the rest of the control channel communication unencrypted.
+     Use one of the <constant>CURLFTPSSL_CCC_<replaceable>*</replaceable></constant> constants.
+     Defaults to <constant>CURLFTPSSL_CCC_NONE</constant>.
+     Available as of cURL 7.16.1.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ftp-use-eprt">
+   <term>
+    <constant>CURLOPT_FTP_USE_EPRT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set to &true; to use <literal>EPRT</literal> (and <literal>LPRT</literal>) when doing active FTP downloads.
+     Set to &false; to disable <literal>EPRT</literal> and <literal>LPRT</literal> and use <literal>PORT</literal> only.
+     Available as of cURL 7.10.5.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ftp-use-epsv">
+   <term>
+    <constant>CURLOPT_FTP_USE_EPSV</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set to &true; to first try an <literal>EPSV</literal> command for FTP transfers before reverting back to <literal>PASV</literal>.
+     Set to &false; to disable <literal>EPSV</literal>.
+     Available as of cURL 7.9.2.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ftp-use-pret">
+   <term>
+    <constant>CURLOPT_FTP_USE_PRET</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set to <literal>1</literal> to send a <literal>PRET</literal> command
+     before <literal>PASV</literal> (and <literal>EPSV</literal>).
+     Has no effect when using the active FTP transfers mode.
+     Defaults to <literal>0</literal>.
+     Available as of cURL 7.20.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-gssapi-delegation">
+   <term>
+    <constant>CURLOPT_GSSAPI_DELEGATION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set to <constant>CURLGSSAPI_DELEGATION_FLAG</constant>
+     to allow unconditional GSSAPI credential delegation.
+     Set to <constant>CURLGSSAPI_DELEGATION_POLICY_FLAG</constant>
+     to delegate only if the <literal>OK-AS-DELEGATE</literal> flag is set
+     in the service ticket.
+     Defaults to <constant>CURLGSSAPI_DELEGATION_NONE</constant>.
+     Available as of cURL 7.22.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-happy-eyeballs-timeout-ms">
+   <term>
+    <constant>CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Head start for IPv6 for the happy eyeballs algorithm. Happy eyeballs attempts
+     to connect to both IPv4 and IPv6 addresses for dual-stack hosts,
+     preferring IPv6 first for timeout milliseconds.
+     Defaults to <constant>CURL_HET_DEFAULT</constant>, which is currently 200 milliseconds.
+     This option accepts any value that can be cast to a valid <type>int</type>.
+     Available as of PHP 7.3.0 and cURL 7.59.0
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-haproxyprotocol">
+   <term>
+    <constant>CURLOPT_HAPROXYPROTOCOL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     &true; to send an HAProxy <literal>PROXY</literal> protocol v1 header at the start of the connection.
+     The default action is not to send this header.
+     Available as of PHP 7.3.0 and cURL 7.60.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-header">
+   <term>
+    <constant>CURLOPT_HEADER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set to &true; to include the headers in the output sent to the callback
+     defined by <constant>CURLOPT_WRITEFUNCTION</constant>.
+     Available as of cURL 7.1.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-headerfunction">
+   <term>
+    <constant>CURLOPT_HEADERFUNCTION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A <type>callable</type> with the following signature:
+     <methodsynopsis>
+      <type>int</type><methodname><replaceable>callback</replaceable></methodname>
+      <methodparam><type>resource</type><parameter>curlHandle</parameter></methodparam>
+      <methodparam><type>string</type><parameter>headerData</parameter></methodparam>
+     </methodsynopsis>
+     <variablelist role="function_parameters">
+      <varlistentry>
+       <term><parameter>curlHandle</parameter></term>
+       <listitem>
+        <simpara>
+         The cURL handle.
+        </simpara>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><parameter>headerData</parameter></term>
+       <listitem>
+        <simpara>
+         The header data which must be written by the callback.
+        </simpara>
+       </listitem>
+      </varlistentry>
+     </variablelist>
+     The callback should return the number of bytes written.
+     Available as of cURL 7.7.2.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-headeropt">
+   <term>
+    <constant>CURLOPT_HEADEROPT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Send HTTP headers to both proxy and host or separately.
+     Possible values are any of the
+     <constant>CURLHEADER_<replaceable>*</replaceable></constant> constants.
+     Defaults to <constant>CURLHEADER_SEPARATE</constant> as of cURL
+     7.42.1, and <constant>CURLHEADER_UNIFIED</constant> prior to that.
+     Available as of PHP 7.0.7 and cURL 7.37.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-hsts">
+   <term>
+    <constant>CURLOPT_HSTS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     <type>string</type> with HSTS (HTTP Strict Transport Security) cache file name
+     or &null; to allow HSTS without reading from or writing to any file
+     and clear the list of files to read HSTS data from.
+     Available as of PHP 8.2.0 and cURL 7.74.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-hsts-ctrl">
+   <term>
+    <constant>CURLOPT_HSTS_CTRL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Accepts a bitmask of HSTS (HTTP Strict Transport Security) features
+     defined by the <constant>CURLHSTS_<replaceable>*</replaceable></constant> constants.
+     Available as of PHP 8.2.0 and cURL 7.74.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-http09-allowed">
+   <term>
+    <constant>CURLOPT_HTTP09_ALLOWED</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Whether to allow HTTP/0.9 responses. Defaults to &false; as of cURL 7.66.0;
+     formerly it defaulted to &true;.
+     Available as of PHP 7.3.15 and 7.4.3, respectively, and cURL 7.64.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-http200aliases">
+   <term>
+    <constant>CURLOPT_HTTP200ALIASES</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     An <type>array</type> of HTTP <literal>200</literal> responses that will be treated as valid responses and not as errors.
+     Available as of cURL 7.10.3.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-httpauth">
+   <term>
+    <constant>CURLOPT_HTTPAUTH</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A bitmask of HTTP authentication method(s) to use. The options are:
+     <simplelist type="inline">
+      <member><constant>CURLAUTH_BASIC</constant></member>
+      <member><constant>CURLAUTH_DIGEST</constant></member>
+      <member><constant>CURLAUTH_GSSNEGOTIATE</constant></member>
+      <member><constant>CURLAUTH_NTLM</constant></member>
+      <member><constant>CURLAUTH_AWS_SIGV4</constant></member>
+      <member><constant>CURLAUTH_ANY</constant></member>
+      <member><constant>CURLAUTH_ANYSAFE</constant></member>
+     </simplelist>.
+     If more than one method is used, cURL will poll the server to see
+     what methods it supports and pick the best one.
+     <constant>CURLAUTH_ANY</constant> sets all bits. cURL will automatically select
+     the one it finds most secure.
+     <constant>CURLAUTH_ANYSAFE</constant> sets all bits except <constant>CURLAUTH_BASIC</constant>.
+     cURL will automatically select the one it finds most secure.
+     Available as of cURL 7.10.6.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-httpget">
+   <term>
+    <constant>CURLOPT_HTTPGET</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set to &true; to reset the HTTP request method to <literal>GET</literal>. Since <literal>GET</literal> is the default, this is only necessary if the request
+     method has been changed.
+     Available as of cURL 7.8.1.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-httpheader">
+   <term>
+    <constant>CURLOPT_HTTPHEADER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     An <type>array</type> of HTTP header fields to set, in the format
+     <code>
+      array('Content-type: text/plain', 'Content-length: 100')
+     </code>
+     Available as of cURL 7.1.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-httpproxytunnel">
+   <term>
+    <constant>CURLOPT_HTTPPROXYTUNNEL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     &true; to tunnel through a given HTTP proxy.
+     Available as of cURL 7.3.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-http-content-decoding">
+   <term>
+    <constant>CURLOPT_HTTP_CONTENT_DECODING</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     &false; to get the raw HTTP response body.
+     Available as of cURL 7.16.2.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-http-transfer-decoding">
+   <term>
+    <constant>CURLOPT_HTTP_TRANSFER_DECODING</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     If set to <literal>0</literal>, transfer decoding is disabled.
+     If set to <literal>1</literal>, transfer decoding is enabled.
+     cURL does chunked transfer decoding by default
+     unless this option is set to <literal>0</literal>.
+     Defaults to <literal>1</literal>.
+     Available as of cURL 7.16.2.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-http-version">
+   <term>
+    <constant>CURLOPT_HTTP_VERSION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set to one of the
+     <constant>CURL_HTTP_VERSION_<replaceable>*</replaceable></constant> constants
+     for cURL to use the specified HTTP version.
+     Available as of cURL 7.9.1.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ignore-content-length">
+   <term>
+    <constant>CURLOPT_IGNORE_CONTENT_LENGTH</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     If set to <literal>1</literal>,
+     ignore the <literal>Content-Length</literal> header in the HTTP response
+     and ignore asking for or relying on it for FTP transfers.
+     Defaults to <literal>0</literal>.
+     Available as of cURL 7.14.1.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-infile">
+   <term>
+    <constant>CURLOPT_INFILE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Accepts a file handle <type>resource</type>
+     to the file that the transfer should be read from when uploading.
+     Available as of cURL 7.1.0 and deprecated as of cURL 7.9.7.
+     Use <constant>CURLOPT_READDATA</constant> instead.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-infilesize">
+   <term>
+    <constant>CURLOPT_INFILESIZE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     The expected size, in bytes, of the file when uploading a file to
+     a remote site. Note that using this option will not stop cURL
+     from sending more data, as exactly what is sent depends on
+     <constant>CURLOPT_READFUNCTION</constant>.
+     This option accepts any value that can be cast to a valid <type>int</type>.
+     Available as of cURL 7.1.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-interface">
+   <term>
+    <constant>CURLOPT_INTERFACE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set to a <type>string</type> with the name of the outgoing network interface to use.
+     This can be an interface name, an IP address or a host name.
+     Available as of cURL 7.1.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ipresolve">
+   <term>
+    <constant>CURLOPT_IPRESOLVE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Allows an application to select what kind of IP addresses to use when
+     resolving host names. This is only interesting when using host names that
+     resolve addresses using more than one version of IP.
+     Set to one of the
+     <constant>CURL_IPRESOLVE_<replaceable>*</replaceable></constant> constants.
+     Defaults to <constant>CURL_IPRESOLVE_WHATEVER</constant>.
+     Available as of cURL 7.10.8.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-issuercert">
+   <term>
+    <constant>CURLOPT_ISSUERCERT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     If set to a <type>string</type> naming a file holding a CA certificate in PEM format,
+     an additional check against the peer certificate is performed
+     to verify the issuer is indeed the one associated
+     with the certificate provided by the option.
+     For the result of the check to be considered a failure,
+     this option should be used in combination with the
+     <constant>CURLOPT_SSL_VERIFYPEER</constant> option.
+     Available as of cURL 7.19.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-issuercert-blob">
+   <term>
+    <constant>CURLOPT_ISSUERCERT_BLOB</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Pass a <type>string</type> with binary data of a CA SSL certificate in PEM format.
+     If set, an additional check against the peer certificate is performed
+     to verify the issuer is the one associated with the certificate provided by the option.
+     Available as of PHP 8.1.0 and cURL 7.71.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-keep-sending-on-error">
+   <term>
+    <constant>CURLOPT_KEEP_SENDING_ON_ERROR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set to &true; to keep sending the request body if the HTTP code returned is equal to or larger than <literal>300</literal>.
+     The default action would be to stop sending
+     and close the stream or connection. Suitable for manual NTLM authentication.
+     Most applications do not need this option.
+     Available as of PHP 7.3.0 and cURL 7.51.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-keypasswd">
+   <term>
+    <constant>CURLOPT_KEYPASSWD</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set to a <type>string</type> with the password required to use the <constant>CURLOPT_SSLKEY</constant>
+     or <constant>CURLOPT_SSH_PRIVATE_KEYFILE</constant> private key.
+     Setting this option to &null; disables using a password for these options.
+     Available as of cURL 7.17.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-krb4level">
+   <term>
+    <constant>CURLOPT_KRB4LEVEL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     The KRB4 (Kerberos 4) security level. Any of the following <type>string</type> values
+     (in order from least to most powerful) are valid:
+     <simplelist type="inline">
+      <member><literal>clear</literal></member>
+      <member><literal>safe</literal></member>
+      <member><literal>confidential</literal></member>
+      <member><literal>private</literal></member>
+     </simplelist>.
+     If the <type>string</type> does not match one of these,
+     <literal>private</literal> is used. Setting this option to &null;
+     will disable KRB4 security. Currently KRB4 security only works
+     with FTP transactions.
+     Available as of cURL 7.3.0 and deprecated as of cURL 7.17.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-krblevel">
+   <term>
+    <constant>CURLOPT_KRBLEVEL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set the kerberos security level for FTP and also enables kerberos awareness.
+     This should be set to one of the following <type>string</type>s:
+     <simplelist type="inline">
+      <member><literal>clear</literal></member>
+      <member><literal>safe</literal></member>
+      <member><literal>confidential</literal></member>
+      <member><literal>private</literal></member>
+     </simplelist>.
+     If the <type>string</type> is set but does not match one of these,
+     <literal>private</literal> is used.
+     Setting this option to &null; will disable kerberos support for FTP.
+     Defaults to &null;.
+     Available as of cURL 7.16.4.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-localport">
+   <term>
+    <constant>CURLOPT_LOCALPORT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Sets the local port number of the socket used for the connection.
+     This option accepts any value that can be cast to a valid <type>int</type>.
+     Defaults to <literal>0</literal>.
+     Available as of cURL 7.15.2.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-localportrange">
+   <term>
+    <constant>CURLOPT_LOCALPORTRANGE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     The number of attempts cURL makes to find a working local port number,
+     starting with the one set with <constant>CURLOPT_LOCALPORT</constant>.
+     This option accepts any value that can be cast to a valid <type>int</type>.
+     Defaults to <literal>1</literal>.
+     Available as of cURL 7.15.2.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-login-options">
+   <term>
+    <constant>CURLOPT_LOGIN_OPTIONS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Can be used to set protocol specific login options, such as the
+     preferred authentication mechanism via <literal>AUTH=NTLM</literal> or <literal>AUTH=*</literal>, and should be used in conjunction with the
+     <constant>CURLOPT_USERNAME</constant> option.
+     Available as of PHP 7.0.7 and cURL 7.34.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-low-speed-limit">
+   <term>
+    <constant>CURLOPT_LOW_SPEED_LIMIT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     The transfer speed, in bytes per second, that the transfer should be
+     below during the count of <constant>CURLOPT_LOW_SPEED_TIME</constant>
+     seconds before PHP considers the transfer too slow and aborts.
+     This option accepts any value that can be cast to a valid <type>int</type>.
+     Available as of cURL 7.1.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-low-speed-time">
+   <term>
+    <constant>CURLOPT_LOW_SPEED_TIME</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     The number of seconds the transfer speed should be below
+     <constant>CURLOPT_LOW_SPEED_LIMIT</constant> before PHP considers
+     the transfer too slow and aborts.
+     This option accepts any value that can be cast to a valid <type>int</type>.
+     Available as of cURL 7.1.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-mail-auth">
+   <term>
+    <constant>CURLOPT_MAIL_AUTH</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set a <type>string</type> with the authentication address (identity)
+     of a submitted message that is being relayed to another server.
+     The address should not be specified within a pair of angled brackets
+     (<literal>&gt;&lt;</literal>).
+     If an empty <type>string</type> is used then a pair of brackets are sent by cURL
+     as required by RFC 2554.
+     Available as of cURL 7.25.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-mail-from">
+   <term>
+    <constant>CURLOPT_MAIL_FROM</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set a <type>string</type> with the sender's email address when sending SMTP mail.
+     The email address should be specified with angled brackets
+     (<literal>&gt;&lt;</literal>) around it,
+     which if not specified are added automatically.
+     If this parameter is not specified then an empty address is sent
+     to the SMTP server which might cause the email to be rejected.
+     Available as of cURL 7.20.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-mail-rcpt">
+   <term>
+    <constant>CURLOPT_MAIL_RCPT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set to an <type>array</type> of <type>string</type>s
+     with the recipients to pass to the server in an SMTP mail request.
+     Each recipient should be specified within a pair of angled brackets
+     (<literal>&gt;&lt;</literal>).
+     If an angled bracket is not used as the first character,
+     cURL assumes a single email address has been provided
+     and encloses that address within brackets.
+     Available as of cURL 7.20.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-mail-rcpt-alllowfails">
+   <term>
+    <constant>CURLOPT_MAIL_RCPT_ALLLOWFAILS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set to <literal>1</literal> to allow <literal>RCPT TO</literal> command
+     to fail for some recipients which makes cURL ignore errors
+     for individual recipients and proceed with the remaining accepted recipients.
+     If all recipients trigger failures and this flag is specified,
+     cURL aborts the SMTP conversation
+     and returns the error received from to the last <literal>RCPT TO</literal> command.
+     Replaced by <constant>CURLOPT_MAIL_RCPT_ALLOWFAILS</constant> as of cURL 8.2.0.
+     Available as of PHP 8.2.0 and cURL 7.69.0.
+     Deprecated as of cURL 8.2.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-maxage-conn">
+   <term>
+    <constant>CURLOPT_MAXAGE_CONN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     The maximum idle time allowed for an existing connection to be considered for reuse.
+     Default maximum age is set to <literal>118</literal> seconds.
+     This option accepts any value that can be cast to a valid <type>int</type>.
+     Available as of PHP 8.2.0 and cURL 7.65.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-maxconnects">
+   <term>
+    <constant>CURLOPT_MAXCONNECTS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     The maximum amount of persistent connections that are allowed.
+     When the limit is reached, the oldest one in the cache is closed
+     to prevent increasing the number of open connections.
+     This option accepts any value that can be cast to a valid <type>int</type>.
+     Available as of cURL 7.7.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-maxfilesize">
+   <term>
+    <constant>CURLOPT_MAXFILESIZE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Sets the maximum accepted size (in bytes) of a file to download.
+     If the file requested is found larger than this value,
+     the transfer is aborted
+     and <constant>CURLE_FILESIZE_EXCEEDED</constant> is returned.
+     Passing <literal>0</literal> disables this option,
+     and passing a negative size returns a
+     <constant>CURLE_BAD_FUNCTION_ARGUMENT</constant>.
+     If the file size is not known prior to the start of download,
+     this option has no effect.
+     For setting a size limit above <literal>2GB</literal>,
+     <constant>CURLOPT_MAXFILESIZE_LARGE</constant> should be used.
+     As of cURL 8.4.0, this option also stops ongoing transfers
+     if they reach this threshold.
+     This option accepts any value that can be cast to a valid <type>int</type>.
+     Defaults to <literal>0</literal>.
+     Available as of cURL 7.10.8.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-maxfilesize-large">
+   <term>
+    <constant>CURLOPT_MAXFILESIZE_LARGE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     The maximum file size in bytes allowed to download. If the file requested is found larger than this value,
+     the transfer will not start and <constant>CURLE_FILESIZE_EXCEEDED</constant> will be returned.
+     The file size is not always known prior to download, and for such files this option has no effect even if
+     the file transfer ends up being larger than this given limit.
+     This option accepts any value that can be cast to a valid <type>int</type>.
+     Available as of PHP 8.2.0 and cURL 7.11.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-maxlifetime-conn">
+   <term>
+    <constant>CURLOPT_MAXLIFETIME_CONN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     The maximum time in seconds, since the creation of the connection, that is allowed for an existing
+     connection to have for it to be considered for reuse. If a connection is found in the cache that is older
+     than this value, it will instead be closed once any in-progress transfers are complete.
+     Default is <literal>0</literal> seconds, meaning the option is disabled and all connections are eligible for reuse.
+     This option accepts any value that can be cast to a valid <type>int</type>.
+     Available as of PHP 8.2.0 and cURL 7.80.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-maxredirs">
+   <term>
+    <constant>CURLOPT_MAXREDIRS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     The maximum amount of HTTP redirections to follow. Use this option alongside <constant>CURLOPT_FOLLOWLOCATION</constant>.
+     Default value of <literal>20</literal> is set to prevent infinite redirects.
+     Setting to <literal>-1</literal> allows inifinite redirects, and <literal>0</literal> refuses all redirects.
+     Available as of cURL 7.5.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-max-recv-speed-large">
+   <term>
+    <constant>CURLOPT_MAX_RECV_SPEED_LARGE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     If a download exceeds this speed (counted in bytes per second) on
+     cumulative average during the transfer, the transfer will pause to
+     keep the average rate less than or equal to the parameter value.
+     Defaults to unlimited speed.
+     This option accepts any value that can be cast to a valid <type>int</type>.
+     Available as of cURL 7.15.5.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-max-send-speed-large">
+   <term>
+    <constant>CURLOPT_MAX_SEND_SPEED_LARGE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     If an upload exceeds this speed (counted in bytes per second) on
+     cumulative average during the transfer, the transfer will pause to
+     keep the average rate less than or equal to the parameter value.
+     Defaults to unlimited speed.
+     This option accepts any value that can be cast to a valid <type>int</type>.
+     Available as of cURL 7.15.5.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-mime-options">
+   <term>
+    <constant>CURLOPT_MIME_OPTIONS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set to a bitmask of <constant>CURLMIMEOPT_<replaceable>*</replaceable></constant>
+     constants. Currently there is only one available option:
+     <constant>CURLMIMEOPT_FORMESCAPE</constant>.
+     Available as of PHP 8.3.0 and cURL 7.81.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-mute">
+   <term>
+    <constant>CURLOPT_MUTE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set to &true; to be completely silent with regards to
+     the cURL functions.
+     Use <constant>CURLOPT_RETURNTRANSFER</constant> instead.
+     Available as of cURL 7.1.0, deprecated as of cURL 7.8.0
+     and last available in cURL 7.15.5.
+     Removed as of PHP 7.3.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-netrc">
+   <term>
+    <constant>CURLOPT_NETRC</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set to &true; to scan the <filename>~/.netrc</filename>
+     file to find a username and password for the remote site that
+     a connection is being established with.
+     Available as of cURL 7.1.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-netrc-file">
+   <term>
+    <constant>CURLOPT_NETRC_FILE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set a <type>string</type> containing the full path name to a <literal>.netrc</literal> file.
+     If this option is omitted and <constant>CURLOPT_NETRC</constant> is set,
+     cURL checks for a <literal>.netrc</literal> file
+     in the current user's home directory.
+     Available as of cURL 7.11.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-new-directory-perms">
+   <term>
+    <constant>CURLOPT_NEW_DIRECTORY_PERMS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Sets the value of the permissions (<type>int</type>) that is set on newly created directories
+     on the remote server. The default value is <literal>0755</literal>.
+     The only protocols that can use this are
+     <literal>sftp://</literal>, <literal>scp://</literal>
+     and <literal>file://</literal>.
+     Available as of cURL 7.16.4.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-new-file-perms">
+   <term>
+    <constant>CURLOPT_NEW_FILE_PERMS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Sets the value of the permissions (as an <type>int</type>) that are set on newly created files
+     on the remote server. The default value is <literal>0644</literal>.
+     The only protocols that can use this are
+     <literal>sftp://</literal>, <literal>scp://</literal>
+     and <literal>file://</literal>.
+     Available as of cURL 7.16.4.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-nobody">
+   <term>
+    <constant>CURLOPT_NOBODY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set to &true; to exclude the body from the output.
+     For HTTP(S), cURL makes a HEAD request. For most other protocols,
+     cURL is not asking for the body data at all.
+     Changing this to &false; will result in body data being included in the output.
+     Available as of cURL 7.1.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-noprogress">
+   <term>
+    <constant>CURLOPT_NOPROGRESS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set to &true; to disable the progress meter for cURL transfers.
+     <note>
+      <para>
+       PHP automatically sets this option to &true;, this should only be
+       changed for debugging purposes.
+      </para>
+     </note>
+     Available as of cURL 7.1.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-noproxy">
+   <term>
+    <constant>CURLOPT_NOPROXY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set a <type>string</type> consisting of a comma separated list of hostnames
+     that do not require a proxy to get reached.
+     Each name in this list is matched as either a domain
+     which contains the hostname or the hostname itself.
+     The only wildcard available in the <type>string</type>
+     is a single <literal>*</literal> character which matches all hosts,
+     effectively disabling the proxy.
+     Setting this option to an empty <type>string</type> enables the proxy for all hostnames.
+     Since cURL 7.86.0, IP addresses set with this option
+     can be provided using CIDR notation.
+     Available as of cURL 7.19.4.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-nosignal">
+   <term>
+    <constant>CURLOPT_NOSIGNAL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     &true; to ignore any cURL function that causes a
+     signal to be sent to the PHP process. This is turned on by default
+     in multi-threaded SAPIs so timeout options can still be used.
+     Available as of cURL 7.10.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-passwdfunction">
+   <term>
+    <constant>CURLOPT_PASSWDFUNCTION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A <type>callable</type> with the following signature:
+     <methodsynopsis>
+      <type>string</type><methodname><replaceable>callback</replaceable></methodname>
+      <methodparam><type>resource</type><parameter>curlHandle</parameter></methodparam>
+      <methodparam><type>string</type><parameter>passwordPrompt</parameter></methodparam>
+      <methodparam><type>int</type><parameter>maximumPasswordLength</parameter></methodparam>
+     </methodsynopsis>
+     <variablelist role="function_parameters">
+      <varlistentry>
+       <term><parameter>curlHandle</parameter></term>
+       <listitem>
+        <simpara>
+         The cURL handle.
+        </simpara>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><parameter>passwordPrompt</parameter></term>
+       <listitem>
+        <simpara>
+         A password prompt.
+        </simpara>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><parameter>maximumPasswordLength</parameter></term>
+       <listitem>
+        <simpara>
+         The maximum length of the password.
+        </simpara>
+       </listitem>
+      </varlistentry>
+     </variablelist>
+     The callback should return a <type>string</type> containing the password.
+     Available as of cURL 7.4.2, deprecated as of cURL 7.11.1
+     and last available in cURL 7.15.5.
+     Removed as of PHP 7.3.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-password">
+   <term>
+    <constant>CURLOPT_PASSWORD</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set to a <type>string</type> with the password to use in authentication.
+     Available as of cURL 7.19.1.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-path-as-is">
+   <term>
+    <constant>CURLOPT_PATH_AS_IS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set to &true; for cURL not alter URL paths before passing them on to the server.
+     Defaults to &false;, which squashes sequences of <literal>/../</literal>
+     or <literal>/./</literal> that may exist in the URL's path part
+     which is supposed to be removed according to RFC 3986 section 5.2.4.
+     Available as of PHP 7.0.7 and cURL 7.42.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-pinnedpublickey">
+   <term>
+    <constant>CURLOPT_PINNEDPUBLICKEY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set a <type>string</type> with the pinned public key.
+     The <type>string</type> can be the file name of the pinned public key
+     in a PEM or DER file format. The <type>string</type> can also be any
+     number of base64 encoded sha256 hashes preceded by <literal>sha256//</literal> and
+     separated by <literal>;</literal>.
+     Available as of PHP 7.0.7 and cURL 7.39.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-pipewait">
+   <term>
+    <constant>CURLOPT_PIPEWAIT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set to &true; to wait for an existing connection to confirm
+     whether it can do multiplexing and use it if it can
+     before creating and using a new connection.
+     Available as of PHP 7.0.7 and cURL 7.43.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-port">
+   <term>
+    <constant>CURLOPT_PORT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     An <type>int</type> with an alternative port number to connect to
+     instead of the one specified in the URL or the default port for the used protocol.
+     Available as of cURL 7.1.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-post">
+   <term>
+    <constant>CURLOPT_POST</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set to &true; to do a HTTP <literal>POST</literal> request.
+     This request uses the <literal>application/x-www-form-urlencoded</literal> header.
+     Defaults to &false;.
+     Available as of cURL 7.1.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-postfields">
+   <term>
+    <constant>CURLOPT_POSTFIELDS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     The full data to post in a HTTP <literal>POST</literal> operation.
+     This parameter can either be
+     passed as a urlencoded <type>string</type> like '<literal>para1=val1&amp;para2=val2&amp;...</literal>'
+     or as an <type>array</type> with the field name as key and field data as value.
+     If <parameter>value</parameter> is an <type>array</type>, the
+     <literal>Content-Type</literal> header will be set to
+     <literal>multipart/form-data</literal>.
+     Files can be sent using <classname>CURLFile</classname> or <classname>CURLStringFile</classname>,
+     in which case <parameter>value</parameter> must be an <type>array</type>.
+     Available as of cURL 7.1.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-postquote">
+   <term>
+    <constant>CURLOPT_POSTQUOTE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     An <type>array</type> of FTP command <type>string</type>s
+     to execute on the server after the FTP request has been performed.
+     Available as of cURL 7.1.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-postredir">
+   <term>
+    <constant>CURLOPT_POSTREDIR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set to a bitmask of <constant>CURL_REDIR_POST_301</constant>,
+     <constant>CURL_REDIR_POST_302</constant> and <constant>CURL_REDIR_POST_303</constant>
+     if the HTTP <literal>POST</literal> method should be maintained
+     when <constant>CURLOPT_FOLLOWLOCATION</constant> is set and a
+     specific type of redirect occurs.
+     Available as of cURL 7.19.1.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-pre-proxy">
+   <term>
+    <constant>CURLOPT_PRE_PROXY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set a <type>string</type> holding the host name or dotted numerical
+     IP address to be used as the preproxy that cURL connects to before
+     it connects to the HTTP(S) proxy specified in the
+     <constant>CURLOPT_PROXY</constant> option for the upcoming request.
+     The preproxy can only be a SOCKS proxy and it should be prefixed with
+     <literal>[scheme]://</literal> to specify which kind of socks is used.
+     A numerical IPv6 address must be written within [brackets].
+     Setting the preproxy to an empty <type>string</type> explicitly disables the use of a preproxy.
+     To specify port number in this <type>string</type>, append <literal>:[port]</literal>
+     to the end of the host name. The proxy's port number may optionally be
+     specified with the separate option <constant>CURLOPT_PROXYPORT</constant>.
+     Defaults to using port 1080 for proxies if a port is not specified.
+     Available as of PHP 7.3.0 and cURL 7.52.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-prequote">
+   <term>
+    <constant>CURLOPT_PREQUOTE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set an <type>array</type> of FTP command <type>string</type>s to pass to the server
+     after the transfer type is set.
+     These commands are not performed when a directory listing is performed,
+     only for file transfers.
+     Available as of cURL 7.9.5.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-private">
+   <term>
+    <constant>CURLOPT_PRIVATE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Any data that should be associated with this cURL handle. This data
+     can subsequently be retrieved with the
+     <constant>CURLINFO_PRIVATE</constant> option of
+     <function>curl_getinfo</function>. cURL does nothing with this data.
+     When using a cURL multi handle, this private data is typically a
+     unique key to identify a standard cURL handle.
+     Available as of cURL 7.10.3.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-progressfunction">
+   <term>
+    <constant>CURLOPT_PROGRESSFUNCTION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A <type>callable</type> with the following signature:
+     <methodsynopsis>
+      <type>int</type><methodname><replaceable>callback</replaceable></methodname>
+      <methodparam><type>resource</type><parameter>curlHandle</parameter></methodparam>
+      <methodparam><type>int</type><parameter>bytesToDownload</parameter></methodparam>
+      <methodparam><type>int</type><parameter>bytesDownloaded</parameter></methodparam>
+      <methodparam><type>int</type><parameter>bytesToUpload</parameter></methodparam>
+      <methodparam><type>int</type><parameter>bytesUploaded</parameter></methodparam>
+     </methodsynopsis>
+     <variablelist role="function_parameters">
+      <varlistentry>
+       <term><parameter>curlHandle</parameter></term>
+       <listitem>
+        <simpara>
+         The cURL handle.
+        </simpara>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><parameter>bytesToDownload</parameter></term>
+       <listitem>
+        <simpara>
+         The total number of bytes expected to be downloaded in this transfer.
+        </simpara>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><parameter>bytesDownloaded</parameter></term>
+       <listitem>
+        <simpara>
+         The number of bytes downloaded so far.
+        </simpara>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><parameter>bytesToUpload</parameter></term>
+       <listitem>
+        <simpara>
+         The total number of bytes expected to be uploaded in this transfer.
+        </simpara>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><parameter>bytesUploaded</parameter></term>
+       <listitem>
+        <simpara>
+         The number of bytes uploaded so far.
+        </simpara>
+       </listitem>
+      </varlistentry>
+     </variablelist>
+     The callback should return an <type>int</type> with a non-zero value to abort the transfer
+     and set a <constant>CURLE_ABORTED_BY_CALLBACK</constant> error.
+     <note>
+      <para>
+       The callback is only called when the <constant>CURLOPT_NOPROGRESS</constant>
+       option is set to &false;.
+      </para>
+     </note>
+     Available as of cURL 7.1.0 and deprecated as of cURL 7.32.0.
+     Use <constant>CURLOPT_XFERINFOFUNCTION</constant> instead.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-protocols">
+   <term>
+    <constant>CURLOPT_PROTOCOLS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Bitmask of <constant>CURLPROTO_<replaceable>*</replaceable></constant> values.
+     If used, this bitmask limits what protocols cURL may use in the transfer.
+     Defaults to <constant>CURLPROTO_ALL</constant>, ie. cURL will accept all protocols it supports.
+     See also <constant>CURLOPT_REDIR_PROTOCOLS</constant>.
+     Available as of cURL 7.19.4 and deprecated as of cURL 7.85.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-protocols-str">
+   <term>
+    <constant>CURLOPT_PROTOCOLS_STR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set to a <type>string</type> with a comma separated list
+     of case insensitive protocol names (URL schemes) to allow in the transfer.
+     Set to <literal>ALL</literal> to enable all protocols.
+     By default, cURL accepts all protocols it was built with support for.
+     Available protocols are:
+     <simplelist type="inline">
+      <member><literal>DICT</literal></member>
+      <member><literal>FILE</literal></member>
+      <member><literal>FTP</literal></member>
+      <member><literal>FTPS</literal></member>
+      <member><literal>GOPHER</literal></member>
+      <member><literal>GOPHERS</literal></member>
+      <member><literal>HTTP</literal></member>
+      <member><literal>HTTPS</literal></member>
+      <member><literal>IMAP</literal></member>
+      <member><literal>IMAPS</literal></member>
+      <member><literal>LDAP</literal></member>
+      <member><literal>LDAPS</literal></member>
+      <member><literal>MQTT</literal></member>
+      <member><literal>POP3</literal></member>
+      <member><literal>POP3S</literal></member>
+      <member><literal>RTMP</literal></member>
+      <member><literal>RTMPE</literal></member>
+      <member><literal>RTMPS</literal></member>
+      <member><literal>RTMPT</literal></member>
+      <member><literal>RTMPTE</literal></member>
+      <member><literal>RTMPTS</literal></member>
+      <member><literal>RTSP</literal></member>
+      <member><literal>SCP</literal></member>
+      <member><literal>SFTP</literal></member>
+      <member><literal>SMB</literal></member>
+      <member><literal>SMBS</literal></member>
+      <member><literal>SMTP</literal></member>
+      <member><literal>SMTPS</literal></member>
+      <member><literal>TELNET</literal></member>
+      <member><literal>TFTP</literal></member>
+      <member><literal>WS</literal></member>
+      <member><literal>WSS</literal></member>
+     </simplelist>.
+     Available as of PHP 8.3.0 and cURL 7.85.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-proxy">
+   <term>
+    <constant>CURLOPT_PROXY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A <type>string</type> with the HTTP proxy to tunnel requests through.
+     This should be the hostname, the dotted numerical IP address
+     or a numerical IPv6 address written within [brackets].
+     Available as of cURL 7.1.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-proxyauth">
+   <term>
+    <constant>CURLOPT_PROXYAUTH</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A bitmask of the HTTP authentication method(s)
+     (<constant>CURLAUTH_<replaceable>*</replaceable></constant> constants)
+     to use for the proxy connection.
+     For proxy authentication, only <constant>CURLAUTH_BASIC</constant> and
+     <constant>CURLAUTH_NTLM</constant> are currently supported.
+     Defaults to <constant>CURLAUTH_BASIC</constant>.
+     Available as of cURL 7.10.7.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-proxyheader">
+   <term>
+    <constant>CURLOPT_PROXYHEADER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     An <type>array</type> of custom HTTP header <type>string</type>s to pass to proxies.
+     Available as of PHP 7.0.7 and cURL 7.37.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-proxypassword">
+   <term>
+    <constant>CURLOPT_PROXYPASSWORD</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set a <type>string</type> with the password to be used for authentication with the proxy.
+     Available as of cURL 7.19.1.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-proxyport">
+   <term>
+    <constant>CURLOPT_PROXYPORT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     An <type>int</type> with the port number of the proxy to connect to.
+     This port number can also be set in <constant>CURLOPT_PROXY</constant>.
+     Setting this to zero makes cURL use the default proxy port number
+     or the port number specified in the proxy URL <type>string</type>.
+     Available as of cURL 7.1.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-proxytype">
+   <term>
+    <constant>CURLOPT_PROXYTYPE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Sets the type of the proxy to one of the
+     <constant>CURLPROXY_<replaceable>*</replaceable></constant> constants.
+     Defaults to <constant>CURLPROXY_HTTP</constant>.
+     Available as of cURL 7.10.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-proxyusername">
+   <term>
+    <constant>CURLOPT_PROXYUSERNAME</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set a <type>string</type> with the username to be used for authentication with the proxy.
+     Available as of cURL 7.19.1.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-proxyuserpwd">
+   <term>
+    <constant>CURLOPT_PROXYUSERPWD</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A <type>string</type> with a username and password formatted as
+     <literal>[username]:[password]</literal> to use for the
+     connection to the proxy.
+     Available as of cURL 7.1.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-proxy-cainfo">
+   <term>
+    <constant>CURLOPT_PROXY_CAINFO</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     The path to proxy Certificate Authority (CA) bundle. Set the path as a
+     <type>string</type> naming a file holding one or more certificates to
+     verify the HTTPS proxy with.
+     This option is for connecting to an HTTPS proxy, not an HTTPS server.
+     Defaults set to the system path where cURL's cacert bundle is assumed
+     to be stored.
+     Available as of PHP 7.3.0 and cURL 7.52.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-proxy-cainfo-blob">
+   <term>
+    <constant>CURLOPT_PROXY_CAINFO_BLOB</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A <type>string</type> with the name of a PEM file holding one or more certificates to verify the HTTPS proxy with.
+     This option is for connecting to an HTTPS proxy, not an HTTPS server.
+     Defaults set to the system path where cURL's cacert bundle is assumed
+     to be stored.
+     Available as of PHP 8.2.0 and cURL 7.77.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-proxy-capath">
+   <term>
+    <constant>CURLOPT_PROXY_CAPATH</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A <type>string</type> with the directory holding multiple CA certificates
+     to verify the HTTPS proxy with.
+     Available as of PHP 7.3.0 and cURL 7.52.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-proxy-crlfile">
+   <term>
+    <constant>CURLOPT_PROXY_CRLFILE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set to a <type>string</type> with the file name
+     with the concatenation of CRL (Certificate Revocation List)
+     in PEM format to use in the certificate validation that occurs during
+     the SSL exchange.
+     Available as of PHP 7.3.0 and cURL 7.52.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-proxy-issuercert">
+   <term>
+    <constant>CURLOPT_PROXY_ISSUERCERT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Proxy issuer SSL certificate filename <type>string</type>.
+     Available as of PHP 8.1.0 and cURL 7.71.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-proxy-issuercert-blob">
+   <term>
+    <constant>CURLOPT_PROXY_ISSUERCERT_BLOB</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A <type>string</type> with the proxy issuer SSL certificate.
+     Available as of PHP 8.1.0 and cURL 7.71.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-proxy-keypasswd">
+   <term>
+    <constant>CURLOPT_PROXY_KEYPASSWD</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set the <type>string</type> be used as the password required to use the
+     <constant>CURLOPT_PROXY_SSLKEY</constant> private key.
+     A passphrase is not needed to load a certificate
+     but one is needed to load a private key.
+     This option is for connecting to an HTTPS proxy, not an HTTPS server.
+     Available as of PHP 7.3.0 and cURL 7.52.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-proxy-pinnedpublickey">
+   <term>
+    <constant>CURLOPT_PROXY_PINNEDPUBLICKEY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set the pinned public key for HTTPS proxy.
+     The <type>string</type> can be the file name of the pinned public key
+     which is expected to be in a <literal>PEM</literal>
+     or <literal>DER</literal> file format.
+     The <type>string</type> can also be any number of base64 encoded sha256 hashes
+     preceded by <literal>sha256//</literal> and separated by <literal>;</literal>.
+     Available as of PHP 7.3.0 and cURL 7.52.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-proxy-service-name">
+   <term>
+    <constant>CURLOPT_PROXY_SERVICE_NAME</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A <type>string</type> with the proxy authentication service name.
+     Available as of PHP 7.0.7, cURL 7.43.0 (for HTTP proxies) and cURL 7.49.0 (for SOCKS5 proxies).
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-proxy-sslcert">
+   <term>
+    <constant>CURLOPT_PROXY_SSLCERT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A <type>string</type> with the file name of the client certificate used to connect to the HTTPS proxy.
+     The default format is <literal>P12</literal> on Secure Transport and <literal>PEM</literal> on other engines,
+     and can be changed with <constant>CURLOPT_PROXY_SSLCERTTYPE</constant>.
+     With NSS or Secure Transport, this can also be the nickname of the certificate
+     used for authentication as it is named in the security database.
+     If a file from the current directory is to be used,
+     it must be prefixed with <literal>./</literal>
+     in order to avoid confusion with a nickname.
+     Available as of PHP 7.3.0 and cURL 7.52.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-proxy-sslcerttype">
+   <term>
+    <constant>CURLOPT_PROXY_SSLCERTTYPE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A <type>string</type> with the format of the client certificate used when connecting to an HTTPS proxy.
+     Supported formats are <literal>PEM</literal> and <literal>DER</literal>, except with Secure Transport.
+     OpenSSL (versions 0.9.3 and later) and Secure Transport
+     (on iOS 5 or later, or OS X 10.7 or later) also support <literal>P12</literal> for
+     PKCS#12-encoded files. Defaults to <literal>PEM</literal>.
+     Available as of PHP 7.3.0 and cURL 7.52.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-proxy-sslcert-blob">
+   <term>
+    <constant>CURLOPT_PROXY_SSLCERT_BLOB</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A <type>string</type> with the SSL proxy client certificate.
+     Available as of PHP 8.1.0 and cURL 7.71.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-proxy-sslkey">
+   <term>
+    <constant>CURLOPT_PROXY_SSLKEY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A <type>string</type> with the file name of the private key
+     used for connecting to the HTTPS proxy.
+     The default format is <literal>PEM</literal> and can be changed with
+     <constant>CURLOPT_PROXY_SSLKEYTYPE</constant>.
+     (iOS and Mac OS X only) This option is ignored if cURL was built against
+     Secure Transport. Available if built with TLS enabled.
+     Available as of PHP 7.3.0 and cURL 7.52.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-proxy-sslkeytype">
+   <term>
+    <constant>CURLOPT_PROXY_SSLKEYTYPE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A <type>string</type> with the format of the private key.
+     Supported formats are:
+     <simplelist type="inline">
+      <member><literal>PEM</literal></member>
+      <member><literal>DER</literal></member>
+      <member><literal>ENG</literal></member>
+     </simplelist>.
+     Available as of PHP 7.3.0 and cURL 7.52.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-proxy-sslkey-blob">
+   <term>
+    <constant>CURLOPT_PROXY_SSLKEY_BLOB</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A <type>string</type> with the private key for connecting to the HTTPS proxy.
+     Available as of PHP 8.1.0 and cURL 7.71.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-proxy-sslversion">
+   <term>
+    <constant>CURLOPT_PROXY_SSLVERSION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set the preferred HTTPS proxy TLS version to one of the
+     <constant>CURL_SSLVERSION_<replaceable>*</replaceable></constant>
+     constants.
+     Defaults to <constant>CURL_SSLVERSION_DEFAULT</constant>.
+     <warning>
+      <simpara>
+       It is better to not set this option and leave the default
+       <constant>CURL_SSLVERSION_DEFAULT</constant>
+       which will attempt to figure out the remote SSL protocol version.
+      </simpara>
+     </warning>
+     Available as of PHP 7.3.0 and cURL 7.52.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-proxy-ssl-cipher-list">
+   <term>
+    <constant>CURLOPT_PROXY_SSL_CIPHER_LIST</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A <type>string</type> with a colon-separated list of ciphers
+     to use for the connection to the HTTPS proxy.
+     When used with OpenSSL commas and spaces are also acceptable as separators,
+     and <literal>!</literal>, <literal>-</literal> and <literal>+</literal>
+     can be used as operators.
+     Available as of PHP 7.3.0 and cURL 7.52.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-proxy-ssl-options">
+   <term>
+    <constant>CURLOPT_PROXY_SSL_OPTIONS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set proxy SSL behavior options, which is a bitmask of the
+     <constant>CURLSSLOPT_<replaceable>*</replaceable></constant> constants.
+     Available as of PHP 7.3.0 and cURL 7.52.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-proxy-ssl-verifyhost">
+   <term>
+    <constant>CURLOPT_PROXY_SSL_VERIFYHOST</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set to <literal>2</literal> to verify in the HTTPS proxy's certificate name fields against the proxy name.
+     When set to <literal>0</literal> the connection succeeds regardless of the names used in the certificate.
+     Use that ability with caution!
+     Set to <literal>1</literal> in cURL 7.28.0 and earlier as a debug option.
+     Set to <literal>1</literal> in  cURL 7.28.1 to 7.65.3 <constant>CURLE_BAD_FUNCTION_ARGUMENT</constant> is returned.
+     As of cURL 7.66.0 <literal>1</literal> and <literal>2</literal> is treated as the same value.
+     Defaults to <literal>2</literal>.
+     In production environments the value of this option should be kept at <literal>2</literal>.
+     Available as of PHP 7.3.0 and cURL 7.52.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-proxy-ssl-verifypeer">
+   <term>
+    <constant>CURLOPT_PROXY_SSL_VERIFYPEER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set to &false; to stop cURL from verifying the peer's certificate.
+     Alternate certificates to verify against can be
+     specified with the <constant>CURLOPT_CAINFO</constant> option
+     or a certificate directory can be specified with the
+     <constant>CURLOPT_CAPATH</constant> option.
+     When set to &false;, the peer certificate verification succeeds regardless.
+     &true; by default.
+     Available as of PHP 7.3.0 and cURL 7.52.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-proxy-tls13-ciphers">
+   <term>
+    <constant>CURLOPT_PROXY_TLS13_CIPHERS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A <type>string</type> with a colon-separated list of ciphers to use for the connection to the TLS 1.3 connection to a proxy.
+     This option is currently used only when cURL is built to use OpenSSL 1.1.1 or later.
+     When using a different SSL backend the TLS 1.3 cipher suites can be set
+     with the <constant>CURLOPT_PROXY_SSL_CIPHER_LIST</constant> option.
+     Available as of PHP 7.3.0 and cURL 7.61.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-proxy-tlsauth-password">
+   <term>
+    <constant>CURLOPT_PROXY_TLSAUTH_PASSWORD</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A <type>string</type> with the password to use for the TLS authentication method specified with the
+     <constant>CURLOPT_PROXY_TLSAUTH_TYPE</constant> option. Requires that the
+     <constant>CURLOPT_PROXY_TLSAUTH_USERNAME</constant> option to also be set.
+     Available as of PHP 7.3.0 and cURL 7.52.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-proxy-tlsauth-type">
+   <term>
+    <constant>CURLOPT_PROXY_TLSAUTH_TYPE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     The method of the TLS authentication used for the HTTPS connection.
+     Supported method is <literal>SRP</literal>.
+     <note>
+      <para>
+       Secure Remote Password (SRP) authentication for TLS provides mutual authentication
+       if both sides have a shared secret. To use TLS-SRP, the
+       <constant>CURLOPT_PROXY_TLSAUTH_USERNAME</constant> and
+       <constant>CURLOPT_PROXY_TLSAUTH_PASSWORD</constant> options must also be set.
+      </para>
+     </note>
+     Available as of PHP 7.3.0 and cURL 7.52.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-proxy-tlsauth-username">
+   <term>
+    <constant>CURLOPT_PROXY_TLSAUTH_USERNAME</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     The username to use for the HTTPS proxy TLS authentication method specified with the
+     <constant>CURLOPT_PROXY_TLSAUTH_TYPE</constant> option. Requires that the
+     <constant>CURLOPT_PROXY_TLSAUTH_PASSWORD</constant> option to also be set.
+     Available as of PHP 7.3.0 and cURL 7.52.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-proxy-transfer-mode">
+   <term>
+    <constant>CURLOPT_PROXY_TRANSFER_MODE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set to <literal>1</literal> to set the transfer mode (binary or ASCII)
+     for FTP transfers done via an HTTP proxy, by appending
+     <literal>type=a</literal> or <literal>type=i</literal> to the URL.
+     Without this setting or it being set to <literal>0</literal>,
+     <constant>CURLOPT_TRANSFERTEXT</constant> has no effect
+     when doing FTP via a proxy.
+     Defaults to <literal>0</literal>.
+     Available as of cURL 7.18.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-put">
+   <term>
+    <constant>CURLOPT_PUT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     &true; to HTTP PUT a file. The file to PUT must
+     be set with <constant>CURLOPT_READDATA</constant> and
+     <constant>CURLOPT_INFILESIZE</constant>.
+     Available as of cURL 7.1.0 and deprecated as of cURL 7.12.1.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-quick-exit">
+   <term>
+    <constant>CURLOPT_QUICK_EXIT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set to &true; for cURL to skip cleanup of resources
+     when recovering from a timeout.
+     This allows for a swift termination of the cURL process
+     at the expense of a possible leak of associated resources.
+     Available as of PHP 8.3.0 and cURL 7.87.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-quote">
+   <term>
+    <constant>CURLOPT_QUOTE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     An <type>array</type> of FTP command <type>string</type>s to execute on the server prior to the FTP request.
+     Available as of cURL 7.1.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-random-file">
+   <term>
+    <constant>CURLOPT_RANDOM_FILE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A <type>string</type> with a filename to be used to seed the random number generator for SSL.
+     Available as of cURL 7.7.0 and deprecated as of cURL 7.84.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-range">
+   <term>
+    <constant>CURLOPT_RANGE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A <type>string</type> with the range(s) of data to retrieve in the format <literal>X-Y</literal> where X or Y are optional. HTTP transfers
+     also support several intervals, separated with commas in the format
+     <literal>X-Y,N-M</literal>.
+     Set to &null; to disable requesting a byte range.
+     Available as of cURL 7.1.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-readdata">
+   <term>
+    <constant>CURLOPT_READDATA</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Sets a file pointer <type>resource</type> that will be used by the file read function
+     set with <constant>CURLOPT_READFUNCTION</constant>.
+     Available as of cURL 7.9.7.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-readfunction">
+   <term>
+    <constant>CURLOPT_READFUNCTION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A <type>callable</type> with the following signature:
+     <methodsynopsis>
+      <type>string</type><methodname><replaceable>callback</replaceable></methodname>
+      <methodparam><type>resource</type><parameter>curlHandle</parameter></methodparam>
+      <methodparam><type>resource</type><parameter>streamResource</parameter></methodparam>
+      <methodparam><type>int</type><parameter>maxAmountOfDataToRead</parameter></methodparam>
+     </methodsynopsis>
+     <variablelist role="function_parameters">
+      <varlistentry>
+       <term><parameter>curlHandle</parameter></term>
+       <listitem>
+        <simpara>
+         The cURL handle.
+        </simpara>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><parameter>streamResource</parameter></term>
+       <listitem>
+        <simpara>
+         Stream <type>resource</type> provided to cURL through the option
+     <constant>CURLOPT_READDATA</constant>.
+        </simpara>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><parameter>maxAmountOfDataToRead</parameter></term>
+       <listitem>
+        <simpara>
+         The maximum amount of data to be read.
+        </simpara>
+       </listitem>
+      </varlistentry>
+     </variablelist>
+     The callback should return a <type>string</type>
+     with a length equal or smaller than the amount of data requested,
+     typically by reading it from the passed stream <type>resource</type>. It should
+     return an empty <type>string</type> to signal <literal>EOF</literal>.
+     Available as of cURL 7.1.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-redir-protocols">
+   <term>
+    <constant>CURLOPT_REDIR_PROTOCOLS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Bitmask of <constant>CURLPROTO_<replaceable>*</replaceable></constant> values
+     which limit what protocols cURL may use in a transfer that it follows to in
+     a redirect when <constant>CURLOPT_FOLLOWLOCATION</constant> is enabled.
+     This allows limiting specific transfers to only be allowed to use a subset
+     of protocols in redirections.
+     As of cURL 7.19.4, by default cURL will allow all protocols
+     except for <literal>FILE</literal> and <literal>SCP</literal>.
+     Prior to cURL 7.19.4, cURL would unconditionally follow to all supported protocols.
+     See also <constant>CURLOPT_PROTOCOLS</constant> for protocol constant values.
+     Available as of cURL 7.19.4 and deprecated as of cURL 7.85.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-redir-protocols-str">
+   <term>
+    <constant>CURLOPT_REDIR_PROTOCOLS_STR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set to a <type>string</type> with a comma separated list
+     of case insensitive protocol names (URL schemes)
+     to allow to follow to in a redirect when
+     <constant>CURLOPT_FOLLOWLOCATION</constant> is enabled.
+     Set to <literal>ALL</literal> to enable all protocols.
+     As of cURL 7.65.2 it defaults to <literal>FTP</literal>,
+     <literal>FTPS</literal>, <literal>HTTP</literal> and <literal>HTTPS</literal>.
+     From cURL 7.40.0 to 7.65.1, this defaults to all protocols except
+     <literal>FILE</literal>, <literal>SCP</literal>, <literal>SMB</literal> and
+     <literal>SMBS</literal>.
+     Prior to cURL 7.40.0, this defaults to all protocols except
+     <literal>FILE</literal> and <literal>SCP</literal>.
+     Available protocols are:
+     <simplelist type="inline">
+      <member><literal>DICT</literal></member>
+      <member><literal>FILE</literal></member>
+      <member><literal>FTP</literal></member>
+      <member><literal>FTPS</literal></member>
+      <member><literal>GOPHER</literal></member>
+      <member><literal>GOPHERS</literal></member>
+      <member><literal>HTTP</literal></member>
+      <member><literal>HTTPS</literal></member>
+      <member><literal>IMAP</literal></member>
+      <member><literal>IMAPS</literal></member>
+      <member><literal>LDAP</literal></member>
+      <member><literal>LDAPS</literal></member>
+      <member><literal>MQTT</literal></member>
+      <member><literal>POP3</literal></member>
+      <member><literal>POP3S</literal></member>
+      <member><literal>RTMP</literal></member>
+      <member><literal>RTMPE</literal></member>
+      <member><literal>RTMPS</literal></member>
+      <member><literal>RTMPT</literal></member>
+      <member><literal>RTMPTE</literal></member>
+      <member><literal>RTMPTS</literal></member>
+      <member><literal>RTSP</literal></member>
+      <member><literal>SCP</literal></member>
+      <member><literal>SFTP</literal></member>
+      <member><literal>SMB</literal></member>
+      <member><literal>SMBS</literal></member>
+      <member><literal>SMTP</literal></member>
+      <member><literal>SMTPS</literal></member>
+      <member><literal>TELNET</literal></member>
+      <member><literal>TFTP</literal></member>
+      <member><literal>WS</literal></member>
+      <member><literal>WSS</literal></member>
+     </simplelist>.
+     Available as of PHP 8.3.0 and cURL 7.85.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-referer">
+   <term>
+    <constant>CURLOPT_REFERER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A <type>string</type> with the contents of the <literal>Referer: </literal>
+     header to be used in a HTTP request.
+     Available as of cURL 7.1.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-request-target">
+   <term>
+    <constant>CURLOPT_REQUEST_TARGET</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A <type>string</type> to use in the upcoming request
+     instead of the path as extracted from the URL.
+     Available as of PHP 7.3.0 and cURL 7.55.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-resolve">
+   <term>
+    <constant>CURLOPT_RESOLVE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Provide an <type>array</type> of colon-separated <type>string</type>s
+     with custom addresses for specific host and port pairs in the following format:
+     <code>
+      array(
+        "example.com:80:127.0.0.1",
+        "example2.com:443:127.0.0.2",
+      )
+     </code>
+     Available as of cURL 7.21.3.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-resume-from">
+   <term>
+    <constant>CURLOPT_RESUME_FROM</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     The offset, in bytes, to resume a transfer from.
+     This option accepts any value that can be cast to a valid <type>int</type>.
+     Available as of cURL 7.1.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-returntransfer">
+   <term>
+    <constant>CURLOPT_RETURNTRANSFER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     &true; to return the transfer as a <type>string</type> of the
+     return value of <function>curl_exec</function> instead of outputting
+     it directly.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-rtsp-client-cseq">
+   <term>
+    <constant>CURLOPT_RTSP_CLIENT_CSEQ</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set an <type>int</type> with the CSEQ number to issue for the next RTSP request.
+     Useful if the application is resuming a previously broken connection.
+     The CSEQ increments from this new number henceforth.
+     Defaults to <literal>0</literal>.
+     Available as of cURL 7.20.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-rtsp-request">
+   <term>
+    <constant>CURLOPT_RTSP_REQUEST</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Sets the kind of RTSP request to make.
+     Must be one of the <constant>CURL_RTSPREQ_<replaceable>*</replaceable></constant>
+     constants.
+     Available as of cURL 7.20.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-rtsp-server-cseq">
+   <term>
+    <constant>CURLOPT_RTSP_SERVER_CSEQ</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set an <type>int</type> with the CSEQ number to expect
+     for the next RTSP Server to Client request.
+     This feature (listening for Server requests) is unimplemented.
+     Defaults to <literal>0</literal>.
+     Available as of cURL 7.20.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-rtsp-session-id">
+   <term>
+    <constant>CURLOPT_RTSP_SESSION_ID</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set a <type>string</type> with the value of the current RTSP Session ID for the handle.
+     Once this value is set to any non-&null; value,
+     cURL returns <constant>CURLE_RTSP_SESSION_ERROR</constant>
+     if the ID received from the server does not match.
+     If set to &null;, cURL automatically sets the ID
+     the first time the server sets it in a response.
+     Defaults to &null;
+     Available as of cURL 7.20.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-rtsp-stream-uri">
+   <term>
+    <constant>CURLOPT_RTSP_STREAM_URI</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Sets a <type>string</type> with the stream URI to operate on.
+     If not set, cURL defaults to operating on generic server options
+     by passing <literal>*</literal> in the place of the RTSP Stream URI.
+     When working with RTSP, <literal>CURLOPT_RTSP_STREAM_URI</literal>
+     indicates what URL to send to the server in the request header
+     while the <literal>CURLOPT_URL</literal> indicates
+     where to make the connection to.
+     Available as of cURL 7.20.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-rtsp-transport">
+   <term>
+    <constant>CURLOPT_RTSP_TRANSPORT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set the <literal>Transport:</literal> header for this RTSP session.
+     Available as of cURL 7.20.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-safe-upload">
+   <term>
+    <constant>CURLOPT_SAFE_UPLOAD</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Always &true;, what disables support for the <literal>@</literal> prefix for
+     uploading files in <constant>CURLOPT_POSTFIELDS</constant>, which
+     means that values starting with <literal>@</literal> can be safely
+     passed as fields. <classname>CURLFile</classname> may be used for
+     uploads instead.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-sasl-authzid">
+   <term>
+    <constant>CURLOPT_SASL_AUTHZID</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     The authorization identity (authzid) <type>string</type> for the transfer. Only applicable to the PLAIN SASL
+     authentication mechanism where it is optional. When not specified, only the authentication identity
+     (authcid) as specified by the username will be sent to the server, along with the password.
+     The server will derive the authzid from the authcid when not provided, which it will then use internally.
+     Available as of PHP 8.2.0 and cURL 7.66.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-sasl-ir">
+   <term>
+    <constant>CURLOPT_SASL_IR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     &true; to enable sending the initial response in the first packet.
+     Available as of PHP 7.0.7 and cURL 7.31.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-service-name">
+   <term>
+    <constant>CURLOPT_SERVICE_NAME</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A <type>string</type> with the authentication service name.
+     Available as of PHP 7.0.7 and cURL 7.43.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-share">
+   <term>
+    <constant>CURLOPT_SHARE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A result of <function>curl_share_init</function>. Makes the cURL
+     handle to use the data from the shared handle.
+     Available as of cURL 7.10.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-socks5-auth">
+   <term>
+    <constant>CURLOPT_SOCKS5_AUTH</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     The SOCKS5 authentication method(s) to use. The options are:
+     <simplelist type="inline">
+      <member><constant>CURLAUTH_BASIC</constant></member>
+      <member><constant>CURLAUTH_GSSAPI</constant></member>
+      <member><constant>CURLAUTH_NONE</constant></member>
+     </simplelist>.
+     When more than one method is set, cURL will poll the server to see
+     what methods it supports and pick the best one.
+     Defaults to <literal>CURLAUTH_BASIC|CURLAUTH_GSSAPI</literal>.
+     Set the actual username and password with the <constant>CURLOPT_PROXYUSERPWD</constant> option.
+     Available as of PHP 7.3.0 and cURL 7.55.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-socks5-gssapi-nec">
+   <term>
+    <constant>CURLOPT_SOCKS5_GSSAPI_NEC</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set to <literal>1</literal> to enable and <literal>0</literal> to disable
+     the unprotected exchange of the protection mode negotiation
+     as part of the GSSAPI negotiation.
+     Available as of cURL 7.19.4.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-socks5-gssapi-service">
+   <term>
+    <constant>CURLOPT_SOCKS5_GSSAPI_SERVICE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set a <type>string</type> holding the name of the SOCKS5 service.
+     Defaults to <literal>rcmd</literal>.
+     Available as of cURL 7.19.4 and deprecated as of cURL 7.49.0.
+     Use <constant>CURLOPT_PROXY_SERVICE_NAME</constant> instead.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ssh-auth-types">
+   <term>
+    <constant>CURLOPT_SSH_AUTH_TYPES</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A bitmask consisting of one or more of the following constants:
+     <simplelist type="inline">
+      <member><constant>CURLSSH_AUTH_PUBLICKEY</constant></member>
+      <member><constant>CURLSSH_AUTH_PASSWORD</constant></member>
+      <member><constant>CURLSSH_AUTH_HOST</constant></member>
+      <member><constant>CURLSSH_AUTH_KEYBOARD</constant></member>
+      <member><constant>CURLSSH_AUTH_AGENT</constant></member>
+      <member><constant>CURLSSH_AUTH_ANY</constant></member>
+     </simplelist>.
+     Defaults to <constant>CURLSSH_AUTH_ANY</constant>.
+     Available as of cURL 7.16.1.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ssh-compression">
+   <term>
+    <constant>CURLOPT_SSH_COMPRESSION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     &true; to enable, &false; to disable built-in SSH compression.
+     Note that the server can disregard this request.
+     Defaults to &false;.
+     Available as of PHP 7.3.0 and cURL 7.56.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ssh-hostkeyfunction">
+   <term>
+    <constant>CURLOPT_SSH_HOSTKEYFUNCTION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A <type>callable</type> that will be called when SSH host key verification is needed.
+     The callback must have the following signature:
+     <methodsynopsis>
+      <type>int</type><methodname><replaceable>callback</replaceable></methodname>
+      <methodparam><type>resource</type><parameter>curlHandle</parameter></methodparam>
+      <methodparam><type>int</type><parameter>keyType</parameter></methodparam>
+      <methodparam><type>string</type><parameter>key</parameter></methodparam>
+      <methodparam><type>int</type><parameter>keyLength</parameter></methodparam>
+     </methodsynopsis>
+     <variablelist role="function_parameters">
+      <varlistentry>
+       <term><parameter>curlHandle</parameter></term>
+       <listitem>
+        <simpara>
+         The cURL handle.
+        </simpara>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><parameter>keyType</parameter></term>
+       <listitem>
+        <simpara>
+         One of the <constant>CURLKHTYPE_<replaceable>*</replaceable></constant> key types.
+        </simpara>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><parameter>key</parameter></term>
+       <listitem>
+        <simpara>
+         The key to check.
+        </simpara>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><parameter>keyLength</parameter></term>
+       <listitem>
+        <simpara>
+         The length of the key in bytes.
+        </simpara>
+       </listitem>
+      </varlistentry>
+     </variablelist>
+     This callback overrides <constant>CURLOPT_SSH_KNOWNHOSTS</constant>.
+     Available as of PHP 8.3.0 and cURL 7.84.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ssh-host-public-key-md5">
+   <term>
+    <constant>CURLOPT_SSH_HOST_PUBLIC_KEY_MD5</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A <type>string</type> containing 32 hexadecimal digits which should contain the
+     MD5 checksum of the remote host's public key, and cURL will reject
+     the connection to the host unless the md5sums match.
+     This option is only for SCP and SFTP transfers.
+     Available as of cURL 7.17.1.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ssh-host-public-key-sha256">
+   <term>
+    <constant>CURLOPT_SSH_HOST_PUBLIC_KEY_SHA256</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A <type>string</type> with the base64-encoded SHA256 hash
+     of the remote host's public key.
+     The transfer will fail if the given hash does not match the hash the remote host provides.
+     Available as of PHP 8.2.0 and cURL 7.80.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ssh-knownhosts">
+   <term>
+    <constant>CURLOPT_SSH_KNOWNHOSTS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set to the filename of the <filename>known_host</filename> file to use
+     which should use the OpenSSH file format as supported by libssh2.
+     Available as of cURL 7.19.6.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ssh-private-keyfile">
+   <term>
+    <constant>CURLOPT_SSH_PRIVATE_KEYFILE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     The file name for a private key. If not used, cURL defaults to
+     <filename>$HOME/.ssh/id_dsa</filename> if the HOME environment variable is set,
+     and just <literal>id_dsa</literal> in the current directory if HOME is not set.
+     If the file is password-protected, set the password with
+     <constant>CURLOPT_KEYPASSWD</constant>.
+     Available as of cURL 7.16.1.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ssh-public-keyfile">
+   <term>
+    <constant>CURLOPT_SSH_PUBLIC_KEYFILE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     The file name for a public key. If not used, cURL defaults to
+     <filename>$HOME/.ssh/id_dsa.pub</filename> if the HOME environment variable is set,
+     and just <literal>id_dsa.pub</literal> in the current directory if HOME is not set.
+     Available as of cURL 7.16.1.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-sslcert">
+   <term>
+    <constant>CURLOPT_SSLCERT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     The name of a file containing a PEM formatted certificate.
+     Available as of cURL 7.1.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-sslcertpasswd">
+   <term>
+    <constant>CURLOPT_SSLCERTPASSWD</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     The password required to use the
+     <constant>CURLOPT_SSLCERT</constant> certificate.
+     Available as of cURL 7.1.0 and deprecated as of cURL 7.17.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-sslcerttype">
+   <term>
+    <constant>CURLOPT_SSLCERTTYPE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A <type>string</type> with the format of the certificate. Supported formats are:
+     <simplelist type="inline">
+      <member><literal>PEM</literal></member>
+      <member><literal>DER</literal></member>
+      <member><literal>ENG</literal></member>
+      <member><literal>P12</literal></member>
+     </simplelist>.
+     <literal>P12</literal> (for PKCS#12-encoded files) is available as of OpenSSL 0.9.3.
+     Defaults to <literal>PEM</literal>.
+     Available as of cURL 7.9.3.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-sslcert-blob">
+   <term>
+    <constant>CURLOPT_SSLCERT_BLOB</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A <type>string</type> with the SSL client certificate.
+     Available as of PHP 8.1.0 and cURL 7.71.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-sslengine">
+   <term>
+    <constant>CURLOPT_SSLENGINE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     The <type>string</type> identifier for the crypto engine of the private SSL key
+     specified in <constant>CURLOPT_SSLKEY</constant>.
+     Available as of cURL 7.9.3.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-sslengine-default">
+   <term>
+    <constant>CURLOPT_SSLENGINE_DEFAULT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     The <type>string</type> identifier for the crypto engine used for asymmetric crypto
+     operations.
+     Available as of cURL 7.9.3.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-sslkey">
+   <term>
+    <constant>CURLOPT_SSLKEY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     The name of a file containing a private SSL key.
+     Available as of cURL 7.9.3.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-sslkeypasswd">
+   <term>
+    <constant>CURLOPT_SSLKEYPASSWD</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     The secret password needed to use the private SSL key specified in
+     <constant>CURLOPT_SSLKEY</constant>.
+     <note>
+      <para>
+       Since this option contains a sensitive password, remember to keep
+       the PHP script it is contained within safe.
+      </para>
+     </note>
+     Available as of cURL 7.9.3 and deprecated as of cURL 7.17.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-sslkeytype">
+   <term>
+    <constant>CURLOPT_SSLKEYTYPE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     The key type of the private SSL key specified in
+     <constant>CURLOPT_SSLKEY</constant>. Supported key types are:
+     <simplelist type="inline">
+      <member><literal>PEM</literal></member>
+      <member><literal>DER</literal></member>
+      <member><literal>ENG</literal></member>
+     </simplelist>.
+     Defaults to <literal>PEM</literal>.
+     Available as of cURL 7.9.3.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-sslkey-blob">
+   <term>
+    <constant>CURLOPT_SSLKEY_BLOB</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A <type>string</type> private key for client cert.
+     Available as of PHP 8.1.0 and cURL 7.71.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-sslversion">
+   <term>
+    <constant>CURLOPT_SSLVERSION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     One of
+     the <constant>CURL_SSLVERSION_<replaceable>*</replaceable></constant> constants.
+     <warning>
+      <simpara>
+       It is better to not set this option and leave the defaults.
+       As setting this to
+       <constant>CURL_SSLVERSION_SSLv2</constant>
+       or
+       <constant>CURL_SSLVERSION_SSLv3</constant>
+       is very dangerous, given the known
+       vulnerabilities in SSLv2 and SSLv3.
+      </simpara>
+     </warning>
+     Defaults to <constant>CURL_SSLVERSION_DEFAULT</constant>.
+     Available as of cURL 7.1.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ssl-cipher-list">
+   <term>
+    <constant>CURLOPT_SSL_CIPHER_LIST</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A colon-separated <type>string</type> of ciphers to use
+     for the TLS 1.2 (1.1, 1.0) connection.
+     Available as of cURL 7.9.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ssl-ec-curves">
+   <term>
+    <constant>CURLOPT_SSL_EC_CURVES</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A colon delimited list of elliptic curve algorithms. For example,
+     <literal>X25519:P-521</literal> is a valid list of two elliptic curves.
+     This option defines the client's key exchange algorithms in the SSL handshake,
+     if the SSL backend cURL is built to use supports it.
+     Available as of PHP 8.2.0 and cURL 7.73.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ssl-enable-alpn">
+   <term>
+    <constant>CURLOPT_SSL_ENABLE_ALPN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     &false; to disable ALPN in the SSL handshake (if the SSL backend
+     cURL is built to use supports it), which can be used to
+     negotiate http2.
+     Available as of PHP 7.0.7 and cURL 7.36.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ssl-enable-npn">
+   <term>
+    <constant>CURLOPT_SSL_ENABLE_NPN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     &false; to disable NPN in the SSL handshake (if the SSL backend
+     cURL is built to use supports it), which can be used to
+     negotiate http2.
+     Available as of PHP 7.0.7 and cURL 7.36.0, and deprecated as of cURL 7.86.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ssl-falsestart">
+   <term>
+    <constant>CURLOPT_SSL_FALSESTART</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     &true; to enable and &false; to disable TLS false start
+     which is a mode where a TLS client starts sending application data
+     before verifying the server's <literal>Finished</literal> message.
+     Available as of PHP 7.0.7 and cURL 7.42.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ssl-options">
+   <term>
+    <constant>CURLOPT_SSL_OPTIONS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set SSL behavior options, which is a bitmask of the
+     <constant>CURLSSLOPT_<replaceable>*</replaceable></constant> constants.
+     Defaults to none of the bits being set.
+     Available as of PHP 7.0.7. and cURL 7.25.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ssl-sessionid-cache">
+   <term>
+    <constant>CURLOPT_SSL_SESSIONID_CACHE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set to <literal>0</literal> to disable and <literal>1</literal> to enable
+     SSL session-ID caching.
+     By default all transfers are done using the cache enabled.
+     Available as of cURL 7.16.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ssl-verifyhost">
+   <term>
+    <constant>CURLOPT_SSL_VERIFYHOST</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     <literal>2</literal> to verify that a Common Name field or a Subject Alternate Name
+     field in the SSL peer certificate matches the provided hostname.
+     <literal>0</literal> to not check the names.
+     <literal>1</literal> should not be used.
+     In production environments the value of this option
+     should be kept at <literal>2</literal> (default value). Support for value <literal>1</literal> removed in cURL 7.28.1.
+     Available as of cURL 7.8.1.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ssl-verifypeer">
+   <term>
+    <constant>CURLOPT_SSL_VERIFYPEER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     &false; to stop cURL from verifying the peer's
+     certificate. Alternate certificates to verify against can be
+     specified with the <constant>CURLOPT_CAINFO</constant> option
+     or a certificate directory can be specified with the
+     <constant>CURLOPT_CAPATH</constant> option.
+     Defaults to &true; as of cURL 7.10.
+     Default bundle of CA certificates installed as of cURL 7.10.
+     Available as of cURL 7.4.2.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ssl-verifystatus">
+   <term>
+    <constant>CURLOPT_SSL_VERIFYSTATUS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     &true; to enable and &false; to disable verification of the certificate's status.
+     Available as of PHP 7.0.7 and cURL 7.41.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-stderr">
+   <term>
+    <constant>CURLOPT_STDERR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Accepts a file handle <type>resource</type> pointing to
+     an alternative location to output errors to instead of
+     <constant>STDERR</constant>.
+     Available as of cURL 7.1.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-stream-weight">
+   <term>
+    <constant>CURLOPT_STREAM_WEIGHT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set the numerical stream weight (a number between <literal>1</literal> and <literal>256</literal>).
+     Available as of PHP 7.0.7 and cURL 7.46.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-suppress-connect-headers">
+   <term>
+    <constant>CURLOPT_SUPPRESS_CONNECT_HEADERS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     &true; to suppress proxy CONNECT response headers from the user callback functions
+     <constant>CURLOPT_HEADERFUNCTION</constant> and <constant>CURLOPT_WRITEFUNCTION</constant>,
+     when <constant>CURLOPT_HTTPPROXYTUNNEL</constant> is used and a CONNECT request is made.
+     Defaults to &false;.
+     Available as of PHP 7.3.0 and cURL 7.54.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-tcp-fastopen">
+   <term>
+    <constant>CURLOPT_TCP_FASTOPEN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     &true; to enable and &false; to disable TCP Fast Open.
+     Available as of PHP 7.0.7 and cURL 7.49.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-tcp-keepalive">
+   <term>
+    <constant>CURLOPT_TCP_KEEPALIVE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     If set to <literal>1</literal>, TCP keepalive probes will be sent. The delay and
+     frequency of these probes can be controlled by the <constant>CURLOPT_TCP_KEEPIDLE</constant>
+     and <constant>CURLOPT_TCP_KEEPINTVL</constant> options, provided the operating system
+     supports them. If set to <literal>0</literal> (default) keepalive probes are disabled.
+     The maximum number of probes can be set with the <constant>CURLOPT_TCP_KEEPCNT</constant>
+     option.
+     Available as of cURL 7.25.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-tcp-keepidle">
+   <term>
+    <constant>CURLOPT_TCP_KEEPIDLE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Sets the delay, in seconds, that the operating system will wait while the connection is
+     idle before sending keepalive probes, if <constant>CURLOPT_TCP_KEEPALIVE</constant> is
+     enabled. Not all operating systems support this option.
+     The default is <literal>60</literal>.
+     Available as of cURL 7.25.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-tcp-keepintvl">
+   <term>
+    <constant>CURLOPT_TCP_KEEPINTVL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Sets the interval, in seconds, that the operating system will wait between sending
+     keepalive probes, if <constant>CURLOPT_TCP_KEEPALIVE</constant> is enabled.
+     Not all operating systems support this option.
+     The default is <literal>60</literal>.
+     Available as of cURL 7.25.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-tcp-keepcnt">
+   <term>
+    <constant>CURLOPT_TCP_KEEPCNT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Sets the maximum number of TCP keep-alive probes.
+     The default is <literal>9</literal>.
+     Available as of PHP 8.4.0 and cURL 8.9.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-tcp-nodelay">
+   <term>
+    <constant>CURLOPT_TCP_NODELAY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     &true; to disable TCP's Nagle algorithm, which tries to minimize
+     the number of small packets on the network.
+     Defaults to &true;.
+     Available as of cURL 7.11.2.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-telnetoptions">
+   <term>
+    <constant>CURLOPT_TELNETOPTIONS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set an <type>array</type> of <type>string</type>s to pass to the telnet negotiations.
+     The variables should be in the format <literal>&gt;option=value&lt;</literal>.
+     cURL supports the options <literal>TTYPE</literal>,
+     <literal>XDISPLOC</literal> and <literal>NEW_ENV</literal>.
+     Available as of cURL 7.7.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-tftp-blksize">
+   <term>
+    <constant>CURLOPT_TFTP_BLKSIZE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set the blocksize to use for TFTP data transmission.
+     Valid range is <literal>8</literal>-<literal>65464</literal> bytes.
+     The default of <literal>512</literal> bytes is used if this option is not specified.
+     The specified block size is only used if supported by the remote server.
+     If the server does not return an option acknowledgment
+     or returns an option acknowledgment with no block size,
+     the default of <literal>512</literal> bytes is used.
+     Available as of cURL 7.19.4.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-tftp-no-options">
+   <term>
+    <constant>CURLOPT_TFTP_NO_OPTIONS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     &true; to not send TFTP options requests.
+     Defaults to &false;.
+     Available as of PHP 7.0.7 and cURL 7.48.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-timecondition">
+   <term>
+    <constant>CURLOPT_TIMECONDITION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set how <constant>CURLOPT_TIMEVALUE</constant> is treated.
+     Use <constant>CURL_TIMECOND_IFMODSINCE</constant> to return the
+     page only if it has been modified since the time specified in
+     <constant>CURLOPT_TIMEVALUE</constant>. If it hasn't been modified,
+     a <literal>304 Not Modified</literal> header will be returned
+     assuming <constant>CURLOPT_HEADER</constant> is &true;.
+     Use <constant>CURL_TIMECOND_IFUNMODSINCE</constant> for the reverse
+     effect. Use <constant>CURL_TIMECOND_NONE</constant> to ignore
+     <constant>CURLOPT_TIMEVALUE</constant> and always return the page.
+     <constant>CURL_TIMECOND_NONE</constant> is the default.
+     Prior to cURL 7.46.0 the default was
+     <constant>CURL_TIMECOND_IFMODSINCE</constant>.
+     Available as of cURL 7.1.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-timeout">
+   <term>
+    <constant>CURLOPT_TIMEOUT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     The maximum number of seconds to allow cURL functions to execute.
+     Defaults to <literal>0</literal>, meaning that functions never time out during transfer.
+     Available as of cURL 7.1.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-timeout-ms">
+   <term>
+    <constant>CURLOPT_TIMEOUT_MS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     The maximum number of milliseconds to allow cURL functions to
+     execute.
+     If cURL is built to use the standard system name resolver, that
+     portion of the connect will still use full-second resolution for
+     timeouts with a minimum timeout allowed of one second.
+     Defaults to <literal>0</literal>, meaning that functions never time out during transfer.
+     Available as of cURL 7.16.2.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-timevalue">
+   <term>
+    <constant>CURLOPT_TIMEVALUE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     The time in seconds since January 1st, 1970. The time will be used
+     by <constant>CURLOPT_TIMECONDITION</constant>.
+     Defaults to <literal>0</literal>.
+     Available as of cURL 7.1.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-timevalue-large">
+   <term>
+    <constant>CURLOPT_TIMEVALUE_LARGE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     The time in seconds since January 1st, 1970. The time will be used
+     by <constant>CURLOPT_TIMECONDITION</constant>. Defaults to zero.
+     The difference between this option and <constant>CURLOPT_TIMEVALUE</constant>
+     is the type of the argument. On systems where 'long' is only 32 bit wide,
+     this option has to be used to set dates beyond the year 2038.
+     Available as of PHP 7.3.0 and cURL 7.59.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-tls13-ciphers">
+   <term>
+    <constant>CURLOPT_TLS13_CIPHERS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A <type>string</type> with a colon-separated list of ciphers
+     to use for the connection to the TLS 1.3 connection.
+     This option is currently used only when cURL is built to use OpenSSL 1.1.1 or later.
+     When using a different SSL backend the TLS 1.3 cipher suites can be set
+     with the <constant>CURLOPT_SSL_CIPHER_LIST</constant> option.
+     Available as of PHP 7.3.0 and cURL 7.61.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-tlsauth-password">
+   <term>
+    <constant>CURLOPT_TLSAUTH_PASSWORD</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set a password to use for the TLS authentication method specified
+     with the <constant>CURLOPT_TLSAUTH_TYPE</constant> option. Requires that
+     the <constant>CURLOPT_TLSAUTH_USERNAME</constant> option also be set.
+     This feature relies on TLS SRP which does not work with TLS 1.3.
+     Available as of cURL 7.21.4.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-tlsauth-type">
+   <term>
+    <constant>CURLOPT_TLSAUTH_TYPE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set a <type>string</type> with the method of the TLS authentication.
+     Supported method is <literal>SRP</literal>
+     (TLS Secure Remote Password authentication).
+     Available as of cURL 7.21.4.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-tlsauth-username">
+   <term>
+    <constant>CURLOPT_TLSAUTH_USERNAME</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set a <type>string</type> with the username to use for the TLS authentication method
+     specified with the <constant>CURLOPT_TLSAUTH_TYPE</constant> option.
+     Requires that the <constant>CURLOPT_TLSAUTH_PASSWORD</constant> option
+     also be set.
+     This feature relies on TLS SRP which does not work with TLS 1.3.
+     Available as of cURL 7.21.4.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-transfer-encoding">
+   <term>
+    <constant>CURLOPT_TRANSFER_ENCODING</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set to <literal>1</literal> to enable and <literal>0</literal> to disable
+     requesting compressed <literal>Transfer Encoding</literal> in the outgoing
+     HTTP request. If the server responds with a compressed
+     <literal>Transfer Encoding</literal>,
+     cURL will automatically uncompress it on reception.
+     Defaults to <literal>0</literal>.
+     Available as of cURL 7.21.6.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-transfertext">
+   <term>
+    <constant>CURLOPT_TRANSFERTEXT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     &true; to use ASCII mode for FTP transfers.
+     For LDAP, it retrieves data in plain text instead of HTML. On
+     Windows systems, it will not set <constant>STDOUT</constant> to binary
+     mode.
+     Defaults to &false;.
+     Available as of cURL 7.1.1.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-unix-socket-path">
+   <term>
+    <constant>CURLOPT_UNIX_SOCKET_PATH</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Enables the use of Unix domain sockets as connection endpoint and
+     sets the path to the given <type>string</type>.
+     Set to &null; to disable.
+     Defaults to &null;.
+     Available as of PHP 7.0.7 and cURL 7.40.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-unrestricted-auth">
+   <term>
+    <constant>CURLOPT_UNRESTRICTED_AUTH</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     &true; to keep sending the username and password
+     when following locations (using
+     <constant>CURLOPT_FOLLOWLOCATION</constant>), even when the
+     hostname has changed.
+     Defaults to &false;.
+     Available as of cURL 7.10.4.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-upkeep-interval-ms">
+   <term>
+    <constant>CURLOPT_UPKEEP_INTERVAL_MS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Some protocols have "connection upkeep" mechanisms. These mechanisms usually send some traffic
+     on existing connections in order to keep them alive. This option defines the connection upkeep interval.
+     Currently, the only protocol with a connection upkeep mechanism is HTTP/2. When the connection upkeep
+     interval is exceeded, an HTTP/2 PING frame is sent on the connection.
+     Defaults to <constant>CURL_UPKEEP_INTERVAL_DEFAULT</constant>
+     which is currently <literal>60</literal> seconds.
+     Available as of PHP 8.2.0 and cURL 7.62.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-upload">
+   <term>
+    <constant>CURLOPT_UPLOAD</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     &true; to prepare for and perform an upload.
+     Defaults to &false;.
+     Available as of cURL 7.1.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-upload-buffersize">
+   <term>
+    <constant>CURLOPT_UPLOAD_BUFFERSIZE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Preferred buffer size in bytes for the cURL upload buffer.
+     The upload buffer size by default is 64 kilobytes. The maximum buffer size allowed to be set is 2 megabytes.
+     The minimum buffer size allowed to be set is 16 kilobytes.
+     Available as of PHP 8.2.0 and cURL 7.62.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-url">
+   <term>
+    <constant>CURLOPT_URL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     The URL to fetch. This can also be set when initializing a
+     session with <function>curl_init</function>.
+     Available as of cURL 7.1.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-use-ssl">
+   <term>
+    <constant>CURLOPT_USE_SSL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Sets the desired level of SSL/TLS for the transfer
+     when using FTP, SMTP, POP3, IMAP, etc.
+     These are all protocols that start out plain text
+     and get "upgraded" to SSL using the STARTTLS command.
+     Set to one of the
+     <constant>CURLUSESSL_<replaceable>*</replaceable></constant> constants.
+     Available as of cURL 7.17.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-useragent">
+   <term>
+    <constant>CURLOPT_USERAGENT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     The contents of the <literal>User-Agent: </literal> header to be
+     used in a HTTP request.
+     Available as of cURL 7.1.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-username">
+   <term>
+    <constant>CURLOPT_USERNAME</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     The user name to use in authentication.
+     Available as of cURL 7.19.1.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-userpwd">
+   <term>
+    <constant>CURLOPT_USERPWD</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A username and password formatted as
+     <literal>[username]:[password]</literal> to use for the
+     connection.
+     Available as cURL 7.1.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-verbose">
+   <term>
+    <constant>CURLOPT_VERBOSE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     &true; to output verbose information. Writes
+     output to <constant>STDERR</constant>, or the file specified using
+     <constant>CURLOPT_STDERR</constant>.
+     Defaults to &false;.
+     Available as of cURL 7.1.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-wildcardmatch">
+   <term>
+    <constant>CURLOPT_WILDCARDMATCH</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Set to <literal>1</literal> to transfer multiple files
+     according to a filename pattern.
+     The pattern can be specified as part of the
+     <constant>CURLOPT_URL</constant> option,
+     using an fnmatch-like pattern (Shell Pattern Matching)
+     in the last part of URL (filename).
+     Available as of cURL 7.21.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-writefunction">
+   <term>
+    <constant>CURLOPT_WRITEFUNCTION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A <type>callable</type> with the following signature:
+     <methodsynopsis>
+      <type>int</type><methodname><replaceable>callback</replaceable></methodname>
+      <methodparam><type>resource</type><parameter>curlHandle</parameter></methodparam>
+      <methodparam><type>string</type><parameter>data</parameter></methodparam>
+     </methodsynopsis>
+     <variablelist role="function_parameters">
+      <varlistentry>
+       <term><parameter>curlHandle</parameter></term>
+       <listitem>
+        <simpara>
+         The cURL handle.
+        </simpara>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><parameter>data</parameter></term>
+       <listitem>
+        <simpara>
+         The data to be written.
+        </simpara>
+       </listitem>
+      </varlistentry>
+     </variablelist>
+     The data must be saved by the callback
+     and the callback must return the exact number of bytes written
+     or the transfer will be aborted with an error.
+     Available as of cURL 7.1.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-writeheader">
+   <term>
+    <constant>CURLOPT_WRITEHEADER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Accepts a file handle <type>resource</type> to the file that the header part of the transfer is written to.
+     Available as of cURL 7.1.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ws-options">
+   <term>
+    <constant>CURLOPT_WS_OPTIONS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Accepts a bitmask setting WebSocket behavior options.
+     The only available option is <constant>CURLWS_RAW_MODE</constant>.
+     Defaults to <literal>0</literal>.
+     Available as of PHP 8.3.0 and cURL 7.86.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-xferinfofunction">
+   <term>
+    <constant>CURLOPT_XFERINFOFUNCTION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A <type>callable</type> with the following signature:
+     <methodsynopsis>
+      <type>int</type><methodname><replaceable>callback</replaceable></methodname>
+      <methodparam><type>resource</type><parameter>curlHandle</parameter></methodparam>
+      <methodparam><type>int</type><parameter>bytesToDownload</parameter></methodparam>
+      <methodparam><type>int</type><parameter>bytesDownloaded</parameter></methodparam>
+      <methodparam><type>int</type><parameter>bytesToUpload</parameter></methodparam>
+      <methodparam><type>int</type><parameter>bytesUploaded</parameter></methodparam>
+     </methodsynopsis>
+     <variablelist role="function_parameters">
+      <varlistentry>
+       <term><parameter>curlHandle</parameter></term>
+       <listitem>
+        <simpara>
+         The cURL handle.
+        </simpara>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><parameter>bytesToDownload</parameter></term>
+       <listitem>
+        <simpara>
+         The total number of bytes expected to be downloaded in this transfer.
+        </simpara>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><parameter>bytesDownloaded</parameter></term>
+       <listitem>
+        <simpara>
+         The number of bytes downloaded so far.
+        </simpara>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><parameter>bytesToUpload</parameter></term>
+       <listitem>
+        <simpara>
+         The total number of bytes expected to be uploaded in this transfer.
+        </simpara>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><parameter>bytesUploaded</parameter></term>
+       <listitem>
+        <simpara>
+         The number of bytes uploaded so far.
+        </simpara>
+       </listitem>
+      </varlistentry>
+     </variablelist>
+     Return <literal>1</literal> to abort the transfer
+     and set a <constant>CURLE_ABORTED_BY_CALLBACK</constant> error.
+     Available as of PHP 8.2.0 and cURL 7.32.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-server-response-timeout">
+   <term>
+    <constant>CURLOPT_SERVER_RESPONSE_TIMEOUT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A timeout in seconds cURL will wait for a response from an
+     <acronym>FTP</acronym>, <acronym>SFTP</acronym>, <acronym>IMAP</acronym>,
+     <acronym>SCP</acronym>, <acronym>SMTP</acronym>, or a <acronym>POP3</acronym> server.
+     This option replaces the existing <constant>CURLOPT_FTP_RESPONSE_TIMEOUT</constant>
+     option which is deprecated in cURL 7.85.0.
+     Available as of PHP 8.4.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-xoauth2-bearer">
+   <term>
+    <constant>CURLOPT_XOAUTH2_BEARER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Specifies the OAuth 2.0 access token.
+     Set to &null; to disable.
+     Defaults to &null;.
+     Available as of PHP 7.0.7 and cURL 7.33.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-prereqfunction">
+   <term>
+    <constant>CURLOPT_PREREQFUNCTION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     A <type>callable</type> with the following signature that gets called after the
+     connection is established, but before the request payload (for example, the
+     GET/POST/DELETE request of an HTTP connection) is sent, and can be used to abort
+     or allow the connection depending on the source and destination IP address and
+     port numbers:
+     <methodsynopsis>
+      <type>int</type><methodname><replaceable>callback</replaceable></methodname>
+      <methodparam><type>CurlHandle</type><parameter>curlHandle</parameter></methodparam>
+      <methodparam><type>string</type><parameter>destination_ip</parameter></methodparam>
+      <methodparam><type>string</type><parameter>local_ip</parameter></methodparam>
+      <methodparam><type>int</type><parameter>destination_port</parameter></methodparam>
+      <methodparam><type>int</type><parameter>local_port</parameter></methodparam>
+     </methodsynopsis>
+     <variablelist role="function_parameters">
+      <varlistentry>
+       <term><parameter>curlHandle</parameter></term>
+       <listitem>
+        <simpara>
+         The cURL handle.
+        </simpara>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><parameter>destination_ip</parameter></term>
+       <listitem>
+        <simpara>
+         The primary IP of the remote server established with this connection.
+         For <acronym>FTP</acronym>, this is the IP for the control connection.
+         IPv6 addresses are represented without surrounding brackets.
+        </simpara>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><parameter>local_ip</parameter></term>
+       <listitem>
+        <simpara>
+         The originating IP for this connection.
+         IPv6 addresses are represented without surrounding brackets.
+        </simpara>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><parameter>destination_port</parameter></term>
+       <listitem>
+        <simpara>
+         The primary port number on the remote server established with this connection.
+         For <acronym>FTP</acronym>, this is the port for the control connection.
+         This can be a <acronym>TCP</acronym> or a <acronym>UDP</acronym> port number depending on the protocol.
+        </simpara>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><parameter>local_port</parameter></term>
+       <listitem>
+        <simpara>
+         The originating port number for this connection.
+         This can be a <acronym>TCP</acronym> or a <acronym>UDP</acronym> port number depending on the protocol.
+        </simpara>
+       </listitem>
+      </varlistentry>
+     </variablelist>
+     Return <constant>CURL_PREREQFUNC_OK</constant> to allow the request, or
+     <constant>CURL_PREREQFUNC_ABORT</constant> to abort the transfer.
+     Available as of PHP 8.4.0 and cURL 7.80.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-debugfunction">
+   <term>
+    <constant>CURLOPT_DEBUGFUNCTION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Available as of PHP 8.4.0.
+     This option requires <constant>CURLOPT_VERBOSE</constant> option enabled.
+     A <type>callable</type> to replace the standard cURL verbose output.
+     This callback gets called during various stages of the request with verbose debug information.
+     The callback should match the following signature:
+     <methodsynopsis>
+      <type>void</type><methodname><replaceable>callback</replaceable></methodname>
+      <methodparam><type>CurlHandle</type><parameter>curlHandle</parameter></methodparam>
+      <methodparam><type>int</type><parameter>type</parameter></methodparam>
+      <methodparam><type>string</type><parameter>data</parameter></methodparam>
+     </methodsynopsis>
+     <variablelist role="function_parameters">
+      <varlistentry>
+       <term><parameter>curlHandle</parameter></term>
+       <listitem>
+        <simpara>
+         The cURL handle.
+        </simpara>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><parameter>type</parameter></term>
+       <listitem>
+        <simpara>
+         One of the following constants indicating the type of the <parameter>data</parameter> value:
+        </simpara>
+        <variablelist xml:id="constant.curl-debugfunction.constants" role="constant_list">
+         <varlistentry xml:id="constant.curlinfo-text">
+          <term>
+           <constant>CURLINFO_TEXT</constant>
+           (<type>int</type>)
+          </term>
+          <listitem>
+           <simpara>
+            Informational text.
+           </simpara>
+          </listitem>
+         </varlistentry>
+         <varlistentry xml:id="constant.curlinfo-header-in">
+          <term>
+           <constant>CURLINFO_HEADER_IN</constant>
+           (<type>int</type>)
+          </term>
+          <listitem>
+           <simpara>
+            Header (or header-like) data received from the peer.
+           </simpara>
+          </listitem>
+         </varlistentry>
+         <varlistentry xml:id="constant.curlinfo-header-out-debug">
+          <term>
+           <constant linkend="constant.curlinfo-header-out-debug">CURLINFO_HEADER_OUT</constant>
+           (<type>int</type>)
+          </term>
+          <listitem>
+           <simpara>
+            Header (or header-like) data sent to the peer.
+           </simpara>
+          </listitem>
+         </varlistentry>
+         <varlistentry xml:id="constant.curlinfo-data-in">
+          <term>
+           <constant>CURLINFO_DATA_IN</constant>
+           (<type>int</type>)
+          </term>
+          <listitem>
+           <simpara>
+            Unprocessed protocol data received from the peer.
+            Even if the data is encoded or compressed, it is not provided decoded nor decompressed to this callback.
+           </simpara>
+          </listitem>
+         </varlistentry>
+         <varlistentry xml:id="constant.curlinfo-data-out">
+          <term>
+           <constant>CURLINFO_DATA_OUT</constant>
+           (<type>int</type>)
+          </term>
+          <listitem>
+           <simpara>
+            Protocol data sent to the peer.
+           </simpara>
+          </listitem>
+         </varlistentry>
+         <varlistentry xml:id="constant.curlinfo-ssl-data-in">
+          <term>
+           <constant>CURLINFO_SSL_DATA_IN</constant>
+           (<type>int</type>)
+          </term>
+          <listitem>
+           <simpara>
+            <acronym>SSL</acronym>/<acronym>TLS</acronym> (binary) data received from the peer.
+           </simpara>
+          </listitem>
+         </varlistentry>
+         <varlistentry xml:id="constant.curlinfo-ssl-data-out">
+          <term>
+           <constant>CURLINFO_SSL_DATA_OUT</constant>
+           (<type>int</type>)
+          </term>
+          <listitem>
+           <simpara>
+            <acronym>SSL</acronym>/<acronym>TLS</acronym> (binary) data sent to the peer.
+           </simpara>
+          </listitem>
+         </varlistentry>
+        </variablelist>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><parameter>data</parameter></term>
+       <listitem>
+        <simpara>
+         Verbose debug data of the type indicate by the <parameter>type</parameter> parameter.
+        </simpara>
+       </listitem>
+      </varlistentry>
+     </variablelist>
+    </para>
+   </listitem>
+  </varlistentry>
+ </variablelist>

--- a/translation.xml
+++ b/translation.xml
@@ -32,6 +32,7 @@
    <person name="Kentaro Takeda" email="takeda@youmind.jp" nick="KentarouTakeda" vcs="yes" />
    <person name="Yuya Hamada" email="youkidearitai@gmail.com" nick="youkidearitai" vcs="yes" />
    <person name="Saki Takamachi" email="saki@php.net" nick="saki" vcs="yes" />
+   <person name="Kensuke Imamura" email="nsfisis@gmail.com" nick="nsfisis" vcs="no" />
   </translators>
 
   <work-in-progress>


### PR DESCRIPTION
refs #150

# 概要

https://github.com/php/doc-en/pull/3818 他で追加・編集されている `reference/curl/constants_curl_setopt.xml` を新規に翻訳しました。

TODO