### PR TITLE
language.operator でWASMを有効化

### DIFF
--- a/language/operators.xml
+++ b/language/operators.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 52407313885d27a4e891e08dd2e2481bcc39e244 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 16934048f79c6e117cd16a23c09c1b2ea502e284 Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa,mumumu -->
-<chapter xml:id="language.operators" xmlns="http://docbook.org/ns/docbook">
+<chapter xml:id="language.operators" xmlns="http://docbook.org/ns/docbook" annotations="interactive">
  <title>演算子</title>
  <simpara>
   演算子とは、ひとつ以上の値 (あるいはプログラミング用語における「式」)

--- a/language/operators/arithmetic.xml
+++ b/language/operators/arithmetic.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 43d07782b514d0c7a8487f2c74063739f302df8d Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 16934048f79c6e117cd16a23c09c1b2ea502e284 Maintainer: mumumu Status: ready -->
 <sect1 xml:id="language.operators.arithmetic">
  <title>算術演算子</title>
  <titleabbrev>算術演算子</titleabbrev>
@@ -20,7 +20,7 @@
    </thead>
    <tbody>
     <row>
-     <entry>+$a</entry>
+     <entry><code>+$a</code></entry>
      <entry>同一</entry>
      <entry>
       <varname>$a</varname> を、必要に応じて <type>int</type>
@@ -28,37 +28,37 @@
      </entry>
     </row>
     <row>
-     <entry>-$a</entry>
+     <entry><code>-$a</code></entry>
      <entry>負にする</entry>
      <entry><varname>$a</varname> の逆</entry>
     </row>
     <row>
-     <entry>$a + $b</entry>
+     <entry><code>$a + $b</code></entry>
      <entry>加算</entry>
      <entry><varname>$a</varname> および <varname>$b</varname> の合計</entry>
     </row>
     <row>
-     <entry>$a - $b</entry>
+     <entry><code>$a - $b</code></entry>
      <entry>減算</entry>
      <entry><varname>$a</varname> と <varname>$b</varname> の差</entry>
     </row>
     <row>
-     <entry>$a * $b</entry>
+     <entry><code>$a * $b</code></entry>
      <entry>乗算</entry>
       <entry><varname>$a</varname> および <varname>$b</varname> の積</entry>
     </row>
     <row>
-     <entry>$a / $b</entry>
+     <entry><code>$a / $b</code></entry>
      <entry>除算</entry>
-      <entry><varname>$a</varname> および <varname>$b</varname> の商</entry>
+     <entry><varname>$a</varname> および <varname>$b</varname> の商</entry>
     </row>
     <row>
-     <entry>$a % $b</entry>
+     <entry><code>$a % $b</code></entry>
      <entry>剰余</entry>
      <entry><varname>$a</varname> を <varname>$b</varname> で割った余り</entry>
     </row>
     <row>
-     <entry>$a ** $b</entry>
+     <entry><code>$a ** $b</code></entry>
      <entry>累乗</entry>
      <entry><varname>$a</varname> の <varname>$b</varname> 乗。</entry>
     </row>
@@ -67,9 +67,10 @@
  </table>
 
  <simpara>
-  除算演算子 ("/") の返す値は浮動小数点数となります。
-  ただし、ふたつのオペランドがともに整数 (あるいは整数に変換できる文字列)
-  であり、かつ結果が割り切れる場合には整数値を返します。
+  除算演算子 <literal>/</literal> の返す値は <type>float</type> となります。
+  ただし、ふたつのオペランドがともに <type>int</type> (あるいは <type>int</type>
+  に型変換される <link linkend="language.types.numeric-strings">数値文字列</link>)
+  であり、かつ被除数が除数の倍数である場合には整数値を返します。
   整数の除算については <function>intdiv</function> を参照ください。
  </simpara>
  <simpara>
@@ -78,22 +79,30 @@
  </simpara>
  <para>
   剰余演算子 <literal>%</literal> の結果の符号は、被除数の符号と同じになります。
-  つまり、<literal>$a % $b</literal> の結果の符号は
+  つまり、<code>$a % $b</code> の結果の符号は
   <varname>$a</varname> と同じになるということです。
-  <informalexample>
+  <example>
+   <title>剰余演算子</title>
    <programlisting role="php">
 <![CDATA[
 <?php
-
-echo (5 % 3)."\n";           // 2
-echo (5 % -3)."\n";          // 2
-echo (-5 % 3)."\n";          // -2
-echo (-5 % -3)."\n";         // -2
-
+var_dump(5 % 3);
+var_dump(5 % -3);
+var_dump(-5 % 3);
+var_dump(-5 % -3);
 ?>
 ]]>
    </programlisting>
