### PR TITLE
FFI 拡張を新規翻訳

### DIFF
--- a/reference/ffi/book.xml
+++ b/reference/ffi/book.xml
@@ -1,43 +1,42 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 46a9cdd2dbef4ec89bf65fad9930e2feb78bbb98 Maintainer: nsfisis Status: working -->
+<!-- EN-Revision: 46a9cdd2dbef4ec89bf65fad9930e2feb78bbb98 Maintainer: nsfisis Status: ready -->
 
 <book xml:id="book.ffi" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <?phpdoc extension-membership="bundled" ?>
- <title>Foreign Function Interface</title>
+ <title>外部関数インターフェース</title>
  <titleabbrev>FFI</titleabbrev>
 
  <preface xml:id="intro.ffi">
   &reftitle.intro;
   <para>
-   This extension allows the loading of shared libraries (<filename>.DLL</filename> or
-   <filename>.so</filename>), calling of C functions and accessing of C data structures
-   in pure PHP, without having to have deep knowledge of the Zend extension API, and
-   without having to learn a third “intermediate” language.
-   The public API is implemented as a single class <classname>FFI</classname> with
-   several static methods (some of them may be called dynamically), and overloaded object
-   methods, which perform the actual interaction with C data.
+   この拡張は、Zend 拡張 API の深い知識が無くとも、あるいは第三の中間言語を学ぶことをせずとも、
+   純粋な PHP で共有ライブラリ (<filename>.DLL</filename> または <filename>.so</filename>)
+   を読み込んだり、C の関数を呼び出したり、C のデータ構造にアクセスしたりすることを
+   可能とします。
+   公開 API は単一のクラス <classname>FFI</classname> として実装されています。
+   このクラスの static メソッド (そのうちのいくつかは非 static メソッドとしても呼び出せます) や
+   オーバーロードされたオブジェクトメソッドが、実際の C のデータとのやり取りを行います。
   </para>
   <caution>
    <para>
-    FFI is dangerous, since it allows to interface with the system on a very low level.
-    The FFI extension should only be used by developers having a working knowledge of C
-    and the used C APIs. To minimize the risk, the FFI API usage may be restricted
-    with the <link linkend="ini.ffi.enable">ffi.enable</link> &php.ini; directive.
+    FFI は、システムと低レベルでやり取りできるため危険です。
+    FFI 拡張は、C 言語および使用する C API についての実用的な知識を持つ開発者のみが
+    用いるべきです。リスクを最小化するため、FFI API の使用は
+    <link linkend="ini.ffi.enable">ffi.enable</link> &php.ini; ディレクティブによって制限できます。
    </para>
   </caution>
   <note>
    <para>
-    The FFI extension does not render the classic PHP extension API obsolete; it is merely
-    provided for ad-hoc interfacing with C functions and data structures.
+    FFI 拡張は、古くからある PHP 拡張の API を廃止しようとしているわけではなく、
+    C の関数やデータ構造へのアドホックなインターフェースを提供するにすぎません。
    </para>
   </note>
   <tip>
    <para>
-    Currently, accessing FFI data structures is significantly (about 2 times) slower
-    than accessing native PHP arrays and objects. Therefore, it makes no sense to use
-    the FFI extension for speed; however, it may make sense to use it to reduce memory
-    consumption.
+    今のところ、FFI のデータ構造へのアクセスは、ネイティブな PHP の配列やオブジェクトへのアクセスと比べて
+    非常に (約 2 倍) 低速です。したがって、速度のために FFI 拡張を使うことには意味がありません。
+    しかし、メモリ消費を減らすために使うのは意味があるかもしれません。
    </para>
   </tip>
  </preface>

--- a/reference/ffi/configure.xml
+++ b/reference/ffi/configure.xml
@@ -1,18 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: cffb5f52894aa8a29109e3802e2257c56b51bcb6 Maintainer: nsfisis Status: working -->
+<!-- EN-Revision: cffb5f52894aa8a29109e3802e2257c56b51bcb6 Maintainer: nsfisis Status: ready -->
 
 <section xml:id="ffi.installation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.install;
 
  <para>
-  To enable the FFI extension, PHP has to be configured with
-  <option role="configure">--with-ffi</option>.
+  FFI 拡張を有効にするには、
+  <option role="configure">--with-ffi</option> を付けて
+  PHP をビルドする必要があります。
  </para>
 
  <para>
-  Windows users have to include <filename>php_ffi.dll</filename> into &php.ini;
-  to enable the FFI extension.
+  Windows ユーザーが FFI 拡張を有効にするには、
+  &php.ini; に <filename>php_ffi.dll</filename> を含める必要があります。
  </para>
 
 </section>

--- a/reference/ffi/ctype/getalignment.xml
+++ b/reference/ffi/ctype/getalignment.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9e0804888ae46a50f28d98514a8d5e70a34e069c Maintainer: nsfisis Status: working -->
+<!-- EN-Revision: 9e0804888ae46a50f28d98514a8d5e70a34e069c Maintainer: nsfisis Status: ready -->
 
 <refentry xml:id="ffi-ctype.getalignment" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>FFI\CType::getAlignment</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>説明</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/ffi/ctype/getarrayelementtype.xml
+++ b/reference/ffi/ctype/getarrayelementtype.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9e0804888ae46a50f28d98514a8d5e70a34e069c Maintainer: nsfisis Status: working -->
+<!-- EN-Revision: 9e0804888ae46a50f28d98514a8d5e70a34e069c Maintainer: nsfisis Status: ready -->
 
 <refentry xml:id="ffi-ctype.getarrayelementtype" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>FFI\CType::getArrayElementType</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>説明</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/ffi/ctype/getarraylength.xml
+++ b/reference/ffi/ctype/getarraylength.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9e0804888ae46a50f28d98514a8d5e70a34e069c Maintainer: nsfisis Status: working -->
+<!-- EN-Revision: 9e0804888ae46a50f28d98514a8d5e70a34e069c Maintainer: nsfisis Status: ready -->
 
 <refentry xml:id="ffi-ctype.getarraylength" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>FFI\CType::getArrayLength</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>説明</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/ffi/ctype/getattributes.xml
+++ b/reference/ffi/ctype/getattributes.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9e0804888ae46a50f28d98514a8d5e70a34e069c Maintainer: nsfisis Status: working -->
+<!-- EN-Revision: 9e0804888ae46a50f28d98514a8d5e70a34e069c Maintainer: nsfisis Status: ready -->
 
 <refentry xml:id="ffi-ctype.getattributes" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>FFI\CType::getAttributes</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>説明</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/ffi/ctype/getenumkind.xml
+++ b/reference/ffi/ctype/getenumkind.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9e0804888ae46a50f28d98514a8d5e70a34e069c Maintainer: nsfisis Status: working -->
+<!-- EN-Revision: 9e0804888ae46a50f28d98514a8d5e70a34e069c Maintainer: nsfisis Status: ready -->
 
 <refentry xml:id="ffi-ctype.getenumkind" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>FFI\CType::getEnumKind</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>説明</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/ffi/ctype/getfuncabi.xml
+++ b/reference/ffi/ctype/getfuncabi.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9e0804888ae46a50f28d98514a8d5e70a34e069c Maintainer: nsfisis Status: working -->
+<!-- EN-Revision: 9e0804888ae46a50f28d98514a8d5e70a34e069c Maintainer: nsfisis Status: ready -->
 
 <refentry xml:id="ffi-ctype.getfuncabi" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>FFI\CType::getFuncABI</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>説明</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/ffi/ctype/getfuncparametercount.xml
+++ b/reference/ffi/ctype/getfuncparametercount.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 55e1ffbb74003fdd5d956afcc134669b2d493986 Maintainer: nsfisis Status: working -->
+<!-- EN-Revision: 55e1ffbb74003fdd5d956afcc134669b2d493986 Maintainer: nsfisis Status: ready -->
 
 <refentry xml:id="ffi-ctype.getfuncparametercount" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>FFI\CType::getFuncParameterCount</refname>
-  <refpurpose>Retrieve the count of parameters of a function type</refpurpose>
+  <refpurpose>関数型の引数の数を取得する</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -28,9 +28,9 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the number of parameters for the underlying function type.
-   If the underlying type is not a function, an
-   <exceptionname>FFI\Exception</exceptionname> is thrown.
+   内部的に保持している関数型の引数の数を返します。
+   内部的に保持している型が関数でない場合、
+   <exceptionname>FFI\Exception</exceptionname> をスローします。
   </para>
  </refsect1>
 

--- a/reference/ffi/ctype/getfuncparametertype.xml
+++ b/reference/ffi/ctype/getfuncparametertype.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 184bc21699133fda630f0327fcd7d636a14d45fb Maintainer: nsfisis Status: working -->
+<!-- EN-Revision: 184bc21699133fda630f0327fcd7d636a14d45fb Maintainer: nsfisis Status: ready -->
 
 <refentry xml:id="ffi-ctype.getfuncparametertype" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>FFI\CType::getFuncParameterType</refname>
-  <refpurpose>Retrieve the type of a function parameter</refpurpose>
+  <refpurpose>関数の引数の型を取得する</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,7 +15,7 @@
    <methodparam><type>int</type><parameter>index</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Returns the type of a parameter for the underlying function type.
