### PR TITLE
ini.core.xml と match.xml を doc-en の最新に同期

### DIFF
--- a/appendices/ini.core.xml
+++ b/appendices/ini.core.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9d4dfe5e427f2e59b3435b2ae7cb2800f3b2cf55 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 185dda85976e5ed392664db011abda0110726c0d Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa,shimooka,mumumu -->
 
  <section xml:id="ini.core" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -818,7 +818,7 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
         このオプションを無効にすると、<varname>$_POST</varname> や
         <varname>$_FILES</varname> に値が入らなくなります。
         リクエストボディは <link linkend="wrappers.php">php://input</link> に残ったままになり、
-        手動で読み取るか <link linkend="wrappers.php">request_parse_body</link> でパースして取得できます。
+        手動で読み取るか <function>request_parse_body</function> でパースして取得できます。
         これは、リクエストをプロキシしたり
         POST データを処理する際のメモリ消費量を抑えたりする際に有用です。
        </simpara>

--- a/language/control-structures/match.xml
+++ b/language/control-structures/match.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 17502ebe0691a84e7d0738c13e8c1061dde98de7 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 840bdb9be79855ee4b2cc66c22cf3e88b781398a Maintainer: mumumu Status: ready -->
 
 <sect1 xml:id="control-structures.match" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>match</title>
@@ -66,7 +66,7 @@ $output = match (true) {
     $age < 2 => "Baby",
     $age < 13 => "Child",
     $age <= 19 => "Teenager",
-    $age >= 40 => "Old adult",
+    $age >= 40 => "Adult",
     $age > 19 => "Young adult",
 };
 


### PR DESCRIPTION
## 翻訳内容

### 独立ファイル

- appendices/ini.core.xml — `<link>` から `<function>` タグへ変更
  1. php/doc-en@185dda8597
- language/control-structures/match.xml — match 構文ドキュメントのサンプルコード文字列を `"Old adult"` から `"Adult"` に変更
  1. php/doc-en@840bdb9be7