-  </informalexample>
+   &example.outputs;
+   <screen>
+<![CDATA[
+int(2)
+int(2)
+int(-2)
+int(-2)
+]]>
+   </screen>
+  </example>
  </para>
  <sect2 role="seealso">
   &reftitle.seealso;

--- a/language/operators/array.xml
+++ b/language/operators/array.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 43d07782b514d0c7a8487f2c74063739f302df8d Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 16934048f79c6e117cd16a23c09c1b2ea502e284 Maintainer: mumumu Status: ready -->
 <sect1 xml:id="language.operators.array">
  <title>配列演算子</title>
  <titleabbrev>配列演算子</titleabbrev>
@@ -57,7 +57,8 @@
   右側の配列にあった同じキーの要素は無視されます。
  </para>
  <para>
-  <informalexample>
+  <example>
+   <title>配列結合演算子</title>
    <programlisting role="php">
 <![CDATA[
 <?php
@@ -78,9 +79,8 @@ var_dump($a);
 ?>
 ]]>
    </programlisting>
-  </informalexample>
-  このスクリプトを実行すると、以下のように出力されます。
-  <screen role="php">
+   &example.outputs;
+   <screen role="php">
 <![CDATA[
 Union of $a and $b:
 array(3) {
@@ -110,7 +110,8 @@ string(6) "banana"
 string(6) "cherry"
 }
 ]]>
-  </screen>
+   </screen>
+  </example>
  </para>
  <para>
   同じキーと値を保持している場合に、配列が等しいとみなされます。

--- a/language/operators/assignment.xml
+++ b/language/operators/assignment.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 43d07782b514d0c7a8487f2c74063739f302df8d Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 16934048f79c6e117cd16a23c09c1b2ea502e284 Maintainer: mumumu Status: ready -->
 <sect1 xml:id="language.operators.assignment">
  <title>代入演算子</title>
  <titleabbrev>代入演算子</titleabbrev>
@@ -13,17 +13,17 @@
  <para>
   代入式の値は、代入される値です。つまり、"<literal>$a = 3</literal>" の値は、3 です。
   これにより、以下のようなトリッキーなことができるようになります。
-  <informalexample>
+  <example>
+   <title>ネストした代入</title>
    <programlisting role="php">
 <![CDATA[
 <?php
-
 $a = ($b = 4) + 5; // $a は 9 に等しくなり、$b には 4 が代入されます
-
+var_dump($a);
 ?>
 ]]>
    </programlisting>
-  </informalexample>
+  </example>
  </para>
  <para>
   基本代入演算子に加えて、全ての<link linkend="language.operators">
@@ -31,20 +31,21 @@ $a = ($b = 4) + 5; // $a は 9 に等しくなり、$b には 4 が代入され�
   「複合演算子」があります。
   これにより、式の中の値を使用し、その値をその式の結果とすることができます。
   例えば、
-  <informalexample>
+  <example>
+   <title>複合代入</title>
    <programlisting role="php">
 <![CDATA[
 <?php
-
 $a = 3;
 $a += 5; // $a を 8 にセットします。$a = $a + 5; と同じです。
 $b = "Hello ";
 $b .= "There!"; // $bを"Hello There!"にセットします。$b = $b . "There!";と同じです。
 
+var_dump($a, $b);
 ?>
 ]]>
    </programlisting>
-  </informalexample>
+  </example>
  </para>
  <para>
   代入は、元の変数を新しい変数にコピーする(値による代入)ため、
@@ -95,7 +96,8 @@ print "$b\n"; // 表示: 4
    <link linkend="language.oop5.basic.new">new</link> の結果を参照で代入するとエラーが発生します。
   </para>
   <para>
-   <informalexample>
+   <example>
+    <title>new 演算子の参照</title>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -108,10 +110,10 @@ $o = &new C;
     &example.outputs;
     <screen>
 <![CDATA[
-Parse error: syntax error, unexpected 'new' (T_NEW) in …
+Parse error: syntax error, unexpected token ";", expecting "("
 ]]>
     </screen>
-   </informalexample>
+   </example>
   </para>
   <para>
    参照に関する詳細な情報やその使い方については、このマニュアルの