+   内部的に保持している関数型の引数の型を返します。
   </para>
 
  </refsect1>
@@ -27,7 +27,7 @@
     <term><parameter>index</parameter></term>
     <listitem>
      <para>
-      Index of the function parameter, zero-based.
+      関数の引数の添字 (ゼロ始まり)。
      </para>
     </listitem>
    </varlistentry>
@@ -37,10 +37,10 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the type of a parameter for the underlying function type.
-   If the underlying type is not a function, or the given index is outside
-   of the range of parameters of the function, an
-   <exceptionname>FFI\Exception</exceptionname> is thrown.
+   内部的に保持している関数型の引数の型を返します。
+   内部的に保持している型が関数でない場合や、
+   与えられた添字がその関数の引数の範囲外の場合、
+   <exceptionname>FFI\Exception</exceptionname> をスローします。
   </para>
  </refsect1>
 

--- a/reference/ffi/ctype/getfuncreturntype.xml
+++ b/reference/ffi/ctype/getfuncreturntype.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9e0804888ae46a50f28d98514a8d5e70a34e069c Maintainer: nsfisis Status: working -->
+<!-- EN-Revision: 9e0804888ae46a50f28d98514a8d5e70a34e069c Maintainer: nsfisis Status: ready -->
 
 <refentry xml:id="ffi-ctype.getfuncreturntype" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>FFI\CType::getFuncReturnType</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>説明</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/ffi/ctype/getkind.xml
+++ b/reference/ffi/ctype/getkind.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9e0804888ae46a50f28d98514a8d5e70a34e069c Maintainer: nsfisis Status: working -->
+<!-- EN-Revision: 9e0804888ae46a50f28d98514a8d5e70a34e069c Maintainer: nsfisis Status: ready -->
 
 <refentry xml:id="ffi-ctype.getkind" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>FFI\CType::getKind</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>説明</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/ffi/ctype/getname.xml
+++ b/reference/ffi/ctype/getname.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9e0804888ae46a50f28d98514a8d5e70a34e069c Maintainer: nsfisis Status: working -->
+<!-- EN-Revision: 9e0804888ae46a50f28d98514a8d5e70a34e069c Maintainer: nsfisis Status: ready -->
 
 <refentry xml:id="ffi-ctype.getname" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>FFI\CType::getName</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>説明</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/ffi/ctype/getpointertype.xml
+++ b/reference/ffi/ctype/getpointertype.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9e0804888ae46a50f28d98514a8d5e70a34e069c Maintainer: nsfisis Status: working -->
+<!-- EN-Revision: 9e0804888ae46a50f28d98514a8d5e70a34e069c Maintainer: nsfisis Status: ready -->
 
 <refentry xml:id="ffi-ctype.getpointertype" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>FFI\CType::getPointerType</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>説明</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/ffi/ctype/getsize.xml
+++ b/reference/ffi/ctype/getsize.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9e0804888ae46a50f28d98514a8d5e70a34e069c Maintainer: nsfisis Status: working -->
+<!-- EN-Revision: 9e0804888ae46a50f28d98514a8d5e70a34e069c Maintainer: nsfisis Status: ready -->
 
 <refentry xml:id="ffi-ctype.getsize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>FFI\CType::getSize</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>説明</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/ffi/ctype/getstructfieldnames.xml
+++ b/reference/ffi/ctype/getstructfieldnames.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9e0804888ae46a50f28d98514a8d5e70a34e069c Maintainer: nsfisis Status: working -->
+<!-- EN-Revision: 9e0804888ae46a50f28d98514a8d5e70a34e069c Maintainer: nsfisis Status: ready -->
 
 <refentry xml:id="ffi-ctype.getstructfieldnames" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>FFI\CType::getStructFieldNames</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>説明</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/ffi/ctype/getstructfieldoffset.xml
+++ b/reference/ffi/ctype/getstructfieldoffset.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9e0804888ae46a50f28d98514a8d5e70a34e069c Maintainer: nsfisis Status: working -->
+<!-- EN-Revision: 9e0804888ae46a50f28d98514a8d5e70a34e069c Maintainer: nsfisis Status: ready -->
 
 <refentry xml:id="ffi-ctype.getstructfieldoffset" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>FFI\CType::getStructFieldOffset</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>説明</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/ffi/ctype/getstructfieldtype.xml
+++ b/reference/ffi/ctype/getstructfieldtype.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9e0804888ae46a50f28d98514a8d5e70a34e069c Maintainer: nsfisis Status: working -->
+<!-- EN-Revision: 9e0804888ae46a50f28d98514a8d5e70a34e069c Maintainer: nsfisis Status: ready -->
 
 <refentry xml:id="ffi-ctype.getstructfieldtype" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>FFI\CType::getStructFieldType</refname>
-  <refpurpose>Description</refpurpose>
+  <refpurpose>説明</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/ffi/examples.xml
+++ b/reference/ffi/examples.xml
@@ -1,32 +1,32 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 8859c8b96cd9e80652813f7bcf561432a5e9f934 Maintainer: nsfisis Status: working -->
+<!-- EN-Revision: 8859c8b96cd9e80652813f7bcf561432a5e9f934 Maintainer: nsfisis Status: ready -->
 
 <chapter xml:id="ffi.examples" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.examples;
  <section xml:id="ffi.examples-basic">
-  <title>Basic FFI usage</title>
+  <title>FFI の基本的な使い方</title>
   <para>
-   Before diving into the details of the FFI API, lets take a look at a few examples
-   demonstrating the simplicity of the FFI API usage for regular tasks.
+   FFI API の詳細に深く立ち入る前に、よくあるタスクに対する FFI API の使い方が
+   どれほど簡単かを示す例をいくつか見てみましょう。
   </para>
   <note>
    <para>
-    Some of these examples require <filename>libc.so.6</filename> and as such will
-    not work on systems where it is not available.
+    これらの例の中には、<filename>libc.so.6</filename> を必要とするものがあります。
+    それらは、このライブラリが利用できないシステムでは動きません。
    </para>
   </note>
   <para>
    <example xml:id="ffi.examples.function">
-    <title>Calling a function from shared library</title>
+    <title>共有ライブラリの関数を呼ぶ</title>
     <programlisting role="php">
 <![CDATA[
 <?php
-// create FFI object, loading libc and exporting function printf()
+// FFI オブジェクトを作成し、libc を読み込んで printf() 関数をエクスポートする
 $ffi = FFI::cdef(
-    "int printf(const char *format, ...);", // this is a regular C declaration
+    "int printf(const char *format, ...);", // ここは通常の C の宣言
     "libc.so.6");
-// call C's printf()
+// C の printf() を呼ぶ
 $ffi->printf("Hello %s!\n", "world");
 ?>
 ]]>
@@ -41,17 +41,17 @@ Hello world!
   </para>
     <note>
    <para>
-    Note that some C functions need specific calling conventions, e.g. <literal>__fastcall</literal>,
-    <literal>__stdcall</literal> or <literal>,__vectorcall</literal>.
+    C の関数のうちのいくつかは、特定の呼び出し規約 (例: <literal>__fastcall</literal>、
+    <literal>__stdcall</literal>、<literal>,__vectorcall</literal> など) を必要とすることに注意してください。
    </para>
   </note>
   <para>
    <example xml:id="ffi.examples.structure">
