### PR TITLE
Use modern markup for E_* constants を取り込み (#4056)

### DIFF
--- a/reference/errorfunc/constants.xml
+++ b/reference/errorfunc/constants.xml
@@ -7,23 +7,29 @@
  &extension.constants.core;
 
  <simpara>
-  上記の値（数値も論理値も）はどのエラーをレポートするかを指定する
-  ビットマスクを組み立てる。<link linkend="language.operators.bitwise">ビット演算子</link>
-  を使用して値を組み合わせたり特定のエラータイプをマスクすることができる。
+  以下の定数 (対応する数値またはそのシンボル名) は、
+  どのエラーを報告するかを指定するビットマスクとして使用します。
+  <link linkend="language.operators.bitwise">ビット演算子</link>
+  を使用して、値を組み合わせたり特定のエラータイプを除外したりできます。
  </simpara>
 
  <tip>
   <simpara>
-   &php.ini; では'|', '~', '!', '^' および '&amp;'のみが解釈されることに
-   注意すべきである。
+   &php.ini; では、対応する生の数値の代わりに定数名を使うことができます。
+   ただし、&php.ini; では
+   <literal>|</literal>、
+   <literal>~</literal>、
+   <literal>^</literal>、
+   <literal>!</literal>、
+   <literal>&amp;</literal>
+   の演算子のみが解釈されます。
   </simpara>
  </tip>
 
  <warning>
   <simpara>
-   以下の定数を&php.ini;で使用することができますが、
-   <filename>httpd.conf</filename>のようなPHPの外部では、
-   代わりにビットマスク値を使用する必要があります。
+   PHP の外部では、シンボル名を使うことはできません。
+   例えば、&httpd.conf; の中では計算済みのビットマスク値を代わりに使わなければなりません。
   </simpara>
  </warning>
 
@@ -35,11 +41,12 @@
    </term>
    <listitem>
     <simpara>
-     重大な実行時エラー。これは、メモリ確保に関する問題のように復帰で
-     きないエラーを示します。スクリプトの実行は中断されます。
+     重大な実行時エラー。
+     これは、メモリ確保の問題といった復帰できないエラーを表します。
+     スクリプトの実行は中断されます。
     </simpara>
     <simpara>
-     <literal>1</literal>
+     定数の値：<literal>1</literal>
     </simpara>
    </listitem>
   </varlistentry>
@@ -51,11 +58,11 @@
    </term>
    <listitem>
     <simpara>
-     実行時の警告 (致命的なエラーではない)。スクリプトの実行は中断さ
-     れません。
+     実行時の警告 (致命的でないエラー)。
+     スクリプトの実行は中断されません。
     </simpara>
     <simpara>
-     <literal>2</literal>
+     定数の値：<literal>2</literal>
     </simpara>
    </listitem>
   </varlistentry>
@@ -67,10 +74,11 @@
    </term>
    <listitem>
     <simpara>
-     コンパイル時のパースエラー。パースエラーはパーサでのみ生成されま
+     コンパイル時のパースエラー。
+     パースエラーはパーサでのみ生成されます。
     </simpara>
     <simpara>
-     <literal>4</literal>
+     定数の値：<literal>4</literal>
     </simpara>
    </listitem>
   </varlistentry>
@@ -82,11 +90,12 @@
    </term>
    <listitem>
     <simpara>
-     実行時の警告。エラーを発しうる状況に遭遇したことを示す。
-     ただし通常のスクリプト実行の場合にもこの警告を発することがありうる。
+     実行時の注意。
+     エラーを示しているかもしれない何かに遭遇したことを表します。
+     ただし、スクリプトを問題なく実行しているときに起こることもあります。
     </simpara>
     <simpara>
-     <literal>8</literal>
+     定数の値：<literal>8</literal>
     </simpara>
    </listitem>
   </varlistentry>
@@ -98,11 +107,12 @@
    </term>
    <listitem>
     <simpara>
-     PHPの初期始動時点での致命的なエラー。<constant>E_ERROR</constant>に
-     似ているがPHPのコアによって発行される点が違う。
+     PHP の初期始動時点で発生した致命的なエラー。
+     <constant>E_ERROR</constant> に似ていますが、
+     PHP のコアによって生成される点が異なります。
     </simpara>
     <simpara>
-     <literal>16</literal>
+     定数の値：<literal>16</literal>
     </simpara>
    </listitem>
   </varlistentry>
@@ -114,12 +124,12 @@
    </term>
    <listitem>
     <simpara>
-     （致命的ではない）警告。PHPの初期始動時に発生する。
-     <constant>E_WARNING</constant>に似ているがPHPのコアによって発行される
-     点が違う。
+     PHP の初期始動時点で発生した (致命的でない) 警告。
+     <constant>E_WARNING</constant> に似ていますが、
+     PHP のコアによって生成される点が異なります。
     </simpara>
     <simpara>
-     <literal>32</literal>
+     定数の値：<literal>32</literal>
     </simpara>
    </listitem>
   </varlistentry>
@@ -131,11 +141,12 @@
    </term>
    <listitem>
     <simpara>
-     コンパイル時の致命的なエラー。<constant>E_ERROR</constant>に
-     似ているがZendスクリプティングエンジンによって発行される点が違う。
+     コンパイル時の致命的なエラー。
+     <constant>E_ERROR</constant>に似ていますが、
+     Zend スクリプティングエンジンによって生成される点が異なります。
     </simpara>
     <simpara>
-     <literal>64</literal>
+     定数の値：<literal>64</literal>
     </simpara>
    </listitem>
   </varlistentry>
@@ -147,11 +158,12 @@
    </term>
    <listitem>
     <simpara>
-     コンパイル時の警告（致命的ではない）。<constant>E_WARNING</constant>に
-     似ているがZendスクリプティングエンジンによって発行される点が違う。
+     コンパイル時の (致命的でない) 警告。
+     <constant>E_WARNING</constant>に似ていますが、
+     Zend スクリプティングエンジンによって生成される点が異なります。
     </simpara>
     <simpara>
-     <literal>128</literal>
+     定数の値：<literal>128</literal>
     </simpara>
    </listitem>
   </varlistentry>
@@ -163,11 +175,12 @@
    </term>
    <listitem>
     <simpara>
-     実行時の注意。これを有効にすると、
-     将来のバージョンで動作しなくなるコードについての警告を受け取ることができる。
+     実行時の非推奨の注意。
+     これを有効にすると、将来のバージョンで
+     動作しなくなるコードについての警告を受け取ることができます。
     </simpara>
     <simpara>
-     <literal>8192</literal>
+     定数の値：<literal>8192</literal>
     </simpara>
    </listitem>
   </varlistentry>
@@ -179,13 +192,22 @@
    </term>
    <listitem>
     <simpara>
-     ユーザーによって発行されるエラーメッセージ。<constant>E_ERROR</constant>
-     に似ているがPHPコード上で<function>trigger_error</function>関数を
-     使用した場合に発行される点が違う。
+     ユーザーによって生成されるエラーメッセージ。
+     <constant>E_ERROR</constant> に似ていますが、
+     <function>trigger_error</function> 関数を用いて PHP コード上で
+     生成される点が異なります。
     </simpara>
     <simpara>
-     <literal>256</literal>
+     定数の値：<literal>256</literal>
     </simpara>
+    <warning>
+     <simpara>
+      この定数を <function>trigger_error</function> と使うのは
+      PHP 8.4.0 で非推奨となりました。
+      代わりに、<exceptionname>Exception</exceptionname> を &throw; するか、
+      <function>exit</function> を呼ぶことが推奨されます。
+     </simpara>
+    </warning>
    </listitem>
   </varlistentry>
 
@@ -196,12 +218,13 @@
    </term>
    <listitem>
     <simpara>
-     ユーザーによって発行される警告メッセージ。<constant>E_WARNING</constant>
-     に似ているがPHPコード上で<function>trigger_error</function>関数を
-     使用した場合に発行される点が違う。
+     ユーザーによって生成される警告メッセージ。
+     <constant>E_WARNING</constant> に似ていますが、
+     <function>trigger_error</function> 関数を用いて PHP コード上で
+     生成される点が異なります。
     </simpara>
     <simpara>
-     <literal>512</literal>
+     定数の値：<literal>512</literal>
     </simpara>
    </listitem>
   </varlistentry>
@@ -213,12 +236,13 @@
    </term>
    <listitem>
     <simpara>
-     ユーザーによって発行される注意メッセージ。<constant>E_NOTICE</constant>に
-     に似ているがPHPコード上で<function>trigger_error</function>関数を
-     使用した場合に発行される点が違う。
+     ユーザーによって生成される注意メッセージ。
+     <constant>E_NOTICE</constant> に似ていますが、
+     <function>trigger_error</function> 関数を用いて PHP コード上で
+     生成される点が異なります。
     </simpara>
     <simpara>
-     <literal>1024</literal>
+     定数の値：<literal>1024</literal>
     </simpara>
    </listitem>
   </varlistentry>
@@ -230,13 +254,13 @@
    </term>
    <listitem>
     <simpara>
-     ユーザー定義の警告メッセージ。これは
-     <constant>E_DEPRECATED</constant> と同等だが、
-     PHP のコード上で関数 <function>trigger_error</function>
-     によって作成されるという点が異なる。
+     ユーザーによって生成される非推奨メッセージ。
+     <constant>E_DEPRECATED</constant> に似ていますが、
+     <function>trigger_error</function> 関数を用いて PHP コード上で
+     生成される点が異なります。
     </simpara>
     <simpara>
-     <literal>16384</literal>
+     定数の値：<literal>16384</literal>
     </simpara>
    </listitem>
   </varlistentry>
@@ -248,12 +272,18 @@
    </term>
    <listitem>
     <simpara>
-     コードの相互運用性や互換性を維持するために
-     PHP がコードの変更を提案する。
+     PHP が実行時に発行する提案。
+     コードの前方互換性を担保するために、実行中のコードについて改善が提案されます。
     </simpara>
     <simpara>
-     <literal>2048</literal>
+     定数の値：<literal>2048</literal>
     </simpara>
+    <warning>
+     <simpara>
+      このエラーレベルは使われておらず、
+      PHP 8.4.0 で非推奨となりました。
+     </simpara>
+    </warning>
    </listitem>
   </varlistentry>
 
@@ -264,15 +294,25 @@
    </term>
    <listitem>
     <simpara>
-     キャッチできる致命的なエラー。危険なエラーが発生したが、
-     エンジンが不安定な状態になるほどではないことを表す。
-     ユーザー定義のハンドラでエラーがキャッチされなかった場合
-     (<function>set_error_handler</function> も参照ください) は、
-     <constant>E_ERROR</constant> として異常終了する。
+     キャッチできる致命的なエラーに相当する従来のエンジン「例外」(訳注: この文脈での括弧付きの「例外」は、<exceptionname>Error</exceptionname> が登場するより前に用いられていた例外の「ような」仕組みを指したものです)。
+     <exceptionname>Error</exceptionname> に似ていますが、
+     ユーザー定義のエラーハンドラー (<function>set_error_handler</function> を参照のこと) によってキャッチしなければなりません。
+     キャッチされなかった場合、<constant>E_ERROR</constant> と同様にスクリプトの実行を中断します。
     </simpara>
     <simpara>
-     <literal>4096</literal>
+     定数の値：<literal>4096</literal>
     </simpara>
+    <note>
+     <simpara>
+      このエラーレベルは実質的に使われていません。
+      唯一発生しうるのは、&object; を <type>bool</type> として解釈するのに失敗したときだけです。
+      これは、内部的なオブジェクトでしか起こりえません。
+     </simpara>
+     <simpara>
+      PHP 8.4.0 より前のバージョンにおける最もよくある例としては、
+      <classname>GMP</classname> インスタンスを条件式で使ったときです。
+     </simpara>
+    </note>
    </listitem>
   </varlistentry>
 
@@ -283,10 +323,10 @@
    </term>
    <listitem>
     <simpara>
-     全てのエラーと警告。
+     すべてのエラー、警告、注意を含んだビットマスク。
     </simpara>
     <simpara>
-     <literal>32767</literal>
+     定数の値：<literal>32767</literal>
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/errorfunc/constants.xml
+++ b/reference/errorfunc/constants.xml
@@ -1,259 +1,298 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: de9c65c91ff1710d8b2d2ec955caea0162679305 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: cb7c0c06545e7943b2de0c595c9e070b8027e0a6 Maintainer: hirokawa Status: ready -->
 <!-- Credits: mumumu -->
 <appendix xml:id="errorfunc.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.constants;
  &extension.constants.core;
- <note>
+
+ <simpara>
+  上記の値（数値も論理値も）はどのエラーをレポートするかを指定する
+  ビットマスクを組み立てる。<link linkend="language.operators.bitwise">ビット演算子</link>
+  を使用して値を組み合わせたり特定のエラータイプをマスクすることができる。
+ </simpara>
+
+ <tip>
+  <simpara>
+   &php.ini; では'|', '~', '!', '^' および '&amp;'のみが解釈されることに
+   注意すべきである。
+  </simpara>
+ </tip>
+
+ <warning>
   <simpara>
    以下の定数を&php.ini;で使用することができますが、
    <filename>httpd.conf</filename>のようなPHPの外部では、
    代わりにビットマスク値を使用する必要があります。
   </simpara>
- </note>
- <table xml:id="errorfunc.constants.errorlevels">
-  <title>エラーとロギング</title>
-  <tgroup cols="4">
-   <thead>
-    <row>
-     <entry>値</entry>
-     <entry>定数</entry>
-     <entry>説明</entry>
-     <entry>注記</entry>
-    </row>
-   </thead>
-   <tbody>
-    <row xml:id="constant.e-error">
-     <entry>1</entry>
-     <entry>
-      <constant>E_ERROR</constant> 
-      (<type>int</type>)
-     </entry>
-     <entry>
-      重大な実行時エラー。これは、メモリ確保に関する問題のように復帰で
-      きないエラーを示します。スクリプトの実行は中断されます。
-     </entry>
-     <entry>
-     </entry>
-    </row>
-    
-    <row xml:id="constant.e-warning">
-     <entry>2</entry>
-     <entry>
-      <constant>E_WARNING</constant> 
-      (<type>int</type>)
-     </entry>
-     <entry>
-      実行時の警告 (致命的なエラーではない)。スクリプトの実行は中断さ
-      れません。
-     </entry>
-     <entry></entry>
-    </row>
+ </warning>
 
-    <row xml:id="constant.e-parse">
-     <entry>4</entry>
-     <entry>
-      <constant>E_PARSE</constant> 
-      (<type>int</type>)
-     </entry>
-     <entry>
-      コンパイル時のパースエラー。パースエラーはパーサでのみ生成されま
-      す。
-     </entry>
-     <entry></entry>
-    </row>
+ <variablelist xml:id="errorfunc.constants.errorlevels">
+  <varlistentry xml:id="constant.e-error">
+   <term>
+    <constant>E_ERROR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     重大な実行時エラー。これは、メモリ確保に関する問題のように復帰で
+     きないエラーを示します。スクリプトの実行は中断されます。
+    </simpara>
+    <simpara>
+     <literal>1</literal>
+    </simpara>
+   </listitem>
+  </varlistentry>
 
-    <row xml:id="constant.e-notice">
-     <entry>8</entry>
-     <entry>
-      <constant>E_NOTICE</constant> 
-      (<type>int</type>)
-     </entry>
-     <entry>
-      実行時の警告。エラーを発しうる状況に遭遇したことを示す。
-      ただし通常のスクリプト実行の場合にもこの警告を発することがありうる。
-     </entry>
-     <entry></entry>
-    </row>
+  <varlistentry xml:id="constant.e-warning">
+   <term>
+    <constant>E_WARNING</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     実行時の警告 (致命的なエラーではない)。スクリプトの実行は中断さ
+     れません。
+    </simpara>
+    <simpara>
+     <literal>2</literal>
+    </simpara>
+   </listitem>
+  </varlistentry>
 
-    <row xml:id="constant.e-core-error">
-     <entry>16</entry>
-     <entry>
-      <constant>E_CORE_ERROR</constant> 
-      (<type>int</type>)
-     </entry>
-     <entry>
-      PHPの初期始動時点での致命的なエラー。<constant>E_ERROR</constant>に
-      似ているがPHPのコアによって発行される点が違う。
-     </entry>
-     <entry></entry>
-    </row>
+  <varlistentry xml:id="constant.e-parse">
+   <term>
+    <constant>E_PARSE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     コンパイル時のパースエラー。パースエラーはパーサでのみ生成されま
+    </simpara>
+    <simpara>
+     <literal>4</literal>
+    </simpara>
+   </listitem>
+  </varlistentry>
 
-    <row xml:id="constant.e-core-warning">
-     <entry>32</entry>
-     <entry>
-      <constant>E_CORE_WARNING</constant> 
-      (<type>int</type>)
-     </entry>
-     <entry>
-      （致命的ではない）警告。PHPの初期始動時に発生する。
-      <constant>E_WARNING</constant>に似ているがPHPのコアによって発行される
-      点が違う。
-     </entry>
-     <entry></entry>
-    </row>
+  <varlistentry xml:id="constant.e-notice">
+   <term>
+    <constant>E_NOTICE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     実行時の警告。エラーを発しうる状況に遭遇したことを示す。
+     ただし通常のスクリプト実行の場合にもこの警告を発することがありうる。
+    </simpara>
+    <simpara>
+     <literal>8</literal>
+    </simpara>
+   </listitem>
+  </varlistentry>
 
-    <row xml:id="constant.e-compile-error">
-     <entry>64</entry>
-     <entry>
-      <constant>E_COMPILE_ERROR</constant> 
-      (<type>int</type>)
-     </entry>
-     <entry>
-      コンパイル時の致命的なエラー。<constant>E_ERROR</constant>に
-      似ているがZendスクリプティングエンジンによって発行される点が違う。
-     </entry>
-     <entry></entry>
-    </row>
+  <varlistentry xml:id="constant.e-core-error">
+   <term>
+    <constant>E_CORE_ERROR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     PHPの初期始動時点での致命的なエラー。<constant>E_ERROR</constant>に
+     似ているがPHPのコアによって発行される点が違う。
+    </simpara>
+    <simpara>
+     <literal>16</literal>
+    </simpara>
+   </listitem>
+  </varlistentry>
 
-    <row xml:id="constant.e-compile-warning">
-     <entry>128</entry>
-     <entry>
-      <constant>E_COMPILE_WARNING</constant> 
-      (<type>int</type>)
-     </entry>
-     <entry>
-      コンパイル時の警告（致命的ではない）。<constant>E_WARNING</constant>に
-      似ているがZendスクリプティングエンジンによって発行される点が違う。
-     </entry>
-     <entry></entry>
-    </row>
+  <varlistentry xml:id="constant.e-core-warning">
+   <term>
+    <constant>E_CORE_WARNING</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     （致命的ではない）警告。PHPの初期始動時に発生する。
+     <constant>E_WARNING</constant>に似ているがPHPのコアによって発行される
+     点が違う。
+    </simpara>
+    <simpara>
+     <literal>32</literal>
+    </simpara>
+   </listitem>
+  </varlistentry>
 
-    <row xml:id="constant.e-user-error">
-     <entry>256</entry>
-     <entry>
-      <constant>E_USER_ERROR</constant> 
-      (<type>int</type>)
-     </entry>
-     <entry>
-      ユーザーによって発行されるエラーメッセージ。<constant>E_ERROR</constant>
-      に似ているがPHPコード上で<function>trigger_error</function>関数を
-      使用した場合に発行される点が違う。
-     </entry>
-     <entry></entry>
-    </row>
+  <varlistentry xml:id="constant.e-compile-error">
+   <term>
+    <constant>E_COMPILE_ERROR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     コンパイル時の致命的なエラー。<constant>E_ERROR</constant>に
+     似ているがZendスクリプティングエンジンによって発行される点が違う。
+    </simpara>
+    <simpara>
+     <literal>64</literal>
+    </simpara>
+   </listitem>
+  </varlistentry>
 
-    <row xml:id="constant.e-user-warning">
-     <entry>512</entry>
-     <entry>
-      <constant>E_USER_WARNING</constant> 
-      (<type>int</type>)
-     </entry>
-     <entry>
-      ユーザーによって発行される警告メッセージ。<constant>E_WARNING</constant>
-      に似ているがPHPコード上で<function>trigger_error</function>関数を
-      使用した場合に発行される点が違う。
-     </entry>
-     <entry></entry>
-    </row>
+  <varlistentry xml:id="constant.e-compile-warning">
+   <term>
+    <constant>E_COMPILE_WARNING</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     コンパイル時の警告（致命的ではない）。<constant>E_WARNING</constant>に
+     似ているがZendスクリプティングエンジンによって発行される点が違う。
+    </simpara>
+    <simpara>
+     <literal>128</literal>
+    </simpara>
+   </listitem>
+  </varlistentry>
 
-    <row xml:id="constant.e-user-notice">
-     <entry>1024</entry>
-     <entry>
-      <constant>E_USER_NOTICE</constant> 
-      (<type>int</type>)
-     </entry>
-     <entry>
-      ユーザーによって発行される注意メッセージ。<constant>E_NOTICE</constant>に
-      に似ているがPHPコード上で<function>trigger_error</function>関数を
-      使用した場合に発行される点が違う。
-     </entry>
-     <entry></entry>
-    </row>
+  <varlistentry xml:id="constant.e-deprecated">
+   <term>
+    <constant>E_DEPRECATED</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     実行時の注意。これを有効にすると、
+     将来のバージョンで動作しなくなるコードについての警告を受け取ることができる。
+    </simpara>
+    <simpara>
+     <literal>8192</literal>
+    </simpara>
+   </listitem>
+  </varlistentry>
 
-    <row xml:id="constant.e-strict">
-     <entry>2048</entry>
-     <entry>
-      <constant>E_STRICT</constant> 
-      (<type>int</type>)
-     </entry>
-     <entry>
-      コードの相互運用性や互換性を維持するために
-      PHP がコードの変更を提案する。
-     </entry>
-     <entry></entry>
-    </row>
+  <varlistentry xml:id="constant.e-user-error">
+   <term>
+    <constant>E_USER_ERROR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     ユーザーによって発行されるエラーメッセージ。<constant>E_ERROR</constant>
+     に似ているがPHPコード上で<function>trigger_error</function>関数を
+     使用した場合に発行される点が違う。
+    </simpara>
+    <simpara>
+     <literal>256</literal>
+    </simpara>
+   </listitem>
+  </varlistentry>
 
-    <row xml:id="constant.e-recoverable-error">
-     <entry>4096</entry>
-     <entry>
-      <constant>E_RECOVERABLE_ERROR</constant> 
-      (<type>int</type>)
-     </entry>
-     <entry>
-      キャッチできる致命的なエラー。危険なエラーが発生したが、
-      エンジンが不安定な状態になるほどではないことを表す。
-      ユーザー定義のハンドラでエラーがキャッチされなかった場合
-      (<function>set_error_handler</function> も参照ください) は、
-      <constant>E_ERROR</constant> として異常終了する。
-     </entry>
-     <entry></entry>
-    </row>
+  <varlistentry xml:id="constant.e-user-warning">
+   <term>
+    <constant>E_USER_WARNING</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     ユーザーによって発行される警告メッセージ。<constant>E_WARNING</constant>
+     に似ているがPHPコード上で<function>trigger_error</function>関数を
+     使用した場合に発行される点が違う。
+    </simpara>
+    <simpara>
+     <literal>512</literal>
+    </simpara>
+   </listitem>
+  </varlistentry>
 
-    <row xml:id="constant.e-deprecated">
-     <entry>8192</entry>
-     <entry>
-      <constant>E_DEPRECATED</constant> 
-      (<type>int</type>)
-     </entry>
-     <entry>
-      実行時の注意。これを有効にすると、
-      将来のバージョンで動作しなくなるコードについての警告を受け取ることができる。
-     </entry>
-     <entry></entry>
-    </row>
+  <varlistentry xml:id="constant.e-user-notice">
+   <term>
+    <constant>E_USER_NOTICE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     ユーザーによって発行される注意メッセージ。<constant>E_NOTICE</constant>に
+     に似ているがPHPコード上で<function>trigger_error</function>関数を
+     使用した場合に発行される点が違う。
+    </simpara>
+    <simpara>
+     <literal>1024</literal>
+    </simpara>
+   </listitem>
+  </varlistentry>
 
-    <row xml:id="constant.e-user-deprecated">
-     <entry>16384</entry>
-     <entry>
-      <constant>E_USER_DEPRECATED</constant> 
-      (<type>int</type>)
-     </entry>
-     <entry>
-      ユーザー定義の警告メッセージ。これは
-      <constant>E_DEPRECATED</constant> と同等だが、
-      PHP のコード上で関数 <function>trigger_error</function>
-      によって作成されるという点が異なる。
-     </entry>
-     <entry></entry>
-    </row>
+  <varlistentry xml:id="constant.e-user-deprecated">
+   <term>
+    <constant>E_USER_DEPRECATED</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     ユーザー定義の警告メッセージ。これは
+     <constant>E_DEPRECATED</constant> と同等だが、
+     PHP のコード上で関数 <function>trigger_error</function>
+     によって作成されるという点が異なる。
+    </simpara>
+    <simpara>
+     <literal>16384</literal>
+    </simpara>
+   </listitem>
+  </varlistentry>
 
-    <row xml:id="constant.e-all">
-     <entry>32767</entry>
-     <entry>
-      <constant>E_ALL</constant> 
-      (<type>int</type>)
-     </entry>
-     <entry>
-      全てのエラーと警告。
-     </entry>
-     <entry></entry>
-    </row>
+  <varlistentry xml:id="constant.e-strict">
+   <term>
+    <constant>E_STRICT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     コードの相互運用性や互換性を維持するために
+     PHP がコードの変更を提案する。
+    </simpara>
+    <simpara>
+     <literal>2048</literal>
+    </simpara>
+   </listitem>
+  </varlistentry>
 
-   </tbody>
-  </tgroup>
- </table>
+  <varlistentry xml:id="constant.e-recoverable-error">
+   <term>
+    <constant>E_RECOVERABLE_ERROR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     キャッチできる致命的なエラー。危険なエラーが発生したが、
+     エンジンが不安定な状態になるほどではないことを表す。
+     ユーザー定義のハンドラでエラーがキャッチされなかった場合
+     (<function>set_error_handler</function> も参照ください) は、
+     <constant>E_ERROR</constant> として異常終了する。
+    </simpara>
+    <simpara>
+     <literal>4096</literal>
+    </simpara>
+   </listitem>
+  </varlistentry>
 
- <para>
-  上記の値（数値も論理値も）はどのエラーをレポートするかを指定する
-  ビットマスクを組み立てる。<link linkend="language.operators.bitwise">ビット演算子</link>
-  を使用して値を組み合わせたり特定のエラータイプをマスクすることができる。
-  &php.ini; では'|', '~', '!', '^' および '&amp;'のみが解釈されることに
-  注意すべきである。
- </para>
-</appendix> 
+  <varlistentry xml:id="constant.e-all">
+   <term>
+    <constant>E_ALL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     全てのエラーと警告。
+    </simpara>
+    <simpara>
+     <literal>32767</literal>
+    </simpara>
+   </listitem>
+  </varlistentry>
 
+ </variablelist>
+</appendix>
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml
@@ -274,4 +313,3 @@ vim600: syn=xml fen fdm=syntax fdl=2 si
 vim: et tw=78 syn=sgml
 vi: ts=1 sw=1
 -->
-


### PR DESCRIPTION
refs #150

https://github.com/php/doc-en/pull/4056 を取り込みました。

"Use modern markup" と言っていますが、実際には XML マークアップの更新と内容の更新を両方含んでいます。この PR ではコミットを2つに分割しました。

* Use modern markup for E_* constants を取り込み: マークアップの変更のみ (#4056)
* Use modern markup for E_* constants を取り込み: 内容を更新 (#4056)

最近追加された訳とは訳の雰囲気が異なっていたので、全体的に書き直しています（特に、常体になっている箇所は敬体へ変更しました）。

1箇所、翻訳で補い切れなかった `E_RECOVERABLE_ERROR` の説明で訳注を足しています。

原文:

> Legacy engine "exceptions" which correspond to catchable fatal error.

今回の訳:

> キャッチできる致命的なエラーに相当する従来のエンジン「例外」(訳注: この文脈での括弧付きの「例外」は、<exceptionname>Error</exceptionname> が登場するより前に用いられていた例外の「ような」仕組みを指したものです)。