--- a/language/operators/bitwise.xml
+++ b/language/operators/bitwise.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 8859c8b96cd9e80652813f7bcf561432a5e9f934 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 16934048f79c6e117cd16a23c09c1b2ea502e284 Maintainer: mumumu Status: ready -->
 <sect1 xml:id="language.operators.bitwise">
  <title>ビット演算子</title>
  <titleabbrev>ビット演算子</titleabbrev>
@@ -89,17 +89,15 @@
   <literal>&gt;&gt;</literal> 演算子のオペランドとその結果は、常に integer として扱います。
  </para>
  <para>
+  PHP の ini 設定 error_reporting はビット値を用いています。
+  これを用いて、特定のビットを落とす演算の例を見てみましょう。
+  notice 以外のすべてのエラーを表示させるには、
+  php.ini ファイルで
+  <userinput>E_ALL &amp; ~E_NOTICE</userinput>
+  と指定することになります。
+ </para>
+ <para>
   <informalexample>
-   <para>
-    <literallayout>
-PHP の ini 設定 error_reporting はビット値を用いています。
-これを用いて、特定のビットを落とす演算の例を見てみましょう。
-notice 以外のすべてのエラーを表示させるには、
-php.ini ファイルで
-<userinput>E_ALL &amp; ~E_NOTICE</userinput>
-と指定することになります。
-    </literallayout>
-   </para>
    <para>
     <literallayout>
 まずは E_ALL。
@@ -112,24 +110,20 @@ php.ini ファイルで
 <computeroutput>00000000000000000111011111110111</computeroutput>
     </literallayout>
    </para>
-   <para>
-    <literallayout>
-同じ結果を得るもうひとつの方法として、 XOR (<literal>^</literal>)
-を使ってどちらか一方だけ立っているビットを探すという方法もあります。
-<userinput>E_ALL ^ E_NOTICE</userinput>
-    </literallayout>
-   </para>
   </informalexample>
  </para>
  <para>
+  同じ結果を得るもうひとつの方法として、 XOR (<literal>^</literal>)
+  を使ってどちらか一方だけ立っているビットを探すという方法もあります。
+  <userinput>E_ALL ^ E_NOTICE</userinput>
+ </para>
+ <para>
+  error_reporting を使って、特定のビットを立てる処理の例を見てみましょう。
+  通常のエラーとリカバー可能なエラーだけを表示させるには、次のようにします。
+  <userinput>E_ERROR | E_RECOVERABLE_ERROR</userinput>
+ </para>
+ <para>
   <informalexample>
-   <para>
-    <literallayout>
-error_reporting を使って、特定のビットを立てる処理の例を見てみましょう。
-通常のエラーとリカバー可能なエラーだけを表示させるには、次のようにします。
-<userinput>E_ERROR | E_RECOVERABLE_ERROR</userinput>
-    </literallayout>
-   </para>
    <para>
     <literallayout>
 この処理は、 E_ERROR
@@ -227,19 +221,19 @@ foreach ($values as $value) {
    <programlisting role="php">
 <![CDATA[
 <?php
-echo 12 ^ 9; // 出力は '5'
+echo 12 ^ 9, PHP_EOL; // 出力は '5'
 
-echo "12" ^ "9"; // 出力はバックスペース文字 (ascii 8)
-               // ('1' (ascii 49)) ^ ('9' (ascii 57)) = #8
+echo "12" ^ "9", PHP_EOL; // 出力はバックスペース文字 (ascii 8)
+                          // ('1' (ascii 49)) ^ ('9' (ascii 57)) = #8
 
-echo "hallo" ^ "hello"; // 出力は、ascii コード #0 #4 #0 #0 #0
-                      // 'a' ^ 'e' = #4
+echo "hallo" ^ "hello", PHP_EOL; // 出力は、ascii コード #0 #4 #0 #0 #0
+                                 // 'a' ^ 'e' = #4
 
-echo 2 ^ "3"; // 出力は 1
-              // 2 ^ ((int) "3") == 1
+echo 2 ^ "3", PHP_EOL; // 出力は 1
+                       // 2 ^ ((int) "3") == 1
 
-echo "2" ^ 3; // 出力は 1
-              // ((int) "2") ^ 3 == 1
+echo "2" ^ 3, PHP_EOL; // 出力は 1
+                       // ((int) "2") ^ 3 == 1
 ?>
 ]]>
    </programlisting>
@@ -359,7 +353,7 @@ function p($res, $val, $op, $places, $note = '') {
       echo " NOTE: $note\n";
   }
 
-  echo "\n";
+  echo "\n\n";
 }
 ?>
 ]]>

