### PR TITLE
doc-en と既訳 3 件を同期

### DIFF
--- a/reference/datetime/dateinterval/createfromdatestring.xml
+++ b/reference/datetime/dateinterval/createfromdatestring.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: c0c9d7721b5a8564a4e27671389a456c1be13e6b Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 
 <refentry xml:id="dateinterval.createfromdatestring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -68,7 +68,7 @@
   <para>
    オブジェクト指向のAPIのみ、
    無効な日付/時刻の文字列が渡された場合に
-   <exceptionname>DateMalformedStringException</exceptionname>
+   <exceptionname>DateMalformedIntervalStringException</exceptionname>
    がスローされます。
   </para>
  </refsect1>
@@ -89,7 +89,7 @@
       <entry>
        無効な文字列が渡された場合、
        <methodname>DateInterval::createFromDateString</methodname>
-       は <exceptionname>DateMalformedStringException</exceptionname>
+       は <exceptionname>DateMalformedIntervalStringException</exceptionname>
        をスローするようになりました。
        これより前のバージョンでは、
        警告が発生して <literal>false</literal> を返していました。

--- a/reference/intl/locale/isrighttoleft.xml
+++ b/reference/intl/locale/isrighttoleft.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ac2b471bbca22b1b77140cf7c67c979d18a0caec Maintainer: KentarouTakeda Status: ready -->
+<!-- EN-Revision: facf6996ca5a6057f7092761079e4aa00c5b7713 Maintainer: KentarouTakeda Status: ready -->
 <refentry xml:id="locale.isrighttoleft"
           xmlns="http://docbook.org/ns/docbook"
           xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -85,8 +85,10 @@
   &reftitle.examples;
   <example>
    <title>ロケールのテキスト方向を調べる</title>
-   <programlisting>
+   <programlisting role="php">
 <![CDATA[
+<?php
+
 var_dump(Locale::isRightToLeft('en-US'));
 var_dump(Locale::isRightToLeft('ar'));
 ]]>

--- a/reference/openssl/functions/openssl-x509-read.xml
+++ b/reference/openssl/functions/openssl-x509-read.xml
@@ -48,10 +48,10 @@
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    X.509 証明書を取得できなかった場合、
    <constant>E_WARNING</constant> レベルのエラーが発生します。
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/openssl/functions/openssl-x509-read.xml
+++ b/reference/openssl/functions/openssl-x509-read.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d1e3ea622e5d4f542cd36eca59a9f22aa0142633 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 47881dcf54038053a6aa70d901e61c14e2c01a06 Maintainer: hirokawa Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="function.openssl-x509-read" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -44,6 +44,14 @@
    成功した場合に <classname>OpenSSLCertificate</classname> オブジェクトを返します。
    &return.falseforfailure;
   </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   X.509 証明書を取得できなかった場合、
+   <constant>E_WARNING</constant> が発生します。
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/openssl/functions/openssl-x509-read.xml
+++ b/reference/openssl/functions/openssl-x509-read.xml
@@ -48,10 +48,10 @@
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <simpara>
+  <para>
    X.509 証明書を取得できなかった場合、
-   <constant>E_WARNING</constant> が発生します。
-  </simpara>
+   <constant>E_WARNING</constant> レベルのエラーが発生します。
+  </para>
  </refsect1>
 
  <refsect1 role="changelog">


### PR DESCRIPTION
最新の doc-en に合わせて 3 件の既訳を同期します。

- \`DateInterval::createFromDateString\`: 例外名を \`DateMalformedIntervalStringException\` に修正 (php/doc-en#5521)
- \`Locale::isRightToLeft\`: サンプルコードに \`<?php\` タグと \`role=\"php\"\` 属性を追加 (php/doc-en#5514)
- \`openssl_x509_read\`: 証明書を取得できなかった場合に \`E_WARNING\` が発生する旨の errors セクションを追加 (php/doc-en#5494)