### PR TITLE
プロパティフックページ更新

### DIFF
--- a/language/oop5/property-hooks.xml
+++ b/language/oop5/property-hooks.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c925e1a0ce0659ee1c12d80f9a4a58b10cc4222f Maintainer: KentarouTakeda Status: ready -->
+<!-- EN-Revision: cd2980a57a0845def25ed84276d9662159a91bd5 Maintainer: KentarouTakeda Status: ready -->
 <sect1 xml:id="language.oop5.property-hooks" xmlns="http://docbook.org/ns/docbook">
  <title>プロパティフック</title>
 


### PR DESCRIPTION
refs #300

`language/oop5/property-hooks.xml` を最新の状態まで追随させました。

### 修正概要

- php/doc-en#4345
  - 単語間のスペース修正なので日本語訳への取り込みの必要なし
- php/doc-en#4392
  - 例10のサンプルコード修正
  - 付随する説明追加
- Added notes stating that these features were added in 8.4: (https://github.com/php/doc-en/commit/617cc59b5902de0cadd32883b72b113bf62cf1b6#diff-efd8446f27c7eac04b8ed976baac78ce391a5486b44bd167287bad4fe8a5c0d3)
  - バージョン情報のNOTE追加
- Fixed examples, and made some self-contained (https://github.com/php/doc-en/commit/d6f54016d62904cfd8200604aadd5e3f0d9bad97#diff-efd8446f27c7eac04b8ed976baac78ce391a5486b44bd167287bad4fe8a5c0d3)
  - サンプルコードに `<?php` 付加
- php/doc-en#4550
  - 例6のサンプルコード修正(readonly除去)
- php/doc-en#4643
  - php/doc-en#4392 で追加された文のタイポ修正なので日本語訳への取り込みの必要なし
- php/doc-en#4676
  - スペルミス修正のため日本語訳への取り込みの必要なし
- 脱字修正
「コード含まれれば」→「コードが含まれれば」

### コミット履歴

https://github.com/php/doc-en/commits/master/language/oop5/property-hooks.xml
