### PR TITLE
セッションのアップロード状況の訳を改善 (#299)

### DIFF
--- a/reference/session/upload-progress.xml
+++ b/reference/session/upload-progress.xml
@@ -15,10 +15,11 @@
   (<acronym>XHR</acronym> などで) 送って状態をチェックできるようになります。
  </para>
  <para>
-  アップロードの状況は、アップロードの処理中にスーパーグローバル <varname>$_SESSION</varname>
-  で取得できます。また、  INI オプション
+  アップロードが進行中かつ、INI オプション
   <link linkend="ini.session.upload-progress.name">session.upload_progress.name</link>
-  で設定した名前でも POST されます。PHP 側では、この POST リクエストを検出すると
+  に設定されているのと同じ名前の変数が POST されていると、アップロードの状況を
+  スーパーグローバル <varname>$_SESSION</varname> から取得できます。
+  PHP 側では、この POST リクエストを検出すると
   <varname>$_SESSION</varname> 内の配列に値を格納します。配列のインデックスは、INI オプション
   <link linkend="ini.session.upload-progress.prefix">session.upload_progress.prefix</link>
   と


### PR DESCRIPTION
close #299

[「セッションのアップロード状況 」のページ ](https://www.php.net/manual/ja/session.upload-progress.php) の訳を改善しました。

元 issue を参考にしつつ、"when ..." 以降の条件部分が長いので日本語での順序を入れ替えました。