### PR TITLE
imagick 拡張モジュールの未翻訳メソッド 21 件を新規翻訳

### DIFF
--- a/reference/imagick/imagick/clampimage.xml
+++ b/reference/imagick/imagick/clampimage.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 1ef9c7a76700b3e72844050d75e6ed1b870f9ca7 Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="imagick.clampimage" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Imagick::clampImage</refname>
+  <refpurpose>色の範囲を 0 から quantum depth までに制限する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>bool</type><methodname>Imagick::clampImage</methodname>
+   <methodparam choice="opt"><type>int</type><parameter>channel</parameter><initializer>Imagick::CHANNEL_DEFAULT</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   色の範囲を 0 から quantum depth までに制限します。
+  </para>
+
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>channel</parameter></term>
+    <listitem>
+     <para>
+
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/imagick/imagick/clipimagepath.xml
+++ b/reference/imagick/imagick/clipimagepath.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 1ef9c7a76700b3e72844050d75e6ed1b870f9ca7 Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="imagick.clipimagepath" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Imagick::clipImagePath</refname>
+  <refpurpose>8BIM プロファイルの名前付きパスがあればそれに沿ってクリップする</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>void</type><methodname>Imagick::clipImagePath</methodname>
+   <methodparam><type>string</type><parameter>pathname</parameter></methodparam>
+   <methodparam><type>string</type><parameter>inside</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   8BIM プロファイル内の名前付きパスが存在する場合、そのパスに沿ってクリップします。
+   以降の操作はパスの内側に対して適用されます。
+   Id の先頭に # を付けると番号付きパスを指定でき、
+   たとえば "#1" で最初のパスを使用します。
+  </para>
+
+  &warn.undocumented.func;
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>pathname</parameter></term>
+    <listitem>
+     <para>
+
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>inside</parameter></term>
+    <listitem>
+     <para>
+
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+
+  </para>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/imagick/imagick/getimageattribute.xml
+++ b/reference/imagick/imagick/getimageattribute.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 636409541f46610b9c38aeeb84e17e819b3ca117 Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="imagick.getimageattribute" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Imagick::getImageAttribute</refname>
+  <refpurpose>名前を指定して属性を返す</refpurpose>
+ </refnamediv>
+
+ <refsynopsisdiv>
+   &imagick.deprecated.function-3-4-4;
+ </refsynopsisdiv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>string</type><methodname>Imagick::getImageAttribute</methodname>
+   <methodparam><type>string</type><parameter>key</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   名前を指定して属性を返します。
+  </para>
+
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>key</parameter></term>
+    <listitem>
+     <para>
+      取得する属性のキー。
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+
+  </para>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/imagick/imagick/getregistry.xml
+++ b/reference/imagick/imagick/getregistry.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 1534707f677267513659e57f530ed5f4cf08f924 Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="imagick.getregistry" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Imagick::getRegistry</refname>
+  <refpurpose>StringRegistry エントリを取得する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <modifier>static</modifier> <type>string</type><methodname>Imagick::getRegistry</methodname>
+   <methodparam><type>string</type><parameter>key</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   指定されたキーの StringRegistry エントリを取得します。
+   設定されていない場合は false を返します。
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>key</parameter></term>
+    <listitem>
+     <para>
+      取得するエントリ。
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+
+  </para>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/imagick/imagick/readimages.xml
+++ b/reference/imagick/imagick/readimages.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 1ef9c7a76700b3e72844050d75e6ed1b870f9ca7 Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="imagick.readimages" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Imagick::readimages</refname>
+  <refpurpose>ファイル名の配列から画像を読み込む</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>bool</type><methodname>Imagick::readImages</methodname>
+   <methodparam><type>array</type><parameter>filenames</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   ファイル名の配列から画像を読み込みます。
+   すべての画像は単一の Imagick オブジェクトに保持されます。
+  </para>
+
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>filenames</parameter></term>
+    <listitem>
+     <para>
+
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &imagick.return.success;
+  </para>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/imagick/imagick/setimageattribute.xml
+++ b/reference/imagick/imagick/setimageattribute.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 1534707f677267513659e57f530ed5f4cf08f924 Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="imagick.setimageattribute" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Imagick::setImageAttribute</refname>
+  <refpurpose>画像の属性を設定する</refpurpose>
+ </refnamediv>
+
+ <refsynopsisdiv>
+   &imagick.deprecated.function-3-4-4;
+ </refsynopsisdiv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>bool</type><methodname>Imagick::setImageAttribute</methodname>
+   <methodparam><type>string</type><parameter>key</parameter></methodparam>
+   <methodparam><type>string</type><parameter>value</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   画像の属性を設定します。
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>key</parameter></term>
+    <listitem>
+     <para>
+
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>value</parameter></term>
+    <listitem>
+     <para>
+
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &imagick.return.success;
+  </para>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/imagick/imagick/setimagebiasquantum.xml
+++ b/reference/imagick/imagick/setimagebiasquantum.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 1534707f677267513659e57f530ed5f4cf08f924 Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="imagick.setimagebiasquantum" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Imagick::setImageBiasQuantum</refname>
+  <refpurpose>画像のバイアスを設定する</refpurpose>
+ </refnamediv>
+
+ <refsynopsisdiv>
+   &imagick.deprecated.function-3-4-4;
+ </refsynopsisdiv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>void</type><methodname>Imagick::setImageBiasQuantum</methodname>
+   <methodparam><type>float</type><parameter>bias</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   画像のバイアスを設定します。バイアスは <literal>0</literal> (調整なし) から
+   <literal>1</literal> (quantum value) の範囲でスケーリングする必要があります。
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>bias</parameter></term>
+    <listitem>
+     <para>
+
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+
+  </para>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/imagick/imagick/setregistry.xml
+++ b/reference/imagick/imagick/setregistry.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 1ef9c7a76700b3e72844050d75e6ed1b870f9ca7 Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="imagick.setregistry" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Imagick::setRegistry</refname>
+  <refpurpose>指定されたキーの ImageMagick レジストリエントリに値を設定する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <modifier>static</modifier> <type>bool</type><methodname>Imagick::setRegistry</methodname>
+   <methodparam><type>string</type><parameter>key</parameter></methodparam>
+   <methodparam><type>string</type><parameter>value</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   指定されたキーの ImageMagick レジストリエントリに値を設定します。
+   これは主に "temporary-path" の設定に役立ちます。
+   "temporary-path" は、たとえば PDF の処理中に ImageMagick が
+   一時的な画像を作成する場所を制御します。
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>key</parameter></term>
+    <listitem>
+     <para>
+
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>value</parameter></term>
+    <listitem>
+     <para>
+
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &imagick.return.success;
+  </para>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/imagick/imagickdraw/getfontstretch.xml
+++ b/reference/imagick/imagickdraw/getfontstretch.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 1ef9c7a76700b3e72844050d75e6ed1b870f9ca7 Maintainer: KentarouTakeda Status: ready -->
+
+<refentry xml:id="imagickdraw.getfontstretch" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ImagickDraw::getFontStretch</refname>
+  <refpurpose>テキストによる注記を行う際に使用するフォントの伸縮を取得する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>int</type><methodname>ImagickDraw::getFontStretch</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   テキストによる注記を行う際に使用するフォントの伸縮を取得します。
+   StretchType を返します。
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+
+  </para>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/imagick/imagickdraw/gettextinterlinespacing.xml
+++ b/reference/imagick/imagickdraw/gettextinterlinespacing.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 1ef9c7a76700b3e72844050d75e6ed1b870f9ca7 Maintainer: KentarouTakeda Status: ready -->
+
+<refentry xml:id="imagickdraw.gettextinterlinespacing" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ImagickDraw::getTextInterlineSpacing</refname>
+  <refpurpose>テキストの行間スペースを取得する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>float</type><methodname>ImagickDraw::getTextInterlineSpacing</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   テキストの行間スペースを取得します。
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+
+  </para>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/imagick/imagickdraw/gettextinterwordspacing.xml
+++ b/reference/imagick/imagickdraw/gettextinterwordspacing.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 1ef9c7a76700b3e72844050d75e6ed1b870f9ca7 Maintainer: KentarouTakeda Status: ready -->
+
+<refentry xml:id="imagickdraw.gettextinterwordspacing" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ImagickDraw::getTextInterwordSpacing</refname>
+  <refpurpose>テキストの単語間のスペースを取得する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>float</type><methodname>ImagickDraw::getTextInterwordSpacing</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   テキストの単語間のスペースを取得します。
+  </para>
+
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+
+  </para>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/imagick/imagickdraw/gettextkerning.xml
+++ b/reference/imagick/imagickdraw/gettextkerning.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 1ef9c7a76700b3e72844050d75e6ed1b870f9ca7 Maintainer: KentarouTakeda Status: ready -->
+
+<refentry xml:id="imagickdraw.gettextkerning" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ImagickDraw::getTextKerning</refname>
+  <refpurpose>テキストのカーニングを取得する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>float</type><methodname>ImagickDraw::getTextKerning</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   テキストのカーニングを取得します。
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+
+  </para>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/imagick/imagickdraw/resetvectorgraphics.xml
+++ b/reference/imagick/imagickdraw/resetvectorgraphics.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 1ef9c7a76700b3e72844050d75e6ed1b870f9ca7 Maintainer: KentarouTakeda Status: ready -->
+
+<refentry xml:id="imagickdraw.resetvectorgraphics" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ImagickDraw::resetVectorGraphics</refname>
+  <refpurpose>ベクターグラフィックをリセットする</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>bool</type><methodname>ImagickDraw::resetVectorGraphics</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   ベクターグラフィックをリセットします。
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &imagick.return.success;
+  </para>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/imagick/imagickdraw/setresolution.xml
+++ b/reference/imagick/imagickdraw/setresolution.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: e4ec40195f0fb0f7a25e827571922dedb1c6f6ac Maintainer: KentarouTakeda Status: ready -->
+
+<refentry xml:id="imagickdraw.setresolution" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ImagickDraw::setResolution</refname>
+  <refpurpose>解像度を設定する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>bool</type><methodname>ImagickDraw::setResolution</methodname>
+   <methodparam><type>float</type><parameter>resolution_x</parameter></methodparam>
+   <methodparam><type>float</type><parameter>resolution_y</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   解像度を設定します。
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>resolution_x</parameter></term>
+    <listitem>
+     <para>
+
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>resolution_y</parameter></term>
+    <listitem>
+     <para>
+
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &imagick.return.success;
+  </para>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/imagick/imagickdraw/settextinterlinespacing.xml
+++ b/reference/imagick/imagickdraw/settextinterlinespacing.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 1ef9c7a76700b3e72844050d75e6ed1b870f9ca7 Maintainer: KentarouTakeda Status: ready -->
+
+<refentry xml:id="imagickdraw.settextinterlinespacing" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ImagickDraw::setTextInterlineSpacing</refname>
+  <refpurpose>テキストの行間スペースを設定する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>bool</type><methodname>ImagickDraw::setTextInterlineSpacing</methodname>
+   <methodparam><type>float</type><parameter>spacing</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   テキストの行間スペースを設定します。
+  </para>
+
+  &warn.undocumented.func;
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>spacing</parameter></term>
+    <listitem>
+     <para>
+
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &imagick.return.success;
+  </para>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/imagick/imagickdraw/settextinterwordspacing.xml
+++ b/reference/imagick/imagickdraw/settextinterwordspacing.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 1ef9c7a76700b3e72844050d75e6ed1b870f9ca7 Maintainer: KentarouTakeda Status: ready -->
+
+<refentry xml:id="imagickdraw.settextinterwordspacing" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ImagickDraw::setTextInterwordSpacing</refname>
+  <refpurpose>テキストの単語間のスペースを設定する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>bool</type><methodname>ImagickDraw::setTextInterwordSpacing</methodname>
+   <methodparam><type>float</type><parameter>spacing</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   テキストの単語間のスペースを設定します。
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>spacing</parameter></term>
+    <listitem>
+     <para>
+
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &imagick.return.success;
+  </para>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/imagick/imagickdraw/settextkerning.xml
+++ b/reference/imagick/imagickdraw/settextkerning.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 1ef9c7a76700b3e72844050d75e6ed1b870f9ca7 Maintainer: KentarouTakeda Status: ready -->
+
+<refentry xml:id="imagickdraw.settextkerning" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ImagickDraw::setTextKerning</refname>
+  <refpurpose>テキストのカーニングを設定する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>bool</type><methodname>ImagickDraw::setTextKerning</methodname>
+   <methodparam><type>float</type><parameter>kerning</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   テキストのカーニングを設定します。
+  </para>
+
+  &warn.undocumented.func;
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>kerning</parameter></term>
+    <listitem>
+     <para>
+
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &imagick.return.success;
+  </para>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/imagick/imagickpixel/getindex.xml
+++ b/reference/imagick/imagickpixel/getindex.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 1ef9c7a76700b3e72844050d75e6ed1b870f9ca7 Maintainer: KentarouTakeda Status: ready -->
+
+<refentry xml:id="imagickpixel.getindex" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ImagickPixel::getIndex</refname>
+  <refpurpose>pixel wand のカラーマップインデックスを取得する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>int</type><methodname>ImagickPixel::getIndex</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   pixel wand のカラーマップインデックスを取得します。
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+
+  </para>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/imagick/imagickpixel/ispixelsimilarquantum.xml
+++ b/reference/imagick/imagickpixel/ispixelsimilarquantum.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 1534707f677267513659e57f530ed5f4cf08f924 Maintainer: KentarouTakeda Status: ready -->
+
+<refentry xml:id="imagickpixel.ispixelsimilarquantum" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ImagickPixel::isPixelSimilarQuantum</refname>
+  <refpurpose>ふたつの色の差が指定した距離未満かどうかを返す</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>bool</type><methodname>ImagickPixel::isPixelSimilarQuantum</methodname>
+   <methodparam><type>string</type><parameter>color</parameter></methodparam>
+   <methodparam choice="opt"><type>string</type><parameter>fuzz</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   ふたつの色の差が指定した距離未満の場合に true を返します。
+   fuzz の値は 0 から QuantumRange の範囲で指定します。
+   最大値は、色空間上で取り得る最長距離を表します。
+   たとえば RGB 色空間では RGB(0, 0, 0) から RGB(255, 255, 255) までの距離です。
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>color</parameter></term>
+    <listitem>
+     <para>
+
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>fuzz</parameter></term>
+    <listitem>
+     <para>
+
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+
+  </para>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/imagick/imagickpixel/setcolorcount.xml
+++ b/reference/imagick/imagickpixel/setcolorcount.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 1ef9c7a76700b3e72844050d75e6ed1b870f9ca7 Maintainer: KentarouTakeda Status: ready -->
+
+<refentry xml:id="imagickpixel.setcolorcount" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ImagickPixel::setColorCount</refname>
+  <refpurpose>この色に関連付けられている色カウントを設定する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>bool</type><methodname>ImagickPixel::setcolorcount</methodname>
+   <methodparam><type>int</type><parameter>colorCount</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   この色に関連付けられている色カウントを設定します。
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>colorCount</parameter></term>
+    <listitem>
+     <para>
+
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &imagick.return.success;
+  </para>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/imagick/imagickpixel/setindex.xml
+++ b/reference/imagick/imagickpixel/setindex.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 1ef9c7a76700b3e72844050d75e6ed1b870f9ca7 Maintainer: KentarouTakeda Status: ready -->
+
+<refentry xml:id="imagickpixel.setindex" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ImagickPixel::setIndex</refname>
+  <refpurpose>pixel wand のカラーマップインデックスを設定する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>bool</type><methodname>ImagickPixel::setIndex</methodname>
+   <methodparam><type>int</type><parameter>index</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   pixel wand のカラーマップインデックスを設定します。
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>index</parameter></term>
+    <listitem>
+     <para>
+
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &imagick.return.success;
+  </para>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
## 翻訳内容

