### PR TITLE
Update var-dump.xml　英語版との違いを修正。

### DIFF
--- a/reference/var/functions/var-dump.xml
+++ b/reference/var/functions/var-dump.xml
@@ -19,7 +19,7 @@
    <methodparam rep="repeat"><type>mixed</type><parameter>values</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   この関数は一つ以上の式についての構造化された情報を式の型と値を含んで表示します。配列とオブジェクトは再帰的に探られ、値は構造を示すためにインデントされます。
+   この関数は一つ以上の式についての構造化された情報を式の型と値を含んで表示します。配列とオブジェクトは再帰的に探られ、構造を示すために値はインデントされます。
   </simpara>
   <simpara>
    オブジェクトのすべての public、private および protected


### PR DESCRIPTION
日本語ドキュメントを使って１日時間を潰した。
試行錯誤してvar_dumpは値を返さず表示しているだけだと気づいた。
英語版のドキュメントを見たらdisplayとあってreturnなんて書いてなかったので修正。返すではなく表示するである。

ついでにArrays and objectsをオブジェクトを抜け落として訳していたりインデントするという部分も抜け落ちているので全部修正。

日本語訳のソースコードの改行部分がウェブでは半角スペースになって変な空白が入っていたので１行にした。

この下の「All public, private and protected properties of objects will be returned in the output unless the object implements a [__debugInfo()](https://www.php.net/manual/en/language.oop5.magic.php#language.oop5.magic.debuginfo) method.」の日本語訳の部分も改行されているが、仕様や方針がよくわからないので放置。一行にしたほうが良ければしてもらいたい。