### PR TITLE
pcntl_*qos_class の新規翻訳と既訳 2 件の同期

### DIFF
--- a/appendices/ini.core.xml
+++ b/appendices/ini.core.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ef757b033ba1df823b1ac5176ada439effe4cab4 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 9d4dfe5e427f2e59b3435b2ae7cb2800f3b2cf55 Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa,shimooka,mumumu -->
 
  <section xml:id="ini.core" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -817,8 +817,8 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
        <simpara>
         このオプションを無効にすると、<varname>$_POST</varname> や
         <varname>$_FILES</varname> に値が入らなくなります。
-        この場合、投稿されたデータを読むには、ストリームラッパー
-        <link linkend="wrappers.php">php://input</link> を使う以外の方法はなくなります。
+        リクエストボディは <link linkend="wrappers.php">php://input</link> に残ったままになり、
+        手動で読み取るか <link linkend="wrappers.php">request_parse_body</link> でパースして取得できます。
         これは、リクエストをプロキシしたり
         POST データを処理する際のメモリ消費量を抑えたりする際に有用です。
        </simpara>

--- a/appendices/migration84/new-functions.xml
+++ b/appendices/migration84/new-functions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ceeec43d340a7f0e0910d7eeeb0850af72ab34d9 Maintainer: KentarouTakeda Status: ready -->
+<!-- EN-Revision: 30b0c51175bb9bc5a329d7924b0ca5eff1f1f9ad Maintainer: KentarouTakeda Status: ready -->
 <!-- Credits: KentarouTakeda -->
 <sect1 xml:id="migration84.new-functions">
  <title>新しく追加された関数</title>
@@ -123,6 +123,7 @@
    <member><function>pcntl_getcpuaffinity</function></member>
    <member><function>pcntl_getqos_class</function></member>
    <member><function>pcntl_setns</function></member>
+   <member><function>pcntl_setqos_class</function></member>
    <member><function>pcntl_waitid</function></member>
   </simplelist>
  </sect2>

--- a/reference/pcntl/functions/pcntl_getqos_class.xml
+++ b/reference/pcntl/functions/pcntl_getqos_class.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 30b0c51175bb9bc5a329d7924b0ca5eff1f1f9ad Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="function.pcntl-getqos-class" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pcntl_getqos_class</refname>
+  <refpurpose>現在のスレッドの QoS クラスを取得する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>Pcntl\QosClass</type><methodname>pcntl_getqos_class</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   QoS クラスを取得します。
+  </simpara>
+  <note>
+   <simpara>この関数は、Apple のプラットフォームでのみ利用可能です。</simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   <enumname>Pcntl\QosClass</enumname> を返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   内部の <literal>pthread_get_qos_class_np()</literal> の呼び出しが失敗した場合、
+   <classname>Error</classname> をスローします。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>pcntl_setqos_class</function></member>
+   <member><enumname>Pcntl\QosClass</enumname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pcntl/functions/pcntl_setqos_class.xml
+++ b/reference/pcntl/functions/pcntl_setqos_class.xml
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 30b0c51175bb9bc5a329d7924b0ca5eff1f1f9ad Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="function.pcntl-setqos-class" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pcntl_setqos_class</refname>
+  <refpurpose>現在のスレッドの QoS クラスを設定する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>void</type><methodname>pcntl_setqos_class</methodname>
+   <methodparam choice="opt"><type>Pcntl\QosClass</type><parameter>qos_class</parameter><initializer><constant>Pcntl\QosClass::Default</constant></initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   QoS クラスを設定します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>qos_class</parameter></term>
+    <listitem>
+     <para>
+      現在のスレッドに割り当てる Quality of Service クラス。
+      オペレーティングシステムは、これを CPU 時間の割り当て、
+      I/O 優先度、電力消費をスケジューリングする際のヒントとして使用し、
+      上位のクラスは下位のクラスに割り込んで実行されます。
+      利用可能なケースについては、<enumname>Pcntl\QosClass</enumname>
+      を参照してください。
+     </para>
+     <para>
+      <variablelist>
+       <varlistentry>
+        <term><constant>Pcntl\QosClass::UserInteractive</constant></term>
+        <listitem>
+         <simpara>
+          最も高い優先度です。ユーザーインターフェイスを直接駆動する処理向けで、
+          イベント処理や描画など、体感的な遅延を避けるために
+          ほぼ瞬時に完了する必要があるものを想定しています。
+         </simpara>
+        </listitem>
+       </varlistentry>
+       <varlistentry>
+        <term><constant>Pcntl\QosClass::UserInitiated</constant></term>
+        <listitem>
+         <simpara>
+          高い優先度で、<constant>UserInteractive</constant> のすぐ下です。
+          ユーザーが明示的に開始し、結果を待っている処理向けで、
+          数秒以内に完了することが期待されるものを想定しています。
+         </simpara>
+        </listitem>
+       </varlistentry>
+       <varlistentry>
+        <term><constant>Pcntl\QosClass::Default</constant></term>
+        <listitem>
+         <simpara>
+          標準の優先度で、より具体的なクラスが該当しない場合に使用します。
+          より優先度の高い処理の後に実行されますが、
+          <constant>Utility</constant> や <constant>Background</constant>
+          よりは先に実行されます。
+         </simpara>
+        </listitem>
+       </varlistentry>
+       <varlistentry>
+        <term><constant>Pcntl\QosClass::Utility</constant></term>
+        <listitem>
+         <simpara>
+          低めの優先度です。ダウンロード、インポート、
+          一括計算など、ユーザーは認識しているものの、
+          結果を待ってはいない長時間の処理向けです。
+          省電力なスケジューリングが行われます。
+         </simpara>
+        </listitem>
+       </varlistentry>
+       <varlistentry>
+        <term><constant>Pcntl\QosClass::Background</constant></term>
+        <listitem>
+         <simpara>
+          最も低い優先度です。プリフェッチ、インデックス作成、
+          メンテナンスなど、ユーザーが認識していない処理向けです。
+          電力効率を強く重視して最適化されており、
+          システムが高負荷の場合は実行が後回しにされる可能性があります。
+         </simpara>
+        </listitem>
+       </varlistentry>
+      </variablelist>
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+  <note>
+   <simpara>この関数は、Apple のプラットフォームでのみ利用可能です。</simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.void;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   内部の <literal>pthread_set_qos_class_self_np()</literal> の呼び出しが失敗した場合、
+   <classname>Error</classname> をスローします。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>pcntl_getqos_class</function></member>
+   <member><enumname>Pcntl\QosClass</enumname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
## 翻訳内容

### pcntl QoS クラス追加（3件）

- appendices/migration84/new-functions.xml — 新規関数一覧に pcntl_setqos_class を追加
  1. php/doc-en@30b0c51175
- reference/pcntl/functions/pcntl_getqos_class.xml — 現在のスレッドの QoS クラスを取得する関数の新規翻訳
  1. php/doc-en@30b0c51175
- reference/pcntl/functions/pcntl_setqos_class.xml — 現在のスレッドの QoS クラスを設定する関数の新規翻訳
  1. php/doc-en@30b0c51175

### 独立ファイル

- appendices/ini.core.xml — enable_post_data_reading=0 時の挙動説明を更新（request_parse_body() でもパース可能）
  1. php/doc-en@9d4dfe5e42