### PR TITLE
date_sun_info()、date_sunrise()、date_sunset() で専門用語を用いるよう修正

### DIFF
--- a/reference/datetime/functions/date-sun-info.xml
+++ b/reference/datetime/functions/date-sun-info.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="function.date-sun-info" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>date_sun_info</refname>
-  <refpurpose>日の出/日の入り時刻と薄明かり (twilight) の開始/終了時刻の情報を含む配列を返す</refpurpose>
+  <refpurpose>日の出/日の入り時刻と薄明 (twilight) の開始/終了時刻の情報を含む配列を返す</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -76,8 +76,8 @@
      <term><literal>transit</literal></term>
      <listitem>
       <simpara>
-       太陽が天頂に達するタイムスタンプ。
-       つまり、もっとも上部に達した時刻です。
+       太陽が天頂に達するときのタイムスタンプ。
+       つまり、最高点に達する時刻です。
       </simpara>
      </listitem> 
     </varlistentry>
@@ -85,7 +85,7 @@
      <term><literal>civil_twilight_begin</literal></term>
      <listitem>
       <simpara>
-       夜明けの始まり(天頂角 = 96°)
+       日の出側の市民薄明 (夜明) が始まる時刻 (天頂角 = 96°)。
        <literal>sunrise</literal> の時刻に終了します。
       </simpara>
      </listitem> 
@@ -94,7 +94,7 @@
      <term><literal>civil_twilight_end</literal></term>
      <listitem>
       <simpara>
-       夕暮れの終わり(天頂角 =  96°)
+       日の入り側の市民薄明 (夕暮) が終わる時刻 (天頂角 =  96°)。
        <literal>sunset</literal> の時刻に始まります。
       </simpara>
      </listitem> 
@@ -103,8 +103,8 @@
      <term><literal>nautical_twilight_begin</literal></term>
      <listitem>
       <simpara>
-       航海上の夜明け (天頂角 = 102°)
-       <literal>civil_twilight_begin</literal> に終了します。
+       日の出側の航海薄明が始まる時刻 (天頂角 = 102°)。
+       <literal>civil_twilight_begin</literal> の時刻に終了します。
       </simpara>
      </listitem> 
     </varlistentry>
@@ -112,7 +112,7 @@
      <term><literal>nautical_twilight_end</literal></term>
      <listitem>
       <simpara>
-       航海上の夕暮れ (天頂角 =  102°)
+       日の入り側の航海薄明が終わる時刻 (天頂角 = 102°)。
        <literal>civil_twilight_end</literal> の時刻に始まります。
       </simpara>
      </listitem> 
@@ -121,8 +121,8 @@
      <term><literal>astronomical_twilight_begin</literal></term>
      <listitem>
       <simpara>
-       天文学上の夜明け (天頂角 = 108°)
-       <literal>nautical_twilight_begin</literal> に終了します。
+       日の出側の天文薄明が始まる時刻 (天頂角 = 108°)。
+       <literal>nautical_twilight_begin</literal> の時刻に終了します。
       </simpara>
      </listitem> 
     </varlistentry>
@@ -130,7 +130,7 @@
      <term><literal>astronomical_twilight_end</literal></term>
      <listitem>
       <simpara>
-       天文学上の夕暮れ (天頂角 = 108°)
+       日の入り側の天文薄明が終わる時刻 (天頂角 = 108°)。
        <literal>nautical_twilight_end</literal> の時刻に始まります。
       </simpara>
      </listitem> 
@@ -243,7 +243,7 @@ never: sunset
 
   <para>
    <example>
-    <title>Midnight sun の例(Tromsø, Norway)</title>
+    <title>白夜の例(Tromsø, Norway)</title>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/datetime/functions/date-sunrise.xml
+++ b/reference/datetime/functions/date-sunrise.xml
@@ -127,15 +127,15 @@
           </row>
           <row>
            <entry>96°</entry>
-           <entry>薄明かり: 夜明けの始まりを示すのに慣習的に使われます</entry>
+           <entry>市民薄明: 夜明けの始まりを示すのに慣習的に使われます</entry>
           </row>
           <row>
            <entry>102°</entry>
-           <entry>航海上の薄明かり: 海の上で、水平線が見えはじめる点</entry>
+           <entry>航海薄明: 海の上で、水平線が見えはじめる点</entry>
           </row>
           <row>
            <entry>108°</entry>
-           <entry>天文学上の薄明かり: 太陽があらゆる明かりの光源になりはじめる点</entry>
+           <entry>天文薄明: 太陽があらゆる明かりの光源になりはじめる点</entry>
           </row>
          </tbody>
         </tgroup>

--- a/reference/datetime/functions/date-sunset.xml
+++ b/reference/datetime/functions/date-sunset.xml
@@ -127,15 +127,15 @@
           </row>
           <row>
            <entry>96°</entry>
-           <entry>薄明かり: 夕暮れの終わりを示すのに慣習的に使われます</entry>
+           <entry>市民薄明: 夕暮れの終わりを示すのに慣習的に使われます</entry>
           </row>
           <row>
            <entry>102°</entry>
-           <entry>航海上の薄明かり: 海の上で、水平線が見えなくなった点</entry>
+           <entry>航海薄明: 海の上で、水平線が見えなくなった点</entry>
           </row>
           <row>
            <entry>108°</entry>
-           <entry>天文学上の薄明かり: 太陽があらゆる明かりの光源ではなくなった点</entry>
+           <entry>天文薄明: 太陽があらゆる明かりの光源ではなくなった点</entry>
           </row>
          </tbody>
         </tgroup>


### PR DESCRIPTION
date_sun_info()、date_sunrise()、date_sunset() の3ページの訳を修正しました。

# 共通

「薄明かり」を「薄明」(はくめい) に変更しました。この分野ではこれが定訳のようです。

# date_sun_info()

* 「。」の抜けを修正
* "start of" / "end of" の訳抜けを修正
* "Midnight sun" の訳し忘れを修正（→「白夜」）
* 「〜の時刻に始まります」と「〜に終了します」で後者にだけ「の時刻」がなかったため統一

# 訳の選択

末尾に示す参考文献を元に、次のように訳を選択しました。

* twilight → 薄明
* civil twilight → 市民薄明
* nautical twilight → 航海薄明
* astronomical twilight → 天文薄明
* civil dusk → ~~日の出~~日の入り側の市民薄明 (夜明)
* civil dawn → ~~日の入り~~日の出側の市民薄明 (夕暮)
* nautical dusk → ~~日の出~~日の入り側の航海薄明
* nautical dawn → ~~日の入り~~日の出側の航海薄明
* astronomical dusk → ~~日の出~~日の入り側の天文薄明
* astronomical dawn → ~~日の入り~~日の出側の天文薄明

twilight は「薄明」に対応し、dusk と dawn の総称です。dusk と dawn に直接対応する用語はないようでした。

日本語の「夜明」は「日の出側の市民薄明」を、「夕暮」は「日の入り側の市民薄明」を特に指すようです。dusk に「~~薄明~~薄暮」を、dawn に「~~薄暮~~薄明」という訳を当てて解説している web ページも存在したのですが、信頼性を確認することができませんでした。

※このあたりの定訳をご存知の方いらっしゃいましたらご教示ください。

# 参考

国立天文台の以下資料を参考にしました。

https://eco.mtk.nao.ac.jp/koyomi/wiki/C7F6CCC0.html
https://eco.mtk.nao.ac.jp/koyomi/wiki/C7F6CCC02FCCEBCCC0A4C8C6FCCAEB.html