--- a/language/operators/comparison.xml
+++ b/language/operators/comparison.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e50e79746736dbdfbabe9bd3566793b3ddf38f58 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 16934048f79c6e117cd16a23c09c1b2ea502e284 Maintainer: mumumu Status: ready -->
 <sect1 xml:id="language.operators.comparison">
  <title>比較演算子</title>
  <titleabbrev>比較演算子</titleabbrev>
@@ -146,58 +146,58 @@ a
  </warning>
 
  <para>
-  <informalexample>
+  <example>
+   <title>比較演算子</title>
    <programlisting role="php">
 <![CDATA[
 <?php  
 // Integer
-echo 1 <=> 1; // 0
-echo 1 <=> 2; // -1
-echo 2 <=> 1; // 1
+echo 1 <=> 1, ' '; // 0
+echo 1 <=> 2, ' '; // -1
+echo 2 <=> 1, ' '; // 1
  
 // Float
-echo 1.5 <=> 1.5; // 0
-echo 1.5 <=> 2.5; // -1
-echo 2.5 <=> 1.5; // 1
+echo 1.5 <=> 1.5, ' '; // 0
+echo 1.5 <=> 2.5, ' '; // -1
+echo 2.5 <=> 1.5, ' '; // 1
  
 // 文字列
-echo "a" <=> "a"; // 0
-echo "a" <=> "b"; // -1
-echo "b" <=> "a"; // 1
+echo "a" <=> "a", ' '; // 0
+echo "a" <=> "b", ' '; // -1
+echo "b" <=> "a", ' '; // 1
  
-echo "a" <=> "aa"; // -1
-echo "zz" <=> "aa"; // 1
+echo "a" <=> "aa", ' ';  // -1
+echo "zz" <=> "aa", ' '; // 1
  
 // 配列
-echo [] <=> []; // 0
-echo [1, 2, 3] <=> [1, 2, 3]; // 0
-echo [1, 2, 3] <=> []; // 1
-echo [1, 2, 3] <=> [1, 2, 1]; // 1
-echo [1, 2, 3] <=> [1, 2, 4]; // -1
+echo [] <=> [], ' ';               // 0
+echo [1, 2, 3] <=> [1, 2, 3], ' '; // 0
+echo [1, 2, 3] <=> [], ' ';        // 1
+echo [1, 2, 3] <=> [1, 2, 1], ' '; // 1
+echo [1, 2, 3] <=> [1, 2, 4], ' '; // -1
  
 // オブジェクト
 $a = (object) ["a" => "b"]; 
 $b = (object) ["a" => "b"]; 
-echo $a <=> $b; // 0
+echo $a <=> $b, ' '; // 0
  
 $a = (object) ["a" => "b"]; 
 $b = (object) ["a" => "c"]; 
-echo $a <=> $b; // -1
+echo $a <=> $b, ' '; // -1
  
 $a = (object) ["a" => "c"]; 
 $b = (object) ["a" => "b"]; 
-echo $a <=> $b; // 1
+echo $a <=> $b, ' '; // 1
  
 // 比較するのは値だけではない; キーも一致しなければならない
 $a = (object) ["a" => "b"]; 
 $b = (object) ["b" => "b"]; 
-echo $a <=> $b; // 1
+echo $a <=> $b, ' '; // 1
 
 ?>
 ]]>
-    
    </programlisting>
-  </informalexample>
+  </example>
  </para>
 
  <para>
@@ -280,7 +280,7 @@ var_dump(min(-100, -10, NULL, 10, 100)); // NULL - (bool) NULL < (bool) -100 is 
  <para>
   <example>
    <title>一般的な配列の比較</title>
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 // 標準の比較演算子や、宇宙船演算子を用いて、配列はこのように比較されます

--- a/language/operators/errorcontrol.xml
+++ b/language/operators/errorcontrol.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 43d07782b514d0c7a8487f2c74063739f302df8d Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 16934048f79c6e117cd16a23c09c1b2ea502e284 Maintainer: mumumu Status: ready -->
 <sect1 xml:id="language.operators.errorcontrol">
  <title>エラー制御演算子</title>
  <titleabbrev>エラー制御演算子</titleabbrev>
@@ -32,22 +32,32 @@
   この関数の結果はエラーごとに変わります。よって速やかに確認する必要があります。
  </simpara>
  <para>
