### PR TITLE
「&Functions;」の前の余計な空白を削除

### DIFF
--- a/reference/array/reference.xml
+++ b/reference/array/reference.xml
@@ -3,7 +3,7 @@
 <!-- EN-Revision: d335ba69a16f4013280de8e3e71d9ba19fe3cb3c Maintainer: hirokawa Status: ready -->
 
 <reference xml:id="ref.array" xmlns="http://docbook.org/ns/docbook">
- <title>配列 &Functions;</title>
+ <title>配列&Functions;</title>
  <partintro xml:id="array.seealso">
    &reftitle.seealso;
    <para>

--- a/reference/calendar/reference.xml
+++ b/reference/calendar/reference.xml
@@ -5,7 +5,7 @@
 <!-- Membership: bundled -->
 
  <reference xml:id="ref.calendar" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
-  <title>カレンダー &Functions;</title>
+  <title>カレンダー&Functions;</title>
 
 &reference.calendar.entities.functions;
 

--- a/reference/datetime/reference.xml
+++ b/reference/datetime/reference.xml
@@ -4,7 +4,7 @@
 <!-- CREDITS: shimooka -->
 
 <reference xml:id="ref.datetime" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>日付・時刻 &Functions;</title>
+ <title>日付・時刻&Functions;</title>
 
  &reference.datetime.entities.functions;
 

--- a/reference/dir/reference.xml
+++ b/reference/dir/reference.xml
@@ -3,7 +3,7 @@
 <!-- EN-Revision: 96c9d88bad9a7d7d44bfb7f26c226df7ee9ddf26 Maintainer: hirokawa Status: ready -->
 
 <reference xml:id="ref.dir" xmlns="http://docbook.org/ns/docbook">
- <title>ディレクトリ &Functions;</title>
+ <title>ディレクトリ&Functions;</title>
 
  <partintro>
   &reftitle.seealso;

--- a/reference/filesystem/reference.xml
+++ b/reference/filesystem/reference.xml
@@ -4,7 +4,7 @@
 <!-- CREDITS: shimooka -->
 
 <reference xml:id="ref.filesystem" xmlns="http://docbook.org/ns/docbook">
- <title>ファイルシステム &Functions;</title>
+ <title>ファイルシステム&Functions;</title>
 
  <partintro>
   &reftitle.seealso;

--- a/reference/funchand/reference.xml
+++ b/reference/funchand/reference.xml
@@ -4,7 +4,7 @@
 <!-- CREDITS: takagi -->
 
 <reference xml:id="ref.funchand" xmlns="http://docbook.org/ns/docbook">
- <title>関数処理 &Functions;</title>
+ <title>関数処理&Functions;</title>
 
  &reference.funchand.entities.functions;
 

--- a/reference/info/reference.xml
+++ b/reference/info/reference.xml
@@ -3,7 +3,7 @@
 <!-- EN-Revision: 96c9d88bad9a7d7d44bfb7f26c226df7ee9ddf26 Maintainer: hirokawa Status: ready -->
  
 <reference xml:id="ref.info" xmlns="http://docbook.org/ns/docbook">
- <title>PHP オプション/情報 &Functions;</title>
+ <title>PHP オプション/情報&Functions;</title>
 
  &reference.info.entities.functions;
 

--- a/reference/intl/reference.xml
+++ b/reference/intl/reference.xml
@@ -2,7 +2,7 @@
 <!-- $Revision$ -->
 <!-- EN-Revision: af4410a7e15898c3dbe83d6ea38246745ed9c6fb Maintainer: takagi Status: ready -->
 <reference xml:id="ref.intl" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>国際化 &Functions;</title>
+ <title>国際化&Functions;</title>
  &reference.intl.entities.functions;
 </reference>
 

--- a/reference/mail/reference.xml
+++ b/reference/mail/reference.xml
@@ -4,7 +4,7 @@
 <!-- CREDITS: takagi -->
 
  <reference xml:id="ref.mail" xmlns="http://docbook.org/ns/docbook">
-  <title>メール &Functions;</title>
+  <title>メール&Functions;</title>
 
 &reference.mail.entities.functions;
 

--- a/reference/mbstring/reference.xml
+++ b/reference/mbstring/reference.xml
@@ -3,7 +3,7 @@
 <!-- EN-Revision: 96c9d88bad9a7d7d44bfb7f26c226df7ee9ddf26 Maintainer: hirokawa Status: ready -->
 
  <reference xml:id="ref.mbstring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
-  <title>マルチバイト文字列 &Functions;</title> 
+  <title>マルチバイト文字列&Functions;</title>
 
   <partintro>
     <title>リファレンス</title>

--- a/reference/network/reference.xml
+++ b/reference/network/reference.xml
@@ -3,7 +3,7 @@
 <!-- EN-Revision: af4410a7e15898c3dbe83d6ea38246745ed9c6fb Maintainer: hirokawa Status: ready -->
 
 <reference xml:id="ref.network" xmlns="http://docbook.org/ns/docbook">
- <title>ネットワーク &Functions;</title>
+ <title>ネットワーク&Functions;</title>
 
  &reference.network.entities.functions;
 

--- a/reference/outcontrol/reference.xml
+++ b/reference/outcontrol/reference.xml
@@ -4,7 +4,7 @@
 <!-- CREDITS: shimooka -->
 
 <reference xml:id="ref.outcontrol" xmlns="http://docbook.org/ns/docbook">
- <title>出力制御 &Functions;</title>
+ <title>出力制御&Functions;</title>
 
  <partintro>
   &reftitle.seealso;

--- a/reference/sockets/reference.xml
+++ b/reference/sockets/reference.xml
@@ -3,7 +3,7 @@
 <!-- EN-Revision: af4410a7e15898c3dbe83d6ea38246745ed9c6fb Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: shimooka -->
 <reference xml:id="ref.sockets" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>ソケット &Functions;</title>
+ <title>ソケット&Functions;</title>
 
  &reference.sockets.entities.functions;
 

--- a/reference/stream/reference.xml
+++ b/reference/stream/reference.xml
@@ -4,7 +4,7 @@
 <!-- CREDITS: shimooka -->
 
 <reference xml:id="ref.stream" xmlns="http://docbook.org/ns/docbook">
- <title>ストリーム &Functions;</title>
+ <title>ストリーム&Functions;</title>
 
  &reference.stream.entities.functions;
 

--- a/reference/var/reference.xml
+++ b/reference/var/reference.xml
@@ -4,7 +4,7 @@
 <!-- CREDITS: shimooka,takagi -->
 
 <reference xml:id="ref.var" xmlns="http://docbook.org/ns/docbook">
- <title>変数操作 &Functions;</title>
+ <title>変数操作&Functions;</title>
 
  &reference.var.entities.functions;
 

--- a/reference/xml/reference.xml
+++ b/reference/xml/reference.xml
@@ -4,7 +4,7 @@
 <!-- CREDITS: shimooka -->
 
 <reference xml:id="ref.xml" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>XML パーサ &Functions;</title>
+ <title>XML パーサ&Functions;</title>
 
  &reference.xml.entities.functions;
 


### PR DESCRIPTION
https://www.php.net/manual/ja/ref.array.php

上記「配列 関数」などのページで見られる、「関数」の前にスペースが一つ入っているページタイトルを修正しました。

`[^0-9A-Za-z] &Functions;` の正規表現に当てはまる `&Functions;` の前の空白を削除しています。

`<title>Apache &Functions;</title>` （「Apache 関数」へ展開）のような、「英語」+「関数」の組み合わせはそのままにしています。