### PR TITLE
features.commandline.differences の誤訳を修正

### DIFF
--- a/features/commandline.xml
+++ b/features/commandline.xml
@@ -149,9 +149,10 @@
           <entry><link linkend="ini.implicit-flush">implicit_flush</link></entry>
           <entry>&true;</entry>
           <entry>
+           シェル環境では、
            <function>print</function>, <function>echo</function> および
            関連するものによる全ての出力は、直ちに出力され、バッファに
-           キャッシュされないことが望ましいと言えます。この場合でも、
+           保持されないことが望ましいと言えます。この場合でも、
            標準出力を保留または操作したい場合には、
            <link linkend="ref.outcontrol">出力バッファリング</link>
            を使用することが可能です。


### PR DESCRIPTION
# 概要

https://www.php.net/manual/ja/features.commandline.differences.php における誤訳を修正しました。

# 現在の文

https://www.php.net/manual/en/features.commandline.differences.php

> In a shell environment, it is usually desirable for output, such as from print, echo and friends, to be displayed immediately, and not held in a buffer

https://www.php.net/manual/ja/features.commandline.differences.php

> print, echo および 関連するものによる全ての出力は、直ちに出力され、バッファに キャッシュされないことが望ましいと言えます。

# 修正内容

以下のように変更しました（変更箇所太字）。

> **シェル環境では、** print, echo および 関連するものによる全ての出力は、直ちに出力され、バッファに **保持** されないことが望ましいと言えます。

* "In a shell environment" の訳抜けを追加しました
* 「バッファにキャッシュ」を「バッファに保持」へ修正しました
    * いわゆる buffering を指したもので、cache とは無関係です