-  <informalexample>
+  <example>
+   <title>意図的なエラー</title>
    <programlisting role="php">
 <![CDATA[
 <?php
-/* 意図的なエラー */
 $my_file = @file ('non_existent_file') or
-  die ("Failed opening file: error was '" . error_get_last()['message'] . "'");
-
-// この演算子は関数だけでなく、全ての式で動作します。
-$value = @$cache[$key]; 
-// インデックス $key が存在しない場合でも、警告を発生しません。
-
+  die ("Failed opening file: error was '" . error_get_last()['message'] . "'")
+;
 ?>
 ]]>
    </programlisting>
-  </informalexample>
+  </example>
+ </para>
+ <para>
+  <example>
+   <title>式でのエラー抑制</title>
+   <programlisting>
+<![CDATA[
+<?php
+// この演算子は関数だけでなく、全ての式で動作します。
+$value = @$cache[$key]; 
+// インデックス $key が存在しない場合でも、警告を発生しません。
+?>
+]]>
+   </programlisting>
+  </example>
  </para>
  <note>
   <simpara>

--- a/language/operators/execution.xml
+++ b/language/operators/execution.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ebfd524ef6937b8ca42b05a6b01f43fbd8757244 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 16934048f79c6e117cd16a23c09c1b2ea502e284 Maintainer: mumumu Status: ready -->
 <sect1 xml:id="language.operators.execution">
  <title>実行演算子</title>
  <titleabbrev>実行演算子</titleabbrev>
@@ -11,7 +11,10 @@
   (すなわち、出力を単にダンプするのではなく、変数に代入することが
   できます) 。
   バッククォート演算子の使用は <function>shell_exec</function> と等価です。
-  <informalexample>
+ </para>
+ <para>
+  <example>
+   <title>バッククォート演算子</title>
    <programlisting role="php">
 <![CDATA[
 <?php
@@ -20,7 +23,7 @@ echo "<pre>$output</pre>";
 ?>
 ]]>
    </programlisting>
-  </informalexample>
+  </example>
  </para>
  <note>
   <para>

--- a/language/operators/increment.xml
+++ b/language/operators/increment.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 43d07782b514d0c7a8487f2c74063739f302df8d Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 16934048f79c6e117cd16a23c09c1b2ea502e284 Maintainer: mumumu Status: ready -->
 <sect1 xml:id="language.operators.increment">
  <title>加算子/減算子</title>
  <titleabbrev>加算子/減算子</titleabbrev>
@@ -44,8 +44,8 @@
  </table>
 
  <para>
-  以下に簡単なスクリプトの例を示します:
-  <informalexample>
+  <example>
+   <title>インクリメント/デクリメントの例</title>
    <programlisting role="php">
 <![CDATA[
 <?php
@@ -88,7 +88,7 @@ int(4)
 int(4)
 ]]>
    </screen>
-  </informalexample>
+  </example>
 
   <warning>
    <para>

--- a/language/operators/precedence.xml
+++ b/language/operators/precedence.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 43d07782b514d0c7a8487f2c74063739f302df8d Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 16934048f79c6e117cd16a23c09c1b2ea502e284 Maintainer: mumumu Status: ready -->
 <sect1 xml:id="language.operators.precedence">
  <title>演算子の優先順位</title>
  <titleabbrev>演算子の優先順位</titleabbrev>
@@ -298,12 +298,31 @@
 <![CDATA[
 <?php
 $a = 3 * 3 % 5; // (3 * 3) % 5 = 4
-// PHP の三項演算子の結合法則は、C/C++のそれとは異なります
-$a = true ? 0 : true ? 1 : 2; // PHP 8.0.0 より前のバージョンでは、(true ? 0 : true) ? 1 : 2 = 2
+var_dump($a);
 
 $a = 1;
 $b = 2;
 $a = $b += 3; // $a = ($b += 3) -> $a = 5, $b = 5
+var_dump($a, $b);
+?>
+]]>
+   </programlisting>
+  </example>
+ </para>
+ <para>
+  三項演算子は特に、優先順位を明確にするための括弧が必要となります。
+ </para>
+ <para>
+  <example>
+   <title>優先順位の明示</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$a = true ? 0 : (true ? 1 : 2);
+var_dump($a);
+
+// PHP 8 以降は以下のように書くことはできません
+// $a = true ? 0 : true ? 1 : 2;
 ?>
 ]]>
    </programlisting>