### reference/imagick/imagick（8件）

- reference/imagick/imagick/clampimage.xml — 画像のカラーチャンネルを範囲内に制限
  1. php/doc-en@1ef9c7a
- reference/imagick/imagick/clipimagepath.xml — 名前付きパスに沿って画像をクリッピング
  1. php/doc-en@1ef9c7a
- reference/imagick/imagick/getimageattribute.xml — 画像の属性を返す
  1. php/doc-en@6364095
- reference/imagick/imagick/getregistry.xml — ImageMagick レジストリエントリを取得
  1. php/doc-en@1534707
- reference/imagick/imagick/readimages.xml — ファイル名の配列から画像を読み込む
  1. php/doc-en@1ef9c7a
- reference/imagick/imagick/setimageattribute.xml — 画像の属性を設定
  1. php/doc-en@1534707
- reference/imagick/imagick/setimagebiasquantum.xml — 画像のバイアスを設定
  1. php/doc-en@1534707
- reference/imagick/imagick/setregistry.xml — ImageMagick レジストリエントリを設定
  1. php/doc-en@1ef9c7a

### reference/imagick/imagickdraw（9件）

- reference/imagick/imagickdraw/getfontstretch.xml — フォントの伸縮を取得
  1. php/doc-en@1ef9c7a
