### PR TITLE
PHP_VERSION_* を PHP_*_VERSION に修正

### DIFF
--- a/reference/info/functions/phpversion.xml
+++ b/reference/info/functions/phpversion.xml
@@ -132,7 +132,7 @@ if (PHP_VERSION_ID < 50207) {
    <para>
     この情報は、定義済みの定数 <constant>PHP_VERSION</constant>
     でも取得可能です。その他のバージョン関連の情報は、定数
-    <constant>PHP_VERSION_*</constant> で取得可能です。
+    <constant>PHP_<replaceable>*</replaceable>_VERSION</constant> で取得可能です。
    </para>
   </note>
   <note>


### PR DESCRIPTION
https://www.php.net/manual/ja/function.phpversion.php#refsect1-function.phpversion-notes の注意の部分です。

PHP_VERSION_* となっていますが、PHP_*_VERSION が正しいと思います。