### PR TITLE
PHP 8.5 移行ガイド日本語版

### DIFF
--- a/appendices/migration85.xml
+++ b/appendices/migration85.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: ec45af749649dc0d6a23eaedeed1b601f7460813 Maintainer: mumumu Status: ready -->
 <appendix xml:id="migration85" xmlns="http://docbook.org/ns/docbook">
  <title>PHP 8.4.x から PHP 8.5.x への移行</title>
 

--- a/appendices/migration85/constants.xml
+++ b/appendices/migration85/constants.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: ec45af749649dc0d6a23eaedeed1b601f7460813 Maintainer: mumumu Status: ready -->
 <sect1 xml:id="migration85.constants">
  <title>新しいグローバル定数</title>
 

--- a/appendices/migration85/deprecated.xml
+++ b/appendices/migration85/deprecated.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: ec45af749649dc0d6a23eaedeed1b601f7460813 Maintainer: mumumu Status: ready -->
 <sect1 xml:id="migration85.deprecated">
  <title>PHP 8.5.x で推奨されなくなる機能</title>
 

--- a/appendices/migration85/incompatible.xml
+++ b/appendices/migration85/incompatible.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: ec45af749649dc0d6a23eaedeed1b601f7460813 Maintainer: mumumu Status: ready -->
 <sect1 xml:id="migration85.incompatible" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>下位互換性のない変更点</title>
 

--- a/appendices/migration85/new-classes.xml
+++ b/appendices/migration85/new-classes.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: ec45af749649dc0d6a23eaedeed1b601f7460813 Maintainer: mumumu Status: ready -->
 <sect1 xml:id="migration85.new-classes" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>新しいクラスとインターフェイス</title>
 

--- a/appendices/migration85/new-features.xml
+++ b/appendices/migration85/new-features.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: ec45af749649dc0d6a23eaedeed1b601f7460813 Maintainer: mumumu Status: ready --> 
 <sect1 xml:id="migration85.new-features" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>新機能</title>
 

--- a/appendices/migration85/new-functions.xml
+++ b/appendices/migration85/new-functions.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: ec45af749649dc0d6a23eaedeed1b601f7460813 Maintainer: mumumu Status: ready -->
 <sect1 xml:id="migration85.new-functions">
  <title>新しく追加された関数</title>
 

--- a/appendices/migration85/other-changes.xml
+++ b/appendices/migration85/other-changes.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: ec45af749649dc0d6a23eaedeed1b601f7460813 Maintainer: mumumu Status: ready -->
 <sect1 xml:id="migration85.other-changes">
  <title>その他の変更</title>
 

--- a/appendices/migration85/windows-support.xml
+++ b/appendices/migration85/windows-support.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: ec45af749649dc0d6a23eaedeed1b601f7460813 Maintainer: mumumu Status: ready -->
 <sect1 xml:id="migration85.windows-support">
  <title>Windows のサポート</title>
 


### PR DESCRIPTION
英語版: https://github.com/php/doc-en/pull/4906

- TODO
  * [x] New Features
  * [x] New Classes and Interfaces
  * [x] New Functions
  * [x] New Global Constants
  * [x] Backward Incompatible Changes
  * [x] Deprecated Features
  * [x] Windows Support
  * [x] Other Changes