### PR TITLE
language-snippets.ent: warn.removed.feature-8-5-0 を追加

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d6dc2be3c5c70e4a1c3d13f788643ea232747c19 Maintainer: takagi Status: working -->
+<!-- EN-Revision: 2d6fb23e0fb7a40ca25086d9dac763f12b02daec Maintainer: takagi Status: working -->
 <!-- Credits: hirokawa,haruki,shimooka,mumumu,jdkfx -->
 
 <!ENTITY installation.enabled.disable 'この拡張モジュールはデフォルトで有効になっています。無効にしたい場合は、次のオプションを指定してコンパイルします。'>
@@ -437,6 +437,8 @@ PHP 7.4.0 で <emphasis>削除</emphasis> されました。</simpara></warning>
 <!ENTITY warn.deprecated.alias-8-0-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>このエイリアスは PHP 8.0.0 で <emphasis>非推奨</emphasis> になりました。</simpara></warning>'>
 
 <!ENTITY warn.removed.alias-8-0-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>このエイリアスは PHP 8.0.0 で <emphasis>削除</emphasis> されました。</simpara></warning>'>
+
+<!ENTITY warn.removed.feature-8-5-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>この機能は PHP 8.5.0 で <emphasis>削除</emphasis> されました。</simpara></warning>'>
 
 <!ENTITY warn.experimental.func '<warning xmlns="http://docbook.org/ns/docbook"><simpara>この関数は、
 <emphasis>実験的</emphasis> なものです。この関数の動作・


### PR DESCRIPTION
PHP 8.5.0 で削除された機能を示す新しい warning エンティティ \`warn.removed.feature-8-5-0\` を doc-en に追従して追加します。

表現は既存の \`warn.removed.alias-8-0-0\` のパターンに揃えています：

\`\`\`
この機能は PHP 8.5.0 で <emphasis>削除</emphasis> されました。
\`\`\`

doc-en 側 (php/doc-en@2d6fb23e) で定義されたばかりで、現時点では参照箇所はありませんが、今後 reference/ 配下で利用された際に英語のフォールバックが表示されないようあらかじめ翻訳します。