### PR TITLE
compactのChangeLog翻訳漏れ

### DIFF
--- a/reference/array/functions/compact.xml
+++ b/reference/array/functions/compact.xml
@@ -76,6 +76,12 @@
     </thead>
     <tbody>
      <row>
+      <entry>8.0.0</entry>
+      <entry>
+       与えられた文字列が示す変数が未定義の場合、<constant>E_WARNING</constant> レベルのエラーを発行するようになりました。
+      </entry>
+     </row>
+     <row>
       <entry>7.3.0</entry>
       <entry>
        <function>compact</function> は、与えられた文字列が示す変数が未定義の場合、


### PR DESCRIPTION
php/doc-en#2776 の取り込み（commit 3687432）での compact() の Changelog パートの翻訳漏れ