- reference/imagick/imagickdraw/gettextinterlinespacing.xml — テキストの行間スペースを取得
  1. php/doc-en@1ef9c7a
- reference/imagick/imagickdraw/gettextinterwordspacing.xml — テキストの単語間スペースを取得
  1. php/doc-en@1ef9c7a
- reference/imagick/imagickdraw/gettextkerning.xml — テキストのカーニングを取得
  1. php/doc-en@1ef9c7a
- reference/imagick/imagickdraw/resetvectorgraphics.xml — ベクターグラフィックをリセット
  1. php/doc-en@1ef9c7a
- reference/imagick/imagickdraw/setresolution.xml — 解像度を設定
  1. php/doc-en@e4ec401
- reference/imagick/imagickdraw/settextinterlinespacing.xml — テキストの行間スペースを設定
  1. php/doc-en@1ef9c7a
- reference/imagick/imagickdraw/settextinterwordspacing.xml — テキストの単語間スペースを設定
  1. php/doc-en@1ef9c7a
- reference/imagick/imagickdraw/settextkerning.xml — テキストのカーニングを設定
  1. php/doc-en@1ef9c7a

### reference/imagick/imagickpixel（4件）

- reference/imagick/imagickpixel/getindex.xml — カラーマップインデックスを取得
  1. php/doc-en@1ef9c7a
- reference/imagick/imagickpixel/ispixelsimilarquantum.xml — 2つの色の差が指定量子内か判定
  1. php/doc-en@1534707
- reference/imagick/imagickpixel/setcolorcount.xml — pixel wand に関連付けられた色カウントを設定
  1. php/doc-en@1ef9c7a
- reference/imagick/imagickpixel/setindex.xml — カラーマップインデックスを設定
  1. php/doc-en@1ef9c7a