-    <title>Calling a function, returning a structure through an argument</title>
+    <title>関数を呼び出し、構造体を引数経由で返す</title>
     <programlisting role="php">
 <![CDATA[
 <?php
-// create gettimeofday() binding
+// gettimeofday() のバインディングを作成する
 $ffi = FFI::cdef("
     typedef unsigned int time_t;
     typedef unsigned int suseconds_t;
@@ -68,14 +68,14 @@ $ffi = FFI::cdef("
  
     int gettimeofday(struct timeval *tv, struct timezone *tz);    
 ", "libc.so.6");
-// create C data structures
+// C のデータ構造を作成する
 $tv = $ffi->new("struct timeval");
 $tz = $ffi->new("struct timezone");
-// call C's gettimeofday()
+// C の gettimeofday() を呼ぶ
 var_dump($ffi->gettimeofday(FFI::addr($tv), FFI::addr($tz)));
-// access field of C data structure
+// C のデータ構造のフィールドにアクセスする
 var_dump($tv->tv_sec);
-// print the whole C data structure
+// C のデータ構造全体を出力する
 var_dump($tz);
 ?>
 ]]>
@@ -97,15 +97,15 @@ object(FFI\CData:struct timezone)#3 (2) {
   </para>
   <para>
    <example xml:id="ffi.examples.variable-existing">
-    <title>Accessing existing C variables</title>
+    <title>既存の C の変数にアクセスする</title>
     <programlisting role="php">
 <![CDATA[
 <?php
-// create FFI object, loading libc and exporting errno variable
+// FFI オブジェクトを作成し、libc を読み込んで errno 変数をエクスポートする
 $ffi = FFI::cdef(
-    "int errno;", // this is a regular C declaration
+    "int errno;", // ここは通常の C の宣言
     "libc.so.6");
-// print C's errno
+// C の errno を出力する
 var_dump($ffi->errno);
 ?>
 ]]>
@@ -120,19 +120,19 @@ int(0)
   </para>
   <para>
    <example xml:id="ffi.examples.variable-creating">
-    <title>Creating and Modifying C variables</title>
+    <title>C の変数を作成して書き換える</title>
     <programlisting role="php">
 <![CDATA[
 <?php
-// create a new C int variable
+// 新しい C の int 変数を作成する
 $x = FFI::new("int");
 var_dump($x->cdata);
 
-// simple assignment
+// 単純な代入
 $x->cdata = 5;
 var_dump($x->cdata);
 
-// compound assignment
+// 複合代入
 $x->cdata += 2;
 var_dump($x->cdata);
 ?>
@@ -150,13 +150,13 @@ int(7)
   </para>
   <para>
    <example xml:id="ffi.examples.array">
-    <title>Working with C arrays</title>
+    <title>C の配列を扱う</title>
     <programlisting role="php">
 <![CDATA[
 <?php
-// create C data structure
+// C のデータ構造を作成する
 $a = FFI::new("long[1024]");
-// work with it like with a regular PHP array
+// 通常の PHP の配列を扱うのと同じように扱う
 for ($i = 0; $i < count($a); $i++) {
     $a[$i] = $i;
 }
@@ -184,7 +184,7 @@ int(8192)
   </para>
   <para>
     <example xml:id="ffi.examples.enum">
-    <title>Working with C enums</title>
+    <title>C の enum を扱う</title>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -213,12 +213,12 @@ int(3)
   </para>
  </section>
  <section xml:id="ffi.examples-callback">
-  <title>PHP Callbacks</title>
+  <title>PHP のコールバック</title>
   <para>
-   It is possible to assign a PHP closure to a native variable of function pointer type
-   or to pass it as a function argument:
+   PHP のクロージャを、関数ポインタ型のネイティブ変数に代入したり、
+   関数の引数として渡したりできます。
    <example>
-    <title>Assigning a PHP <classname>Closure</classname> to a C function pointer</title>
+    <title>PHP の <classname>Closure</classname> を C の関数ポインタに代入する</title>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -254,18 +254,18 @@ Hello World 3!
 ]]>
     </screen>
    </example>
-   Although this works, this functionality is not supported on all libffi platforms, is not efficient
-   and leaks resources by the end of request.
+   これは動作こそしますが、この機能は libffi が動作するすべてのプラットフォームでサポートされているわけではありません。
+   また、非効率的であり、リクエストの終了時にリソースがリークします。
    <tip>
     <simpara>
-     It is therefore recommended to minimize the usage of PHP callbacks.
+     したがって、PHP のコールバックの使用は最小限にすることを推奨します。
     </simpara>
    </tip>
   </para>
  </section>
 
  <section xml:id="ffi.examples-complete">
-  <title>A Complete PHP/FFI/preloading Example</title>
+  <title>PHP/FFI/事前ロードの完全な例</title>
   <informalexample>
    <simpara><filename>php.ini</filename></simpara>
    <programlisting role="ini">

--- a/reference/ffi/ffi.cdata.xml
+++ b/reference/ffi/ffi.cdata.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: nsfisis Status: working -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: nsfisis Status: ready -->
 
 <reference xml:id="class.ffi-cdata" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
- <title>C Data Handles</title>
+ <title>C のデータハンドル</title>
  <titleabbrev>FFI\CData</titleabbrev>
 
  <partintro>
@@ -13,87 +13,87 @@
   <section xml:id="ffi-cdata.intro">
    &reftitle.intro;
    <para>
-    <classname>FFI\CData</classname> objects can be used in a number of ways as a regular
+    <classname>FFI\CData</classname> オブジェクトは、通常の PHP データのように様々な方法で使用できます:
 
-    PHP data:
     <itemizedlist>
      <listitem>
       <simpara>
-       C data of scalar types can be read and assigned via the <property>$cdata</property> property, e.g. 
+       スカラー型の C のデータは <property>$cdata</property> プロパティを通してアクセスできます。例:
        <code>$x = FFI::new('int'); $x-&gt;cdata = 42;</code>
       </simpara>
      </listitem>
      <listitem>
       <simpara>
-       C struct and union fields can be accessed as regular PHP object property, e.g.
+       C の構造体や共用体のフィールドは通常の PHP のオブジェクトプロパティのようにアクセスできます。例:
        <code>$cdata-&gt;field</code>
       </simpara>
      </listitem>
      <listitem>
       <simpara>
-       C array elements can be accessed as regular PHP array elements, e.g.
+       C の配列要素は通常の PHP の配列要素のようにアクセスできます。例:
        <code>$cdata[$offset]</code>
       </simpara>
      </listitem>
      <listitem>
       <simpara>
-       C arrays can be iterated using &foreach; statements.
+       C の配列は &foreach; 文を使って反復できます。
       </simpara>
      </listitem>
      <listitem>
       <simpara>
-       C arrays can be used as arguments of <function>count</function>.
+       C の配列は <function>count</function> の引数として使えます。
       </simpara>
      </listitem>
      <listitem>
       <simpara>
-       C pointers can be dereferenced as arrays, e.g. <code>$cdata[0]</code>
+       C のポインタは配列のように参照外しできます。例: <code>$cdata[0]</code>
       </simpara>
      </listitem>
      <listitem>
       <simpara>
-       C pointers can be compared using regular comparison operators (<code>&lt;</code>,
-       <code>&lt;=</code>, <code>==</code>, <code>!=</code>, <code>&gt;=</code>, <code>&gt;</code>).
+       C のポインタは通常の比較演算子を使って比較できます (<code>&lt;</code>、
+       <code>&lt;=</code>、<code>==</code>、<code>!=</code>、<code>&gt;=</code>、<code>&gt;</code>)。
       </simpara>
      </listitem>
      <listitem>
       <simpara>
-       C pointers can be incremented and decremented using regular <code>+</code>/<code>-</code>/
-       <code>++</code>/<code>--</code> operations, e.g. <code>$cdata += 5</code>
+       C のポインタは通常の <code>+</code>/<code>-</code>/
+       <code>++</code>/<code>--</code> 演算子を使ってインクリメント・デクリメントできます。例: <code>$cdata += 5</code>
       </simpara>
      </listitem>
      <listitem>
       <simpara>
-       C pointers can be subtracted from another using regular <code>-</code> operations.
+       C のポインタは通常の <code>-</code> 演算子を使って他のポインタと引き算できます。
       </simpara>
      </listitem>
      <listitem>
       <simpara>
-       C pointers to functions can be called as a regular PHP closure, e.g. <code>$cdata()</code>
+       C の関数ポインタは通常の PHP のクロージャのように呼び出せます。例: <code>$cdata()</code>
       </simpara>
      </listitem>
      <listitem>
       <simpara>
-       Any C data can be duplicated using the <link linkend="language.oop5.cloning">clone</link>
-       operator, e.g. <code>$cdata2 = clone $cdata;</code>
+       任意の C のデータは <link linkend="language.oop5.cloning">clone</link> 演算子を使って
+       複製できます。例: <code>$cdata2 = clone $cdata;</code>
       </simpara>
      </listitem>
      <listitem>
       <simpara>
-       Any C data can be visualized using <function>var_dump</function>, <function>print_r</function>, etc.
+       任意の C のデータは <function>var_dump</function> や <function>print_r</function> 等を
+       使って可視化できます。
       </simpara>
      </listitem>
      <listitem>
       <simpara>
-       <classname>FFI\CData</classname> can now be assigned to structs and fields as of PHP 8.3.0.
+       PHP 8.3.0 以降、<classname>FFI\CData</classname> は構造体やフィールドに代入できるようになりました。
       </simpara>
      </listitem>
     </itemizedlist>
     <note>
      <simpara>
-      Notable limitations are that <classname>FFI\CData</classname> instances do not support
-      <function>isset</function>, <function>empty</function> and <function>unset</function>,
-      and that wrapped C structs and unions do not implement <interfacename>Traversable</interfacename>.
+      特筆すべき制限として、<classname>FFI\CData</classname> インスタンスは
+      <function>isset</function>、<function>empty</function>、<function>unset</function> をサポートしていません。
+      また、ラップされた C の構造体や共用体は <interfacename>Traversable</interfacename> を実装していません。
      </simpara>
     </note>
    </para>
@@ -128,7 +128,7 @@
       <row>
        <entry>8.3.0</entry>
        <entry>
-        <classname>FFI\CData</classname> can now be assigned to structs and fields.
+        <classname>FFI\CData</classname> は構造体やフィールドに代入できるようになりました。
        </entry>
       </row>
      </tbody>

--- a/reference/ffi/ffi.ctype.xml
+++ b/reference/ffi/ffi.ctype.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: nsfisis Status: working -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: nsfisis Status: ready -->
 
 <reference xml:id="class.ffi-ctype" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
- <title>C Type Handles</title>
+ <title>C の型ハンドル</title>
  <titleabbrev>FFI\CType</titleabbrev>
 
  <partintro>

--- a/reference/ffi/ffi.exception.xml
+++ b/reference/ffi/ffi.exception.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: nsfisis Status: working -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: nsfisis Status: ready -->
 
 <reference xml:id="class.ffi-exception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
- <title>FFI Exceptions</title>
+ <title>FFI 例外</title>
  <titleabbrev>FFI\Exception</titleabbrev>
 
  <partintro>

--- a/reference/ffi/ffi.parserexception.xml
+++ b/reference/ffi/ffi.parserexception.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: nsfisis Status: working -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: nsfisis Status: ready -->
 
 <reference xml:id="class.ffi-parserexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
- <title>FFI Parser Exceptions</title>
+ <title>FFI パーサー例外</title>
  <titleabbrev>FFI\ParserException</titleabbrev>
 
  <partintro>

--- a/reference/ffi/ffi.xml
+++ b/reference/ffi/ffi.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: nsfisis Status: working -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: nsfisis Status: ready -->
 
 <reference xml:id="class.ffi" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
- <title>Main interface to C code and data</title>
+ <title>C のコードやデータへの主要インターフェース</title>
  <titleabbrev>FFI</titleabbrev>
 
  <partintro>
@@ -13,25 +13,27 @@
   <section xml:id="ffi.intro">
    &reftitle.intro;
    <para>
-    Objects of this class are created by the factory methods <methodname>FFI::cdef</methodname>,
-    <methodname>FFI::load</methodname> or <methodname>FFI::scope</methodname>. Defined C variables
-    are made available as properties of the FFI instance, and defined C functions are made available
-    as methods of the FFI instance. Declared C types can be used to create new C data structures
-    using <methodname>FFI::new</methodname> and <methodname>FFI::type</methodname>.
+    このクラスのオブジェクトは、ファクトリーメソッドである <methodname>FFI::cdef</methodname> や
+    <methodname>FFI::load</methodname>、<methodname>FFI::scope</methodname> によって作成されます。
+    定義された C の変数は FFI インスタンスのプロパティとして利用可能となり、
+    定義された C の関数は FFI インスタンスのメソッドとして利用可能となります。
+    宣言された C の型は、<methodname>FFI::new</methodname> や <methodname>FFI::type</methodname> を使って
+    新しい C のデータ構造を作成するのに使用できます。
    </para>
    <para>
-    FFI definition parsing and shared library loading may take significant time. It is not useful
-    to do it on each HTTP request in a Web environment. However, it is possible to preload FFI definitions
-    and libraries at PHP startup, and to instantiate FFI objects when necessary. Header files
-    may be extended with special <literal>FFI_SCOPE</literal> defines (e.g. <code>#define FFI_SCOPE "foo"</code>;
-    the default scope is "C") and then loaded by <methodname>FFI::load</methodname> during preloading.
-    This leads to the creation of a persistent binding, that will be available to all the following
-    requests through <methodname>FFI::scope</methodname>.
-    Refer to the <link linkend="ffi.examples-complete">complete PHP/FFI/preloading example</link>
-    for details.
+    FFI 定義のパースや共有ライブラリの読み込みには長い時間がかかることがあります。
+    Web 環境において、各 HTTP リクエストでこれを行うのは不便です。
+    しかし、FFI 定義やライブラリを PHP の起動時に事前ロードし、FFI オブジェクトを必要なときにインスタンス化することが可能です。
+    ヘッダーファイルは特殊な define である <literal>FFI_SCOPE</literal> によって拡張することができ
+    (例: <code>#define FFI_SCOPE "foo"</code>。デフォルトのスコープは "C" です)、
+    事前ロード中に <methodname>FFI::load</methodname> によって読み込むことができます。
+    これによって、永続的なバインディングが作成されます。
+    こうして作られたバインディングは、<methodname>FFI::scope</methodname> を通じて後続する全リクエストで利用可能となります。
+    詳しくは <link linkend="ffi.examples-complete">PHP/FFI/事前ロードの完全な例</link>
+    を参照してください。
    </para>
    <para>
-    It is possible to preload more than one C header file into the same scope.
+    複数の C のヘッダーファイルを同一のスコープへと事前ロードできます。
    </para>
   </section>
 <!-- }}} -->

--- a/reference/ffi/ffi/addr.xml
+++ b/reference/ffi/ffi/addr.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9e0804888ae46a50f28d98514a8d5e70a34e069c Maintainer: nsfisis Status: working -->
+<!-- EN-Revision: 9e0804888ae46a50f28d98514a8d5e70a34e069c Maintainer: nsfisis Status: ready -->
 
 <refentry xml:id="ffi.addr" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>FFI::addr</refname>
-  <refpurpose>Creates an unmanaged pointer to C data</refpurpose>
+  <refpurpose>C のデータへのアンマネージドなポインターを作成する</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,9 +15,10 @@
    <methodparam><type>FFI\CData</type><parameter role="reference">ptr</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Creates an unmanaged pointer to the C data represented by the given
-   <classname>FFI\CData</classname>. The source <parameter>ptr</parameter> must survive the
-   resulting pointer. This function is mainly useful to pass arguments to C functions by pointer.
+   与えられた <classname>FFI\CData</classname> によって表される C のデータへの
+   アンマネージドなポインターを作成します。元になる <parameter>ptr</parameter>
+   は返されるポインターよりも長く生存しなければなりません。
+   この関数は、主に C の関数へ引数をポインタ経由で渡すのに便利です。
   </para>
  </refsect1>
 
@@ -28,7 +29,7 @@
     <term><parameter>ptr</parameter></term>
     <listitem>
      <para>
-      The handle of the pointer to a C data structure.
+      C のデータ構造へのポインターのハンドル。
      </para>
     </listitem>
    </varlistentry>
@@ -38,7 +39,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the freshly created <classname>FFI\CData</classname> object.
+   新しく作成された <classname>FFI\CData</classname> オブジェクトを返します。
   </para>
  </refsect1>
 

--- a/reference/ffi/ffi/alignof.xml
+++ b/reference/ffi/ffi/alignof.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9e0804888ae46a50f28d98514a8d5e70a34e069c Maintainer: nsfisis Status: working -->
+<!-- EN-Revision: 9e0804888ae46a50f28d98514a8d5e70a34e069c Maintainer: nsfisis Status: ready -->
 
 <refentry xml:id="ffi.alignof" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>FFI::alignof</refname>
-  <refpurpose>Gets the alignment</refpurpose>
+  <refpurpose>アラインメントを取得する</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,8 +15,8 @@
    <methodparam><type class="union"><type>FFI\CData</type><type>FFI\CType</type></type><parameter role="reference">ptr</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Gets the alignment of the given <classname>FFI\CData</classname> or
-   <classname>FFI\CType</classname> object.
+   与えられた <classname>FFI\CData</classname> オブジェクトまたは
+   <classname>FFI\CType</classname> オブジェクトのアラインメントを返します。
   </para>
  </refsect1>
 
@@ -27,7 +27,7 @@
     <term><parameter>ptr</parameter></term>
     <listitem>
      <para>
-      The handle of the C data or type.
+      C のデータまたは C の型のハンドル。
      </para>
     </listitem>
    </varlistentry>
@@ -37,8 +37,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the alignment of the given <classname>FFI\CData</classname> or
-   <classname>FFI\CType</classname> object.
+   与えられた <classname>FFI\CData</classname> オブジェクトまたは
+   <classname>FFI\CType</classname> オブジェクトのアラインメントを返します。
   </para>
  </refsect1>
 

--- a/reference/ffi/ffi/arraytype.xml
+++ b/reference/ffi/ffi/arraytype.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9e0804888ae46a50f28d98514a8d5e70a34e069c Maintainer: nsfisis Status: working -->
+<!-- EN-Revision: 9e0804888ae46a50f28d98514a8d5e70a34e069c Maintainer: nsfisis Status: ready -->
 
 <refentry xml:id="ffi.arraytype" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>FFI::arrayType</refname>
-  <refpurpose>Dynamically constructs a new C array type</refpurpose>
+  <refpurpose>新しい C の配列型を動的に構築する</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -16,9 +16,9 @@
    <methodparam><type>array</type><parameter>dimensions</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Dynamically constructs a new C array type with elements of type defined by <parameter>type</parameter>,
-   and dimensions specified by <parameter>dimensions</parameter>. In the following example <code>$t1</code>
-   and <code>$t2</code> are equivalent array types:
+   <parameter>type</parameter> で指定された要素型と <parameter>dimensions</parameter> で指定された次元を持つ
+   新しい C の配列型を動的に構築します。以下の例において <code>$t1</code> と
+   <code>$t2</code> は等しい配列型です。
    <informalexample>
     <programlisting role="php">
 <![CDATA[
@@ -39,8 +39,7 @@ $t2 = FFI::arrayType(FFI::type("int"), [2, 3]);
     <term><parameter>type</parameter></term>
     <listitem>
      <para>
-      A valid C declaration as <type>string</type>, or an instance of <classname>FFI\CType</classname>
-      which has already been created.
+      有効な C の宣言を表す <type>string</type> か、作成済みの <classname>FFI\CType</classname> のインスタンス。
      </para>
     </listitem>
    </varlistentry>
@@ -48,7 +47,7 @@ $t2 = FFI::arrayType(FFI::type("int"), [2, 3]);
     <term><parameter>dimensions</parameter></term>
     <listitem>
      <para>
-      The dimensions of the type as <type>array</type>.
+      型の次元を表す <type>array</type>。
      </para>
     </listitem>
    </varlistentry>
@@ -58,7 +57,7 @@ $t2 = FFI::arrayType(FFI::type("int"), [2, 3]);
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the freshly created <classname>FFI\CType</classname> object.
+   新しく作成した <classname>FFI\CType</classname> オブジェクトを返します。
   </para>
  </refsect1>
 

--- a/reference/ffi/ffi/cast.xml
+++ b/reference/ffi/ffi/cast.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 10beb4156579b621246bca461be7a0017bc280ad Maintainer: nsfisis Status: working -->
+<!-- EN-Revision: 10beb4156579b621246bca461be7a0017bc280ad Maintainer: nsfisis Status: ready -->
 
 <refentry xml:id="ffi.cast" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>FFI::cast</refname>
-  <refpurpose>Performs a C type cast</refpurpose>
+  <refpurpose>C の型キャストを実行する</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -16,12 +16,13 @@
    <methodparam><type class="union"><type>FFI\CData</type><type>int</type><type>float</type><type>bool</type><type>null</type></type><parameter role="reference">ptr</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <methodname>FFI::cast</methodname> creates a new <classname>FFI\CData</classname>
-   object, that references the same C data structure, but is associated with a different type.
-   The resulting object does not own the C data, and the source <parameter>ptr</parameter>
-   must survive the result. The C type may be specified as a <type>string</type> with any
-   valid C type declaration or as <classname>FFI\CType</classname> object, created before.
-   Any type declared for the instance is allowed.
+   <methodname>FFI::cast</methodname> は、同じ C のデータ構造を参照するものの別の型が紐付けられた
+   <classname>FFI\CData</classname> オブジェクトを新しく作成します。
+   返却されるオブジェクトはその C のデータを所有しません。元の <parameter>ptr</parameter> は
+   その返り値よりも長く生存する必要があります。
+   C の型は、有効な C の型宣言を表す <type>string</type> として指定するか、
+   以前作成した <classname>FFI\CType</classname> オブジェクトとして指定します。
+   このインスタンスで宣言された任意の型が使えます。
   </para>
  </refsect1>
 
@@ -32,8 +33,7 @@
     <term><parameter>type</parameter></term>
     <listitem>
      <para>
-      A valid C declaration as <type>string</type>, or an instance of <classname>FFI\CType</classname>
-      which has already been created.
+      有効な C の宣言を表す <type>string</type> か、作成済みの <classname>FFI\CType</classname> のインスタンス。
      </para>
     </listitem>
    </varlistentry>
@@ -41,7 +41,7 @@
     <term><parameter>ptr</parameter></term>
     <listitem>
      <para>
-      The handle of the pointer to a C data structure.
+      C のデータ構造へのポインターのハンドル。
      </para>
     </listitem>
    </varlistentry>
@@ -51,7 +51,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the freshly created <classname>FFI\CData</classname> object.
+   新しく作成された <classname>FFI\CData</classname> オブジェクトを返します。
   </para>
  </refsect1>
 
@@ -70,7 +70,7 @@
       <row>
        <entry>8.3.0</entry>
        <entry>
-        Calling <methodname>FFI::cast</methodname> statically is now deprecated.
+        <methodname>FFI::cast</methodname> を static メソッドとして呼び出すのは非推奨となりました。
        </entry>
       </row>
      </tbody>

--- a/reference/ffi/ffi/cdef.xml
+++ b/reference/ffi/ffi/cdef.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 63fe550f7f1b717e4be6f2bdde7e84ae00569208 Maintainer: nsfisis Status: working -->
+<!-- EN-Revision: 63fe550f7f1b717e4be6f2bdde7e84ae00569208 Maintainer: nsfisis Status: ready -->
 
 <refentry xml:id="ffi.cdef" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>FFI::cdef</refname>
-  <refpurpose>Creates a new FFI object</refpurpose>
+  <refpurpose>新しい FFI オブジェクトを作成する</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -16,7 +16,7 @@
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>lib</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Creates a new FFI object.
+   新しい FFI オブジェクトを作成します。
   </para>
  </refsect1>
 
@@ -27,14 +27,13 @@
     <term><parameter>code</parameter></term>
     <listitem>
      <para>
-      A string containing a sequence of declarations in regular C language
-      (types, structures, functions, variables, etc). Actually, this string may
-      be copy-pasted from C header files.
+      通常の C 言語の宣言 (型、構造体、関数、変数など) を含む文字列。
+      実際には、この文字列は C のヘッダーファイルからコピーペーストしてきたものかもしれません。
      </para>
      <note>
       <para>
-       C preprocessor directives are not supported, i.e. <code>#include</code>,
-       <code>#define</code> and CPP macros do not work.
+       C のプリプロセッサーディレクティブはサポートされていません。
+       例えば、<code>#include</code> や <code>#define</code>、プリプロセッサーマクロは動作しません。
       </para>
      </note>
     </listitem>
@@ -43,14 +42,15 @@
     <term><parameter>lib</parameter></term>
     <listitem>
      <para>
-      The name of a shared library file, to be loaded and linked with the
-      definitions.
+      共有ライブラリの名前。
+      ここで指定したライブラリが読み込まれ、与えた定義とリンクされます。
      </para>
      <note>
       <para>
-       If <parameter>lib</parameter> is omitted or &null;, platforms supporting <literal>RTLD_DEFAULT</literal>
-       attempt to lookup symbols declared in <parameter>code</parameter> in the normal global
-       scope. Other systems will fail to resolve these symbols.
+       <parameter>lib</parameter> を省略したり &null; を渡したりすると、
+       <literal>RTLD_DEFAULT</literal> をサポートしているプラットフォームでは、
+       通常のグローバルスコープから <parameter>code</parameter> で宣言されているシンボルを探索しようとします。
+       そうでないシステムでは、シンボルの解決に失敗します。
       </para>
      </note>
     </listitem>
@@ -61,7 +61,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the freshly created <classname>FFI</classname> object.
+   新しく作成された <classname>FFI</classname> オブジェクトを返します。
   </para>
  </refsect1>
 
@@ -79,14 +79,14 @@
      <row>
       <entry>8.3.0</entry>
       <entry>
-       C functions returning <literal>void</literal> return a PHP <type>null</type>
-       instead of <varname>FFI\CType::TYPE_VOID</varname>.
+       <literal>void</literal> を返す C の関数が、<varname>FFI\CType::TYPE_VOID</varname>
+       ではなく PHP の <type>null</type> を返すようになりました。
       </entry>
      </row>
      <row>
       <entry>8.0.0</entry>
       <entry>
-       <parameter>lib</parameter> is nullable now.
+       <parameter>lib</parameter> は、nullable になりました。
       </entry>
      </row>
     </tbody>

--- a/reference/ffi/ffi/free.xml
+++ b/reference/ffi/ffi/free.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9e0804888ae46a50f28d98514a8d5e70a34e069c Maintainer: nsfisis Status: working -->
+<!-- EN-Revision: 9e0804888ae46a50f28d98514a8d5e70a34e069c Maintainer: nsfisis Status: ready -->
 
 <refentry xml:id="ffi.free" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>FFI::free</refname>
-  <refpurpose>Releases an unmanaged data structure</refpurpose>
+  <refpurpose>アンマネージドなデータ構造を解放する</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,7 +15,7 @@
    <methodparam><type>FFI\CData</type><parameter role="reference">ptr</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Manually releases a previously created unmanaged data structure.
+   以前に作成されたアンマネージドなデータ構造を手で解放します。
   </para>
  </refsect1>
 
@@ -26,7 +26,7 @@
     <term><parameter>ptr</parameter></term>
     <listitem>
      <para>
-      The handle of the unmanaged pointer to a C data structure.
+      C のデータ構造へのアンマネージドなポインターのハンドル。
      </para>
     </listitem>
    </varlistentry>

--- a/reference/ffi/ffi/isnull.xml
+++ b/reference/ffi/ffi/isnull.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e281e1f40a1480dcc5a3d874185ce841bcae40d8 Maintainer: nsfisis Status: working -->
+<!-- EN-Revision: e281e1f40a1480dcc5a3d874185ce841bcae40d8 Maintainer: nsfisis Status: ready -->
 
 <refentry xml:id="ffi.isnull" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>FFI::isNull</refname>
-  <refpurpose>Checks whether a FFI\CData is a null pointer</refpurpose>
+  <refpurpose>FFI\CData が NULL ポインターかどうかを調べる</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,7 +15,7 @@
    <methodparam><type>FFI\CData</type><parameter role="reference">ptr</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Checks whether a FFI\CData is a null pointer.
+   FFI\CData が NULL ポインターかどうかを調べます。
   </para>
  </refsect1>
 
@@ -26,7 +26,7 @@
     <term><parameter>ptr</parameter></term>
     <listitem>
      <para>
-      The handle of the pointer to a C data structure.
+      C のデータ構造へのポインターのハンドル。
      </para>
     </listitem>
    </varlistentry>
@@ -36,7 +36,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns whether a <classname>FFI\CData</classname> is a null pointer.
+   <classname>FFI\CData</classname> が NULL ポインターかどうかを返します。
   </para>
  </refsect1>
 

--- a/reference/ffi/ffi/load.xml
+++ b/reference/ffi/ffi/load.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 965e20aa04e351a46200f1df658e717eb654efd4 Maintainer: nsfisis Status: working -->
+<!-- EN-Revision: 965e20aa04e351a46200f1df658e717eb654efd4 Maintainer: nsfisis Status: ready -->
 
 <refentry xml:id="ffi.load" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>FFI::load</refname>
-  <refpurpose>Loads C declarations from a C header file</refpurpose>
+  <refpurpose>C のヘッダーファイルから C の宣言を読み込む</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,8 +15,9 @@
    <methodparam><type>string</type><parameter>filename</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Loads C declarations from a C header file. It is possible to specify shared libraries that should be loaded,
-   using special <literal>FFI_LIB</literal> defines in the loaded C header file.
+   C のヘッダーファイルから C の宣言を読み込みます。
+   読み込まれる C のヘッダーファイル内で特殊な define <literal>FFI_LIB</literal> を使うことで、
+   読み込む共有ライブラリを指定することが可能です。
   </para>
  </refsect1>
 
@@ -27,24 +28,25 @@
     <term><parameter>filename</parameter></term>
     <listitem>
      <para>
-      The name of a C header file.
+      C のヘッダーファイル名。
      </para>
      <para>
-      C preprocessor directives are not supported, i.e. <literal>#include</literal>,
-      <literal>#define</literal> and CPP macros do not work, except for special cases
-      listed below.
+      C のプリプロセッサーディレクティブはサポートされていません。
+      例えば、<code>#include</code> や <code>#define</code>、プリプロセッサーマクロは動作しません。
+      ただし、次に挙げる特殊な場合を除きます。
      </para>
      <para>
-      The header file <emphasis>should</emphasis> contain a <literal>#define</literal> statement for the
-      <literal>FFI_SCOPE</literal> variable, e.g.: <code>#define FFI_SCOPE "MYLIB"</code>.
-      Refer to the <link linkend="ffi.intro">class introduction</link> for details.
+      このヘッダーファイルでは、<literal>#define</literal> 文で
+      <literal>FFI_SCOPE</literal> 変数を定義<emphasis>すべき</emphasis>です
+      (例: <code>#define FFI_SCOPE "MYLIB"</code>)。
+      詳しくは <link linkend="ffi.intro">FFI クラスの概要</link> を参照してください。
      </para>
      <para>
-      The header file <emphasis>may</emphasis> contain a <literal>#define</literal> statement for the
-      <literal>FFI_LIB</literal> variable to specify the library it exposes. If it is
-      a system library only the file name is required, e.g.: <code>#define FFI_LIB
-      "libc.so.6"</code>.  If it is a custom library, a relative path is required,
-      e.g.: <code>#define FFI_LIB "./mylib.so"</code>.
+      このヘッダーファイルでは、<literal>#define</literal> 文で
+      <literal>FFI_LIB</literal> 変数を定義することで、公開するライブラリを指定<emphasis>しても構いません</emphasis>。
+      それがシステムライブラリなら、必要なのはファイル名だけです (例: <code>#define FFI_LIB
+      "libc.so.6"</code>)。カスタムライブラリなら、相対パスが必要です
+      (例: <code>#define FFI_LIB "./mylib.so"</code>)。
      </para>
     </listitem>
    </varlistentry>
@@ -54,7 +56,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the freshly created <classname>FFI</classname> object, or &null; on failure.
+   新しく作成された <classname>FFI</classname> オブジェクトを返します。
+   失敗時には &null; を返します。
   </para>
  </refsect1>
 
@@ -72,10 +75,10 @@
      <row>
       <entry>8.3.0</entry>
       <entry>
-       <methodname>FFI::load</methodname> is now allowed in
-       <link linkend="opcache.preloading">preload scripts</link> when the
-       current system user is the same as the one defined in the
-       <literal>opcache.preload_user</literal> configuration directive.
+       現在のシステムユーザが <literal>opcache.preload_user</literal>
+       設定ディレクティブで定義されたユーザと同じである場合、
+       <link linkend="opcache.preloading">事前ロードスクリプト</link> の中で
+       <methodname>FFI::load</methodname> を呼べるようになりました。
       </entry>
      </row>
     </tbody>

--- a/reference/ffi/ffi/memcmp.xml
+++ b/reference/ffi/ffi/memcmp.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e281e1f40a1480dcc5a3d874185ce841bcae40d8 Maintainer: nsfisis Status: working -->
+<!-- EN-Revision: e281e1f40a1480dcc5a3d874185ce841bcae40d8 Maintainer: nsfisis Status: ready -->
 
 <refentry xml:id="ffi.memcmp" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>FFI::memcmp</refname>
-  <refpurpose>Compares memory areas</refpurpose>
+  <refpurpose>メモリ領域を比較する</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -17,10 +17,11 @@
    <methodparam><type>int</type><parameter>size</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Compares <parameter>size</parameter> bytes from the memory areas <parameter>ptr1</parameter> and
-   <parameter>ptr2</parameter>. Both <parameter>ptr1</parameter> and <parameter>ptr2</parameter>
-   can be any native data structures (<classname>FFI\CData</classname>) or PHP
-   <type>string</type>s.
+   メモリ領域 <parameter>ptr1</parameter> と <parameter>ptr2</parameter> を
+   <parameter>size</parameter> バイト分比較します。
+   <parameter>ptr1</parameter> も <parameter>ptr2</parameter> も、
+   ネイティブデータ構造 (<classname>FFI\CData</classname>) または
+   PHP の <type>string</type> にできます。
   </para>
  </refsect1>
 
@@ -31,7 +32,7 @@
     <term><parameter>ptr1</parameter></term>
     <listitem>
      <para>
-      The start of one memory area.
+      一方のメモリ領域の開始位置。
      </para>
     </listitem>
    </varlistentry>
@@ -39,7 +40,7 @@
     <term><parameter>ptr2</parameter></term>
     <listitem>
      <para>
-      The start of another memory area.
+      もう一方のメモリ領域の開始位置。
      </para>
     </listitem>
    </varlistentry>
@@ -47,7 +48,7 @@
     <term><parameter>size</parameter></term>
     <listitem>
      <para>
-      The number of bytes to compare.
+      比較するバイト数。
      </para>
     </listitem>
    </varlistentry>
@@ -57,10 +58,12 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns a value less than <literal>0</literal> if the contents of the memory area starting at <parameter>ptr1</parameter>
-   are considered less than the contents of the memory area starting at <parameter>ptr2</parameter>,
-   a value greater than <literal>0</literal> if the contents of the first memory area are considered greater than the second,
-   and <literal>0</literal> if they are equal.
+   <parameter>ptr1</parameter> から始まるメモリ領域の中身が
+   <parameter>ptr2</parameter> から始まるメモリ領域の中身より小さければ、
+   <literal>0</literal> より小さい値を返します。
+   <parameter>ptr1</parameter> が <parameter>ptr2</parameter> より大きければ、
+   <literal>0</literal> より大きい値を返します。
+   両者が等しければ <literal>0</literal> を返します。
   </para>
  </refsect1>
 

--- a/reference/ffi/ffi/memcpy.xml
+++ b/reference/ffi/ffi/memcpy.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9e0804888ae46a50f28d98514a8d5e70a34e069c Maintainer: nsfisis Status: working -->
+<!-- EN-Revision: 9e0804888ae46a50f28d98514a8d5e70a34e069c Maintainer: nsfisis Status: ready -->
 
 <refentry xml:id="ffi.memcpy" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>FFI::memcpy</refname>
-  <refpurpose>Copies one memory area to another</refpurpose>
+  <refpurpose>あるメモリ領域を別の領域へコピーする</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -17,8 +17,8 @@
    <methodparam><type>int</type><parameter>size</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Copies <parameter>size</parameter> bytes from the memory area <parameter>from</parameter>
-   to the memory area <parameter>to</parameter>.
+   <parameter>from</parameter> のメモリ領域から <parameter>size</parameter> バイト分を
+   <parameter>to</parameter> のメモリ領域へとコピーします。
   </para>
  </refsect1>
 
@@ -29,7 +29,7 @@
     <term><parameter>to</parameter></term>
     <listitem>
      <para>
-      The start of the memory area to copy to.
+      コピー先のメモリ領域の開始位置。
      </para>
     </listitem>
    </varlistentry>
@@ -37,7 +37,7 @@
     <term><parameter>from</parameter></term>
     <listitem>
      <para>
-      The start of the memory area to copy from.
+      コピー元のメモリ領域の開始位置。
      </para>
     </listitem>
    </varlistentry>
@@ -45,7 +45,7 @@
     <term><parameter>size</parameter></term>
     <listitem>
      <para>
-      The number of bytes to copy.
+      コピーするバイト数。
      </para>
     </listitem>
    </varlistentry>

--- a/reference/ffi/ffi/memset.xml
+++ b/reference/ffi/ffi/memset.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9e0804888ae46a50f28d98514a8d5e70a34e069c Maintainer: nsfisis Status: working -->
+<!-- EN-Revision: 9e0804888ae46a50f28d98514a8d5e70a34e069c Maintainer: nsfisis Status: ready -->
 
 <refentry xml:id="ffi.memset" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>FFI::memset</refname>
-  <refpurpose>Fills a memory area</refpurpose>
+  <refpurpose>メモリ領域を埋める</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -17,8 +17,8 @@
    <methodparam><type>int</type><parameter>size</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Fills <parameter>size</parameter> bytes of the memory area pointed to by
-   <parameter>ptr</parameter> with the given byte <parameter>value</parameter>.
+   <parameter>ptr</parameter> が指すメモリ領域を <parameter>size</parameter> バイト分
+   与えられた <parameter>value</parameter> で埋めます。
   </para>
  </refsect1>
 
@@ -29,7 +29,7 @@
     <term><parameter>ptr</parameter></term>
     <listitem>
      <para>
-      The start of the memory area to fill.
+      埋めるメモリ領域の開始位置。
      </para>
     </listitem>
    </varlistentry>
@@ -37,7 +37,7 @@
     <term><parameter>value</parameter></term>
     <listitem>
      <para>
-      The byte to fill with.
+      埋めるのに使うバイト。
      </para>
     </listitem>
    </varlistentry>
@@ -45,7 +45,7 @@
     <term><parameter>size</parameter></term>
     <listitem>
      <para>
-      The number of bytes to fill.
+      埋めるバイト数。
      </para>
     </listitem>
    </varlistentry>

--- a/reference/ffi/ffi/new.xml
+++ b/reference/ffi/ffi/new.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 10beb4156579b621246bca461be7a0017bc280ad Maintainer: nsfisis Status: working -->
+<!-- EN-Revision: 10beb4156579b621246bca461be7a0017bc280ad Maintainer: nsfisis Status: ready -->
 
 <refentry xml:id="ffi.new" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>FFI::new</refname>
-  <refpurpose>Creates a C data structure</refpurpose>
+  <refpurpose>C のデータ構造を作成する</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -17,8 +17,8 @@
    <methodparam choice="opt"><type>bool</type><parameter>persistent</parameter><initializer>&false;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Creates a native data structure of the given C type.
-   Any type declared for the instance is allowed.
+   与えられた C の型を持つネイティブデータ構造を作成します。
+   このインスタンスで宣言された任意の型が使えます。
   </para>
  </refsect1>
 
@@ -29,8 +29,8 @@
     <term><parameter>type</parameter></term>
     <listitem>
      <para>
-      <parameter>type</parameter> is a valid C declaration as <type>string</type>, or an
-      instance of <classname>FFI\CType</classname> which has already been created.
+      <parameter>type</parameter> は、有効な C の宣言を表す <type>string</type> か、
+      作成済みの <classname>FFI\CType</classname> のインスタンスです。
      </para>
     </listitem>
    </varlistentry>
@@ -38,11 +38,10 @@
     <term><parameter>owned</parameter></term>
     <listitem>
      <para>
-      Whether to create owned (i.e. managed) or unmanaged data. Managed data lives together
-      with the returned <classname>FFI\CData</classname> object, and is released when the
-      last reference to that object is released by regular PHP reference counting or GC.
-      Unmanaged data should be released by calling <methodname>FFI::free</methodname>,
-      when no longer needed.
+      所有された (マネージドな) データを作成するか、アンマネージドなデータを作成するか。
+      マネージドデータは返される <classname>FFI\CData</classname> オブジェクトと共に生存し、
+      そのオブジェクトへの最後の参照が PHP の通常のリファレンスカウントや GC によって解放されたときに解放されます。
+      アンマネージドなデータは、不要になったら <methodname>FFI::free</methodname> を呼んで解放すべきです。
      </para>
     </listitem>
    </varlistentry>
@@ -50,8 +49,8 @@
     <term><parameter>persistent</parameter></term>
     <listitem>
      <para>
-      Whether to allocate the C data structure permanently on the system heap (using 
-      <function>malloc</function>), or on the PHP request heap (using <function>emalloc</function>).
+      この C のデータ構造をシステムヒープ上に永続的に確保するか (<function>malloc</function> を使用)、
+      PHP のリクエストヒープ上に確保するか (<function>emalloc</function> を使用)。
      </para>
     </listitem>
    </varlistentry>
@@ -61,8 +60,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the freshly created <classname>FFI\CData</classname> object,
-   or &null; on failure.
+   新しく作成された <classname>FFI\CData</classname> オブジェクトを返します。
+   失敗時には &null; を返します。
   </para>
  </refsect1>
 
@@ -81,7 +80,7 @@
       <row>
        <entry>8.3.0</entry>
        <entry>
-        Calling <methodname>FFI::new</methodname> statically is now deprecated.
+        <methodname>FFI::new</methodname> を static メソッドとして呼び出すのは非推奨となりました。
        </entry>
       </row>
      </tbody>

--- a/reference/ffi/ffi/scope.xml
+++ b/reference/ffi/ffi/scope.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9e0804888ae46a50f28d98514a8d5e70a34e069c Maintainer: nsfisis Status: working -->
+<!-- EN-Revision: 9e0804888ae46a50f28d98514a8d5e70a34e069c Maintainer: nsfisis Status: ready -->
 
 <refentry xml:id="ffi.scope" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>FFI::scope</refname>
-  <refpurpose>Instantiates an FFI object with C declarations parsed during preloading</refpurpose>
+  <refpurpose>事前ロード中にパースされた C の宣言を使って FFI オブジェクトをインスタンス化する</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,11 +15,11 @@
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Instantiates an FFI object with C declarations parsed during preloading.
+   事前ロード中にパースされた C の宣言を使って FFI オブジェクトをインスタンス化します。
   </para>
   <para>
-   The <methodname>FFI::scope</methodname> method is safe to call multiple times for the same scope. Multiple references to the
-   same scope may be loaded at the same time.
+   <methodname>FFI::scope</methodname> メソッドを同じスコープに対して複数回呼んでも安全です。
+   同じスコープを指す複数の参照は同時に読み込まれるかもしれません。
   </para>
  </refsect1>
 
@@ -30,7 +30,7 @@
     <term><parameter>name</parameter></term>
     <listitem>
      <para>
-      The scope name defined by a special <literal>FFI_SCOPE</literal> define.
+      特殊な <literal>FFI_SCOPE</literal> define によって定義されたスコープ名。
      </para>
     </listitem>
    </varlistentry>
@@ -40,7 +40,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the freshly created <classname>FFI</classname> object.
+   新しく作成された <classname>FFI</classname> オブジェクトを返します。
   </para>
  </refsect1>
 

--- a/reference/ffi/ffi/sizeof.xml
+++ b/reference/ffi/ffi/sizeof.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9e0804888ae46a50f28d98514a8d5e70a34e069c Maintainer: nsfisis Status: working -->
+<!-- EN-Revision: 9e0804888ae46a50f28d98514a8d5e70a34e069c Maintainer: nsfisis Status: ready -->
 
 <refentry xml:id="ffi.sizeof" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>FFI::sizeof</refname>
-  <refpurpose>Gets the size of C data or types</refpurpose>
+  <refpurpose>C のデータサイズまたは C の型サイズを取得する</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,8 +15,8 @@
    <methodparam><type class="union"><type>FFI\CData</type><type>FFI\CType</type></type><parameter role="reference">ptr</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Returns the size of the given <classname>FFI\CData</classname> or
-   <classname>FFI\CType</classname> object.
+   与えられた <classname>FFI\CData</classname> オブジェクトまたは
+   <classname>FFI\CType</classname> オブジェクトのサイズを返します。
   </para>
  </refsect1>
 
@@ -27,7 +27,7 @@
     <term><parameter>ptr</parameter></term>
     <listitem>
      <para>
-      The handle of the C data or type.
+      C のデータまたは C の型のハンドル。
      </para>
     </listitem>
    </varlistentry>
@@ -37,7 +37,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The size of the memory area pointed at by <parameter>ptr</parameter>.
+   <parameter>ptr</parameter> が指すメモリ領域のサイズ。
   </para>
  </refsect1>
 

--- a/reference/ffi/ffi/string.xml
+++ b/reference/ffi/ffi/string.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e281e1f40a1480dcc5a3d874185ce841bcae40d8 Maintainer: nsfisis Status: working -->
+<!-- EN-Revision: e281e1f40a1480dcc5a3d874185ce841bcae40d8 Maintainer: nsfisis Status: ready -->
 
 <refentry xml:id="ffi.string" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>FFI::string</refname>
-  <refpurpose>Creates a PHP string from a memory area</refpurpose>
+  <refpurpose>メモリ領域から PHP の文字列を作成する</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -16,8 +16,8 @@
    <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>size</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Creates a PHP <type>string</type> from <parameter>size</parameter> bytes of the memory area
-   pointed to by <parameter>ptr</parameter>.
+   <parameter>ptr</parameter> が指すメモリ領域の <parameter>size</parameter> バイト分から
+   PHP の <type>string</type> を作成します。
   </para>
  </refsect1>
 
@@ -28,7 +28,7 @@
     <term><parameter>ptr</parameter></term>
     <listitem>
      <para>
-      The start of the memory area from which to create a <type>string</type>.
+      <type>string</type> を作成する元となるメモリ領域の開始位置。
      </para>
     </listitem>
    </varlistentry>
@@ -36,9 +36,9 @@
     <term><parameter>size</parameter></term>
     <listitem>
      <para>
-      The number of bytes to copy to the <type>string</type>.
-      If <parameter>size</parameter> is omitted or &null;, <parameter>ptr</parameter> must be a zero terminated
-      array of C <literal>char</literal>.
+      <type>string</type> へコピーするバイト数。
+      <parameter>size</parameter> を省略したり &null; を指定したりする場合、
+      <parameter>ptr</parameter> はゼロ終端された C の <literal>char</literal> 配列でなければなりません。
      </para>
     </listitem>
    </varlistentry>
@@ -48,7 +48,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The freshly created PHP <type>string</type>.
+   新しく作成された PHP の <type>string</type>。
   </para>
  </refsect1>
 
@@ -66,8 +66,8 @@
      <row>
       <entry>8.0.0</entry>
       <entry>
-       <parameter>size</parameter> is nullable now; previously, its default was
-       <literal>0</literal>.
+       <parameter>size</parameter> が nullable になりました。以前は
+       <literal>0</literal> がデフォルトでした。
       </entry>
      </row>
     </tbody>

--- a/reference/ffi/ffi/type.xml
+++ b/reference/ffi/ffi/type.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 10beb4156579b621246bca461be7a0017bc280ad Maintainer: nsfisis Status: working -->
+<!-- EN-Revision: 10beb4156579b621246bca461be7a0017bc280ad Maintainer: nsfisis Status: ready -->
 
 <refentry xml:id="ffi.type" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>FFI::type</refname>
-  <refpurpose>Creates an FFI\CType object from a C declaration</refpurpose>
+  <refpurpose>C の宣言から FFI\CType オブジェクトを作成する</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,9 +15,10 @@
    <methodparam><type>string</type><parameter>type</parameter></methodparam>
   </methodsynopsis>
   <para>
-   This function creates and returns a <classname>FFI\CType</classname> object for the
-   given <type>string</type> containing a C type declaration.
-   Any type declared for the instance is allowed.
+   この関数は、C の型宣言を持つ <type>string</type> を渡すと、
+   与えられた <type>string</type> に対応する
+   <classname>FFI\CType</classname> オブジェクトを作成して返します。
+   このインスタンスで宣言された任意の型が使えます。
   </para>
  </refsect1>
 
@@ -28,7 +29,7 @@
     <term><parameter>type</parameter></term>
     <listitem>
      <para>
-      A valid C declaration as <type>string</type>.
+      有効な C の宣言を持つ <type>string</type>。
      </para>
     </listitem>
    </varlistentry>
@@ -38,8 +39,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the freshly created <classname>FFI\CType</classname> object,
-   or &null; on failure.
+   新しく作成された <classname>FFI\CType</classname> オブジェクトを返します。
+   失敗時には &null; を返します。
   </para>
  </refsect1>
 
@@ -58,7 +59,7 @@
       <row>
        <entry>8.3.0</entry>
        <entry>
-        Calling <methodname>FFI::type</methodname> statically is now deprecated.
+        <methodname>FFI::type</methodname> を static メソッドとして呼び出すのは非推奨となりました。
        </entry>
       </row>
      </tbody>

--- a/reference/ffi/ffi/typeof.xml
+++ b/reference/ffi/ffi/typeof.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9e0804888ae46a50f28d98514a8d5e70a34e069c Maintainer: nsfisis Status: working -->
+<!-- EN-Revision: 9e0804888ae46a50f28d98514a8d5e70a34e069c Maintainer: nsfisis Status: ready -->
 
 <refentry xml:id="ffi.typeof" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>FFI::typeof</refname>
-  <refpurpose>Gets the FFI\CType of FFI\CData</refpurpose>
+  <refpurpose>FFI\CData の FFI\CType を取得する</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,8 +15,8 @@
    <methodparam><type>FFI\CData</type><parameter role="reference">ptr</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Gets the <classname>FFI\CType</classname> object representing the type of the given
-   <classname>FFI\CData</classname> object.
+   与えられた <classname>FFI\CData</classname> オブジェクトの型を表す
+   <classname>FFI\CType</classname> オブジェクトを取得します。
   </para>
  </refsect1>
 
@@ -27,7 +27,7 @@
     <term><parameter>ptr</parameter></term>
     <listitem>
      <para>
-      The handle of the pointer to a C data structure.
+      C のデータ構造へのポインターのハンドル。
      </para>
     </listitem>
    </varlistentry>
@@ -37,8 +37,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the <classname>FFI\CType</classname> object representing the type of the given
-   <classname>FFI\CData</classname> object.
+   与えられた <classname>FFI\CData</classname> オブジェクトの型を表す
+   <classname>FFI\CType</classname> オブジェクトを返します。
   </para>
  </refsect1>
 

--- a/reference/ffi/setup.xml
+++ b/reference/ffi/setup.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 48ce43fe79fa0c9f31f187ea8ec995b4cb13037e Maintainer: nsfisis Status: working -->
+<!-- EN-Revision: 48ce43fe79fa0c9f31f187ea8ec995b4cb13037e Maintainer: nsfisis Status: ready -->
 
 <chapter xml:id="ffi.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.setup;
@@ -8,8 +8,8 @@
  <section xml:id="ffi.requirements">
   &reftitle.required;
   <para>
-   This extension requires the <link xlink:href="&url.libffi;">libffi library</link>
-   to be installed.
+   この拡張には、<link xlink:href="&url.libffi;">libffi library</link> の
+   インストールが必要です。
   </para>
  </section>
 
@@ -62,15 +62,16 @@
      </term>
      <listitem>
       <para>
-       Allows enabling (<literal>"true"</literal>) or disabling
-       (<literal>"false"</literal>) FFI API usage, or restricting it only to
-       the CLI SAPI and preloaded files (<literal>"preload"</literal>).
+       FFI API の使用を有効化する (<literal>"true"</literal>) か
+       無効化する (<literal>"false"</literal>) か、
+       CLI SAPI と事前ロードファイルでだけ使えるよう制限する (<literal>"preload"</literal>) かを
+       指定します。
       </para>
       <para>
-       The FFI API restrictions only affect the <classname>FFI</classname> class,
-       but not overloaded functions of <classname>FFI\CData</classname> objects.
-       This means that it is possible to create some <classname>FFI\CData</classname>
-       objects in preloaded files, and then to use these directly in PHP scripts.
+       FFI API の利用制限は、<classname>FFI</classname> クラスにのみ影響し、
+       <classname>FFI\CData</classname> オブジェクトのオーバーロードされた関数には影響しません。
+       つまり、事前ロードファイルで <classname>FFI\CData</classname> オブジェクトを作成し、
+       それを PHP スクリプトで直接使うことは可能だということです。
       </para>
      </listitem>
     </varlistentry>
@@ -81,10 +82,11 @@
      </term>
      <listitem>
       <para>
-       Allows preloading of FFI bindings during startup, which is not possible with <methodname>FFI::load</methodname>
-       if <link linkend="ini.opcache.preload-user">opcache.preload_user</link> is set.
-       This directive accepts a <constant>DIRECTORY_SEPARATOR</constant> delimited list of filenames.
-       The preloaded bindings can be accessed by calling <methodname>FFI::scope</methodname>.
+       FFI バインディングを起動時に事前ロードできるようにします。
+       <link linkend="ini.opcache.preload-user">opcache.preload_user</link> が設定されている場合、
+       FFI の事前ロードを <methodname>FFI::load</methodname> で実現することはできません。
+       このディレクティブは <constant>DIRECTORY_SEPARATOR</constant> で区切られたファイル名のリストを受け付けます。
+       事前ロードされたバインディングは <methodname>FFI::scope</methodname> を呼ぶことでアクセスできます。
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
FFI 拡張を新規翻訳しました。

# 迷った訳

* union: PHP の "union type" は「union 型」で統一されていますが、ここでは「共用体」にしています。PHP の union type と C 言語の union type は別物で、必ずしも訳を統一する必要はないと考えました。それならば、C の union の定訳である「共用体」が良いのではないかと思います。
* call statically / call dynamically: 「静的に呼ぶ」「動的に呼ぶ」ではなく「static メソッドとして呼ぶ」「非 static メソッドとして呼ぶ」としました。static method の訳が「static メソッド」で統一されており、「静的に」「動的に」では意味が通らなくなるためです
* managed / unmanaged: カタカナで「マネージド」「アンマネージド」としています。他の訳としては「管理」「非管理」や「管理された」「管理されていない」などが考えられるかと思います。C# などで似たような意味（その言語のランタイムによって管理されているか否か）の用語がカタカナでそのまま書かれているのに倣いました（C# でも「マネージ」「マネージド」で揺れがあるようですが）。