@@ -316,7 +335,7 @@ $a = $b += 3; // $a = ($b += 3) -> $a = 5, $b = 5
   PHP のバージョンが変わったり前後のコードが変わったりしたときに、評価順が変わる可能性があるからです。
   <example>
    <title>評価順序は未定義</title>
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 $a = 1;
@@ -329,15 +348,43 @@ $array[$i] = $i++; // インデックス 1 をセットするかもしれない�
    </programlisting>
   </example>
   <example>
-   <title><literal>+</literal>、<literal>-</literal>、<literal>.</literal> の優先順位は同じ(PHP 8.0.0 より前のバージョン)</title>
+   <title><literal>+</literal>、<literal>-</literal>、<literal>.</literal> の優先順位</title>
    <programlisting role="php">
 <![CDATA[
 <?php
 $x = 4;
 // 次の行は、予期せぬ結果になることでしょう
 echo "x minus one equals " . $x-1 . ", or so I hope\n";
-// なぜなら、これは次のように評価されるからです(PHP 8.0.0より前のバージョン)
+
+// 期待どおりの結果を得るには、括弧を使って優先順位を指定します
+echo "x minus one equals " . ($x-1) . ", or so I hope\n";
+
+// このようにはできず、TypeError がスローされます
 echo (("x minus one equals " . $x) - 1) . ", or so I hope\n";
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+-1, or so I hope
+-1, or so I hope
+Fatal error: Uncaught TypeError: Unsupported operand types: string - int
+]]>
+   </screen>
+  </example>
+  <example>
+   <title>PHP 8 より前のバージョンでは、 <literal>+</literal>, <literal>-</literal> and <literal>.</literal> の優先順位は同じ</title>
+   <programlisting role="php" annotations="non-interactive">
+<![CDATA[
+<?php
+$x = 4;
+// 次の行は、予期せぬ結果になることでしょう
+echo "x minus one equals " . $x-1 . ", or so I hope\n";
+
+// なぜなら、これは次のように評価されるからです(PHP 8.0.0 より前のバージョン)
+echo (("x minus one equals " . $x) - 1) . ", or so I hope\n";
+
 // 期待どおりの結果を得るには、括弧を使って優先順位を指定します
 echo "x minus one equals " . ($x-1) . ", or so I hope\n";
 ?>

--- a/language/operators/string.xml
+++ b/language/operators/string.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 43d07782b514d0c7a8487f2c74063739f302df8d Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 16934048f79c6e117cd16a23c09c1b2ea502e284 Maintainer: mumumu Status: ready -->
 <sect1 xml:id="language.operators.string">
  <title>文字列演算子</title>
  <titleabbrev>文字列演算子</titleabbrev>
@@ -13,19 +13,22 @@
  </simpara>
 
  <para>
-  <informalexample>
+  <example>
+   <title>文字列結合</title>
    <programlisting role="php">
 <![CDATA[
 <?php
 $a = "Hello ";
 $b = $a . "World!"; // $b は、"Hello World!" となります。
+var_dump($b);
 
 $a = "Hello ";
 $a .= "World!"; // $a は、"Hello World!" となります。
+var_dump($a);
 ?>
 ]]>
    </programlisting>
-  </informalexample>
+  </example>
  </para>
 
  <sect2 role="seealso">

--- a/language/operators/type.xml
+++ b/language/operators/type.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 43d07782b514d0c7a8487f2c74063739f302df8d Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 16934048f79c6e117cd16a23c09c1b2ea502e284 Maintainer: mumumu Status: ready -->
 <sect1 xml:id="language.operators.type">
  <title>型演算子</title>
  <titleabbrev>型演算子</titleabbrev>
@@ -178,8 +178,8 @@ bool(false)
 <?php
 $a = 1;
 $b = NULL;
-$c = imagecreate(5, 5);
-var_dump($a instanceof stdClass); // $a は配列です
+$c = fopen('/tmp/', 'r');
+var_dump($a instanceof stdClass); // $a は整数です
 var_dump($b instanceof stdClass); // $b は NULL です
 var_dump($c instanceof stdClass); // $c はリソースです
 var_dump(FALSE instanceof stdClass);


### PR DESCRIPTION
https://github.com/php/doc-en/commit/16934048f79c6e117cd16a23c09c1b2ea502e284 （および未適用だった https://github.com/php/doc-en/commit/c35ad60a7f790d735bbdca01c6baaf65d4867330 ）を日本語版に適用しています。