### PR TITLE
set_error_handlerのサンプルコードを修正

### DIFF
--- a/reference/errorfunc/functions/set-error-handler.xml
+++ b/reference/errorfunc/functions/set-error-handler.xml
@@ -225,7 +225,7 @@ function myErrorHandler($errno, $errstr, $errfile, $errline)
     if (!(error_reporting() & $errno)) {
         // error_reporting 設定に含まれていないエラーコードのため、
         // 標準の PHP エラーハンドラに渡されます。
-        return;
+        return false;
     }
 
     // $errstr はエスケープする必要があるかもしれません。


### PR DESCRIPTION
https://www.php.net/manual/ja/function.set-error-handler.php
上記ページのサンプルコード6-7行目で、
```
        // error_reporting 設定に含まれていないエラーコードのため、
        // 標準の PHP エラーハンドラに渡されます。
```
と記載されていますが、標準のPHP エラーハンドラに処理を渡すためには`false`を返却する必要があります。
こちらを修正しましたのでご確認ください。