### PR TITLE
PHP 8.0 移行ガイドにおける str_contains() の誤訳を修正

### DIFF
--- a/appendices/migration80/new-features.xml
+++ b/appendices/migration80/new-features.xml
@@ -430,7 +430,7 @@ class ChildClass extends ParentClass {
   <itemizedlist>
    <listitem>
     <para>
-     文字列に <parameter>haystack</parameter> が含まれているかどうかを調べる
+     文字列に <parameter>needle</parameter> が含まれているかどうかを調べる
      <function>str_contains</function> 関数が追加されました。
     </para>
     <para>


### PR DESCRIPTION
PHP 8.0 移行ガイドにおける `str_contains($haystack, $needle)` についての紹介で、 `$needle` と `$haystack` が逆になっていたのを修正しました。