### PR TITLE
Update `basic-syntax.xml`

### DIFF
--- a/language/basic-syntax.xml
+++ b/language/basic-syntax.xml
@@ -1,24 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 6b09bb638aa64d1fad5f4a630a8da9a2692ce733 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 0e618211e53c66f33762be225a4d57c08ef4b2f7 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi, shimooka, mumumu -->
 
- <chapter xml:id="language.basic-syntax" xmlns="http://docbook.org/ns/docbook">
+ <chapter xml:id="language.basic-syntax" xmlns="http://docbook.org/ns/docbook" annotations="interactive">
   <title>基本的な構文</title>
   <sect1 xml:id="language.basic-syntax.phptags">
    <title>PHP タグ</title>
    <para>
-    PHP はファイルを解析して開始タグと終了タグ
-    (<literal>&lt;?php</literal> と <literal>?&gt;</literal>) を探します。
-    タグが見つかると、PHP はコードの実行を開始したり終了したりします。
-    このような仕組みにより、PHP を他のあらゆる形式のドキュメント中に
-    埋め込むことができるのです。つまり、開始タグと終了タグで囲まれている
-    箇所以外のすべての部分は、PHP パーサに無視されます。
+    PHP はファイルを処理する際、開始タグと終了タグ
+    (<literal>&lt;?php</literal> と <literal>?&gt;</literal>) を認識し、
+    PHP コード実行の境界を決めます。タグの外側の内容は PHP パーサに無視されるため、
+    PHP を他のあらゆる形式のドキュメント中に埋め込むことができるのです。
+   </para>
+
+   <para>
+    正しいトークン分割のため、<literal>&lt;?php</literal>
+    の後ろに空白文字（空白、タブ、改行）を入れる必要があります。
+    これがないと文法エラーが発生します。
    </para>
 
    <para>
     PHP では、短い形式のechoタグ <literal>&lt;?=</literal> も使えます。
-    これは、より冗長な <code>&lt;?php echo</code> を短くしたものです。
+    これは、 <code>&lt;?php echo</code> を短くしたものです。
    </para>
 
    <para>
@@ -55,23 +59,26 @@
    </para>
 
    <para>
-    ファイルが PHP コードのみを含む場合は、ファイルの最後の終了タグは省略するのがおすすめです。
+    ファイルが PHP コードで終わる場合は、ファイルの最後の終了タグは省略するのがおすすめです。
     終了タグの後に余分な空白や改行があると、予期せぬ挙動を引き起こす場合があるからです。
     余分な空白や改行のせいで PHP が出力バッファリングを開始し、その時点の内容を意図せず出力してしまうことになります。
-    <informalexample>
+   </para>
+   <para>
+    <example>
+     <title>PHP コードのみのファイル</title>
      <programlisting role="php">
 <![CDATA[
 <?php
-echo "みなさん、こんにちは";
+echo "みなさん、こんにちは\n";
 
 // ... いろんなコードたち
 
-echo "最後のごあいさつ";
+echo "最後のごあいさつ\n";
 
 // PHP 終了タグを書かずに、ここでスクリプトを終わります。
 ]]>
      </programlisting>
-    </informalexample>
+    </example>
    </para>
   </sect1>
 
@@ -81,7 +88,10 @@ echo "最後のごあいさつ";
     PHP のパーサは、開始タグと終了タグに囲まれていない部分をすべて無視します。
     そのおかげで、PHP のファイルにそれ以外のコンテンツを混在させることができるのです。
     たとえば PHP を HTML ドキュメントに組み込んで、テンプレートを作ったりすることもできます。
-    <informalexample>
+   </para>
+   <para>
+    <example>
+     <title>HTML に PHP を埋め込む</title>
      <programlisting role="php">
 <![CDATA[
 <p>この部分は PHP から無視され、そのままブラウザには表示されます。</p>
@@ -89,7 +99,9 @@ echo "最後のごあいさつ";
 <p>この部分も PHP から無視され、そのままブラウザには表示されます。</p>
 ]]>
      </programlisting>
-    </informalexample>
+    </example>
+   </para>
+   <para>
     これは期待通りに動作します。なぜなら、PHP インタプリタは ?&gt; 終了タグを見つけると
     それ以降新たに開始タグを見つけるまでの内容を何でも出力するからです
     (終了タグの直後の改行は別です。
@@ -159,21 +171,22 @@ But newline now
    </para>
 
    <para>
-    PHP パーサの開始と終了の例:
-
-    <informalexample>
+    <example>
+     <title>PHP パーサの開始と終了の例</title>
      <programlisting role="php">
 <![CDATA[
 <?php
-    echo 'テストです';
+    echo "テストです\n";
 ?>
 
-<?php echo 'テストです' ?>
+<?php echo "テストです\n" ?>
 
-<?php echo '終了タグを省略しました';
+<?php echo "終了タグを省略しました\n";
 ]]>
      </programlisting>
-    </informalexample>
+    </example>
+   </para>
+   <para>
     <note>
      <para>
       ファイル終端における PHP ブロックの終了タグはオプション（任意）です。
@@ -193,20 +206,22 @@ But newline now
    <para>
     PHP は、'C', 'C++' および Unix シェル型（Perl 型）のコメントをサポートします。
     例えば、
-
-    <informalexample>
+   </para>
+   <para>
+    <example>
+     <title>コメント</title>
      <programlisting role="php">
 <![CDATA[
 <?php
-echo 'テストです'; // C++型の単一行用のコメント
+echo "テストです\n"; // C++型の単一行用のコメント
 /* 複数行用のコメント
    もう一行分のコメント */
-echo 'もうひとつのテストです';
-echo '最後のテストです'; # シェル型の単一行用のコメント
+echo "もうひとつのテストです\n";
+echo "最後のテストです\n"; # シェル型の単一行用のコメント
 ?>
 ]]>
      </programlisting>
-    </informalexample>
+    </example>
    </para>
    <simpara>
     "一行"コメントは、改行または PHP コードのブロックの終わり
@@ -219,14 +234,15 @@ echo '最後のテストです'; # シェル型の単一行用のコメント
     及ぼしません。
    </simpara>
    <para>
-   <informalexample>
+   <example>
+    <title>一行コメント</title>
     <programlisting role="php">
 <![CDATA[
 <h1>これは <?php # echo 'シンプルな';?> 例です。</h1>
 <p>上の見出しは 'これは  例です。' となります。
 ]]>
     </programlisting>
-   </informalexample>
+   </example>
    </para>
    <simpara>
     'C' 型のコメントは、最初に <literal>*/</literal> が現れた時点で終了します。


### PR DESCRIPTION
`language/basic-syntax.xml`のdoc-en最新版までの差分を取り込んでいます。
https://github.com/php/doc-en/commits/0e618211e53c66f33762be225a4d57c08ef4b2f7/language/basic-syntax.xml?since=2025-02-05&until=2025-08-12

これによって、[言語リファレンス > 基本的な構文](https://www.php.net/manual/ja/language.basic-syntax.php)でWASMによるサンプルコード実行が有効になります。