### PR TITLE
URI 拡張モジュールを完訳（PHP 8.5）

### DIFF
--- a/README_Glossary.md
+++ b/README_Glossary.md
@@ -41,6 +41,10 @@
   * 移行ガイドの文脈での Standard は「標準ライブラリ」で統一する
     - php-src で言うところの ext/standard に入っている関数全てを指す
     - Standard PHP Librady (SPL) は別にあるが、「標準ライブラリ」でいいことにする
+- WHATWG URL Standard
+  * 「WHATWG URL Standard」（原語のまま）で統一
+    - ext/uri などで言及される、URL 仕様の固有名詞
+    - 「WHATWG URL 標準」とはしない
 - throw Exception
   * 例外をスローする
     - 例外を「投げる」とはしない

--- a/build/prh.yml
+++ b/build/prh.yml
@@ -51,3 +51,10 @@ rules:
         to: サーバー
       - from: サーバー
         to: サーバー
+  - expected: WHATWG URL Standard
+    pattern: WHATWG URL 標準
+    specs:
+      - from: WHATWG URL 標準
+        to: WHATWG URL Standard
+      - from: WHATWG URL Standard
+        to: WHATWG URL Standard

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d6dc2be3c5c70e4a1c3d13f788643ea232747c19 Maintainer: takagi Status: working -->
+<!-- EN-Revision: 330903cf6a567b885d24d0a468960d1e3b9ae213 Maintainer: takagi Status: working -->
 <!-- Credits: hirokawa,haruki,shimooka,mumumu,jdkfx -->
 
 <!ENTITY installation.enabled.disable 'この拡張モジュールはデフォルトで有効になっています。無効にしたい場合は、次のオプションを指定してコンパイルします。'>
@@ -4745,6 +4745,21 @@ local: {
     がスローした、あらゆる <classname>Throwable</classname> がスローされます。
   </simpara>
  </listitem>
+'>
+
+<!-- URI snippets -->
+<!ENTITY uri.errors.invalidUriException '
+  <simpara>
+   結果の URI が不正な場合、<exceptionname>Uri\InvalidUriException</exceptionname>
+   がスローされます。
+  </simpara>
+'>
+
+<!ENTITY uri.errors.invalidUrlException '
+  <simpara>
+   結果の URL が不正な場合、<exceptionname>Uri\WhatWg\InvalidUrlException</exceptionname>
+   がスローされます。
+  </simpara>
 '>
 
 <!-- UOPZ snippets -->

--- a/reference/uri/book.xml
+++ b/reference/uri/book.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 4f62b60b56562114d9d816e2e5f13b40a5614c26 Maintainer: KentarouTakeda Status: ready -->
+
+<book xml:id="book.uri" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="interactive">
+ <?phpdoc extension-membership="core" ?>
+ <title>URI</title>
+ <titleabbrev>URI</titleabbrev>
+
+ <preface xml:id="intro.uri">
+  &reftitle.intro;
+  <simpara>
+   この章では、Uniform Resource Identifier (URI) を扱うための関数について説明します。
+   URI とは、リソースを識別するために使われる文字列です。
+   URI は、インターネット上のリソースを識別するために、Web 技術で利用されています。
+  </simpara>
+  <simpara>
+   この拡張モジュールは、
+   <link xlink:href="&url.url.rfc3986;">RFC 3986,
+   Uniform Resource Identifier (URI): Generic Syntax</link> および
+   <link xlink:href="&url.url.whatwg-url;">WHATWG URL Standard</link>
+   の仕様に従う機能を実装しています。
+  </simpara>
+ </preface>
+
+ &reference.uri.uri.rfc3986.uri;
+
+ &reference.uri.uri.whatwg.url;
+
+ &reference.uri.uri.uricomparisonmode;
+
+ &reference.uri.uri.uriexception;
+ &reference.uri.uri.urierror;
+ &reference.uri.uri.invaliduriexception;
+ &reference.uri.uri.whatwg.invalidurlexception;
+ &reference.uri.uri.whatwg.urlvalidationerror;
+ &reference.uri.uri.whatwg.urlvalidationerrortype;
+</book>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri.invaliduriexception.xml
+++ b/reference/uri/uri.invaliduriexception.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 8a341f6c434f352133a6ac7eb5a7d90208604d84 Maintainer: KentarouTakeda Status: ready -->
+<reference xml:id="class.uri-invaliduriexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>Uri\InvalidUriException クラス</title>
+ <titleabbrev>Uri\InvalidUriException</titleabbrev>
+
+ <partintro>
+  <section xml:id="uri-invaliduriexception.intro">
+   &reftitle.intro;
+   <simpara>
+    指定された URI が不正であるか、操作の結果が不正な URI になることを示します。
+   </simpara>
+  </section>
+
+  <section xml:id="uri-invaliduriexception.synopsis">
+   &reftitle.classsynopsis;
+
+   <packagesynopsis>
+    <package>Uri</package>
+
+    <classsynopsis class="class">
+     <ooexception>
+      <exceptionname>InvalidUriException</exceptionname>
+     </ooexception>
+
+     <ooclass>
+      <modifier>extends</modifier>
+      <classname>Uri\UriException</classname>
+     </ooclass>
+
+     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+      <xi:fallback/>
+     </xi:include>
+
+     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
+      <xi:fallback/>
+     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
+      <xi:fallback/>
+     </xi:include>
+    </classsynopsis>
+   </packagesynopsis>
+  </section>
+ </partintro>
+</reference>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri.rfc3986.uri.xml
+++ b/reference/uri/uri.rfc3986.uri.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: e4aca6ce959c13feaaf1a1c880defd94cb2d8b06 Maintainer: KentarouTakeda Status: ready -->
+
+<reference xml:id="class.uri-rfc3986-uri" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>Uri\Rfc3986\Uri クラス</title>
+ <titleabbrev>Uri\Rfc3986\Uri</titleabbrev>
+
+ <partintro>
+  <section xml:id="uri-rfc3986-uri.intro">
+   &reftitle.intro;
+   <simpara>
+   </simpara>
+  </section>
+
+  <section xml:id="uri-rfc3986-uri.synopsis">
+   &reftitle.classsynopsis;
+
+   <packagesynopsis>
+    <package>Uri\Rfc3986</package>
+
+    <classsynopsis class="class">
+     <ooclass>
+      <modifier>final</modifier>
+      <modifier>readonly</modifier>
+      <classname>Uri</classname>
+     </ooclass>
+
+     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.uri-rfc3986-uri')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Uri\\Rfc3986\\Uri'])">
+      <xi:fallback/>
+     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.uri-rfc3986-uri')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Uri\\Rfc3986\\Uri'])">
+      <xi:fallback/>
+     </xi:include>
+    </classsynopsis>
+   </packagesynopsis>
+  </section>
+ </partintro>
+
+ &reference.uri.uri.rfc3986.entities.uri;
+
+</reference>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri.uricomparisonmode.xml
+++ b/reference/uri/uri.uricomparisonmode.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 9e2dd56cb1b2fb3e97eed9b16b4b94ac0dbefadc Maintainer: KentarouTakeda Status: ready -->
+<reference xml:id="enum.uri-uricomparisonmode" role="enum" xmlns="http://docbook.org/ns/docbook">
+ <title>Uri\UriComparisonMode Enum</title>
+ <titleabbrev>Uri\UriComparisonMode</titleabbrev>
+
+ <partintro>
+  <section xml:id="enum.uri-uricomparisonmode.intro">
+   &reftitle.intro;
+   <simpara>
+    URI の比較結果に <literal>fragment</literal> コンポーネントを反映させるかどうかを指定します。
+   </simpara>
+   <simpara>
+    フラグメントが比較から除外される場合、2 つの URI はどちらも <literal>fragment</literal>
+    コンポーネントを持たないかのように比較されます。
+   </simpara>
+  </section>
+
+  <section xml:id="enum.uri-uricomparisonmode.synopsis">
+   &reftitle.enumsynopsis;
+
+   <packagesynopsis>
+    <package>Uri</package>
+
+    <enumsynopsis>
+     <enumname>UriComparisonMode</enumname>
+
+     <enumitem>
+      <enumidentifier>IncludeFragment</enumidentifier>
+      <enumitemdescription><literal>fragment</literal> コンポーネントを比較に含めます。</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>ExcludeFragment</enumidentifier>
+      <enumitemdescription><literal>fragment</literal> コンポーネントを比較から除外します。</enumitemdescription>
+     </enumitem>
+    </enumsynopsis>
+   </packagesynopsis>
+  </section>
+ </partintro>
+</reference>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri.urierror.xml
+++ b/reference/uri/uri.urierror.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 8a341f6c434f352133a6ac7eb5a7d90208604d84 Maintainer: KentarouTakeda Status: ready -->
+<reference xml:id="class.uri-urierror" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>Uri\UriError クラス</title>
+ <titleabbrev>Uri\UriError</titleabbrev>
+
+ <partintro>
+  <section xml:id="uri-urierror.intro">
+   &reftitle.intro;
+   <simpara>
+    URI の処理中に発生する <type>Error</type> の基底クラスです。
+   </simpara>
+  </section>
+
+  <section xml:id="uri-urierror.synopsis">
+   &reftitle.classsynopsis;
+
+   <packagesynopsis>
+    <package>Uri</package>
+
+    <classsynopsis class="class">
+     <ooexception>
+      <exceptionname>UriError</exceptionname>
+     </ooexception>
+
+     <ooclass>
+      <modifier>extends</modifier>
+      <classname>Error</classname>
+     </ooclass>
+
+     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+      <xi:fallback/>
+     </xi:include>
+
+     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])">
+      <xi:fallback/>
+     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])">
+      <xi:fallback/>
+     </xi:include>
+    </classsynopsis>
+   </packagesynopsis>
+  </section>
+ </partintro>
+</reference>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri.uriexception.xml
+++ b/reference/uri/uri.uriexception.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 8a341f6c434f352133a6ac7eb5a7d90208604d84 Maintainer: KentarouTakeda Status: ready -->
+
+<reference xml:id="class.uri-uriexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>Uri\UriException クラス</title>
+ <titleabbrev>Uri\UriException</titleabbrev>
+
+ <partintro>
+  <section xml:id="uri-uriexception.intro">
+   &reftitle.intro;
+   <simpara>
+    URI の処理中に発生する <type>Exception</type> の基底クラスです。
+   </simpara>
+  </section>
+
+  <section xml:id="uri-uriexception.synopsis">
+   &reftitle.classsynopsis;
+
+   <packagesynopsis>
+    <package>Uri</package>
+
+    <classsynopsis class="class">
+     <ooexception>
+      <exceptionname>UriException</exceptionname>
+     </ooexception>
+
+     <ooclass>
+      <modifier>extends</modifier>
+      <classname>Exception</classname>
+     </ooclass>
+
+     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+      <xi:fallback/>
+     </xi:include>
+
+     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
+      <xi:fallback/>
+     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
+      <xi:fallback/>
+     </xi:include>
+    </classsynopsis>
+   </packagesynopsis>
+  </section>
+ </partintro>
+</reference>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri.whatwg.invalidurlexception.xml
+++ b/reference/uri/uri.whatwg.invalidurlexception.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 8a341f6c434f352133a6ac7eb5a7d90208604d84 Maintainer: KentarouTakeda Status: ready -->
+<reference xml:id="class.uri-whatwg-invalidurlexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>Uri\WhatWg\InvalidUrlException クラス</title>
+ <titleabbrev>Uri\WhatWg\InvalidUrlException</titleabbrev>
+
+ <partintro>
+  <section xml:id="uri-whatwg-invalidurlexception.intro">
+   &reftitle.intro;
+   <simpara>
+    指定された URL が不正であるか、操作の結果が
+    <link xlink:href="&url.url.whatwg-url;">WHATWG URL Standard</link>
+    に従って不正な URL になることを示します。
+   </simpara>
+  </section>
+
+  <section xml:id="uri-whatwg-invalidurlexception.synopsis">
+   &reftitle.classsynopsis;
+
+   <packagesynopsis>
+    <package>Uri\WhatWg</package>
+
+    <classsynopsis class="class">
+     <ooexception>
+      <exceptionname>InvalidUrlException</exceptionname>
+     </ooexception>
+
+     <ooclass>
+      <modifier>extends</modifier>
+      <classname>Uri\InvalidUriException</classname>
+     </ooclass>
+
+     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+     <fieldsynopsis>
+      <modifier>public</modifier>
+      <modifier>readonly</modifier>
+      <type>array</type>
+      <varname linkend="uri-whatwg-invalidurlexception.props.errors">errors</varname>
+     </fieldsynopsis>
+
+     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+      <xi:fallback/>
+     </xi:include>
+
+     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.uri-whatwg-invalidurlexception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Uri\\WhatWg\\InvalidUrlException'])">
+      <xi:fallback/>
+     </xi:include>
+
+     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
+      <xi:fallback/>
+     </xi:include>
+    </classsynopsis>
+   </packagesynopsis>
+  </section>
+
+  <section xml:id="uri-whatwg-invalidurlexception.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="uri-whatwg-invalidurlexception.props.errors">
+     <term><varname>errors</varname></term>
+     <listitem>
+      <simpara>
+       <classname>Uri\WhatWg\UrlValidationError</classname> オブジェクトの &array;。
+      </simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+ </partintro>
+
+ &reference.uri.uri.whatwg.entities.invalidurlexception;
+
+</reference>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri.whatwg.url.xml
+++ b/reference/uri/uri.whatwg.url.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: e4aca6ce959c13feaaf1a1c880defd94cb2d8b06 Maintainer: KentarouTakeda Status: ready -->
+<reference xml:id="class.uri-whatwg-url" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>Uri\WhatWg\Url クラス</title>
+ <titleabbrev>Uri\WhatWg\Url</titleabbrev>
+
+ <partintro>
+  <section xml:id="uri-whatwg-url.intro">
+   &reftitle.intro;
+   <simpara>
+   </simpara>
+  </section>
+
+  <section xml:id="uri-whatwg-url.synopsis">
+   &reftitle.classsynopsis;
+
+   <packagesynopsis>
+    <package>Uri\WhatWg</package>
+
+    <classsynopsis class="class">
+     <ooclass>
+      <modifier>final</modifier>
+      <modifier>readonly</modifier>
+      <classname>Url</classname>
+     </ooclass>
+
+     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.uri-whatwg-url')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Uri\\WhatWg\\Url'])">
+      <xi:fallback/>
+     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.uri-whatwg-url')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Uri\\WhatWg\\Url'])">
+      <xi:fallback/>
+     </xi:include>
+    </classsynopsis>
+   </packagesynopsis>
+  </section>
+ </partintro>
+
+ &reference.uri.uri.whatwg.entities.url;
+
+</reference>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri.whatwg.urlvalidationerror.xml
+++ b/reference/uri/uri.whatwg.urlvalidationerror.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: b6e9565ba267f4c9a463104ffb0ea45e1a6753b0 Maintainer: KentarouTakeda Status: ready -->
+<reference xml:id="class.uri-whatwg-urlvalidationerror" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>Uri\WhatWg\UrlValidationError クラス</title>
+ <titleabbrev>Uri\WhatWg\UrlValidationError</titleabbrev>
+
+ <partintro>
+  <section xml:id="uri-whatwg-urlvalidationerror.intro">
+   &reftitle.intro;
+   <simpara>
+    <classname>Uri\WhatWg\Url</classname> で URL をパースする際に
+    検出されたエラーの詳細情報を提供します。
+   </simpara>
+  </section>
+
+  <section xml:id="uri-whatwg-urlvalidationerror.synopsis">
+   &reftitle.classsynopsis;
+
+   <packagesynopsis>
+    <package>Uri\WhatWg</package>
+
+    <classsynopsis class="class">
+     <ooclass>
+      <modifier>final</modifier>
+      <modifier>readonly</modifier>
+      <classname>UrlValidationError</classname>
+     </ooclass>
+
+     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+     <fieldsynopsis>
+      <modifier>public</modifier>
+      <type>string</type>
+      <varname linkend="uri-whatwg-urlvalidationerror.props.context">context</varname>
+     </fieldsynopsis>
+     <fieldsynopsis>
+      <modifier>public</modifier>
+      <type>Uri\WhatWg\UrlValidationErrorType</type>
+      <varname linkend="uri-whatwg-urlvalidationerror.props.type">type</varname>
+     </fieldsynopsis>
+     <fieldsynopsis>
+      <modifier>public</modifier>
+      <type>bool</type>
+      <varname linkend="uri-whatwg-urlvalidationerror.props.failure">failure</varname>
+     </fieldsynopsis>
+
+     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.uri-whatwg-urlvalidationerror')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Uri\\WhatWg\\UrlValidationError'])">
+      <xi:fallback/>
+     </xi:include>
+    </classsynopsis>
+   </packagesynopsis>
+  </section>
+
+  <section xml:id="uri-whatwg-urlvalidationerror.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="uri-whatwg-urlvalidationerror.props.context">
+     <term><varname>context</varname></term>
+     <listitem>
+      <simpara>
+       エラーが検出された時点での入力 URL。
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="uri-whatwg-urlvalidationerror.props.type">
+     <term><varname>type</varname></term>
+     <listitem>
+      <simpara>
+       エラーの種類。
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="uri-whatwg-urlvalidationerror.props.failure">
+     <term><varname>failure</varname></term>
+     <listitem>
+      <simpara>
+       &true; の場合、エラーにより URL は不正として拒否されます。&false;
+       の場合、エラーはパース中に自動的に修正されたソフトエラーです。
+      </simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+ </partintro>
+
+ &reference.uri.uri.whatwg.entities.urlvalidationerror;
+
+</reference>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri.whatwg.urlvalidationerrortype.xml
+++ b/reference/uri/uri.whatwg.urlvalidationerrortype.xml
@@ -1,0 +1,203 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 8352249a84d0b91b38c741ff1c256061127dbfbb Maintainer: KentarouTakeda Status: ready -->
+<reference xml:id="enum.uri-whatwg-urlvalidationerrortype" role="enum" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://docbook.org/ns/docbook">
+ <title>Uri\WhatWg\UrlValidationErrorType Enum</title>
+ <titleabbrev>Uri\WhatWg\UrlValidationErrorType</titleabbrev>
+
+ <partintro>
+  <section xml:id="enum.uri-whatwg-urlvalidationerrortype.intro">
+   &reftitle.intro;
+   <simpara>
+    <link xlink:href="&url.url.whatwg-url;">WHATWG URL Standard</link> で定義されている検証エラーの種類です。
+   </simpara>
+  </section>
+
+  <section xml:id="enum.uri-whatwg-urlvalidationerrortype.synopsis">
+   &reftitle.enumsynopsis;
+
+   <packagesynopsis>
+    <package>Uri\WhatWg</package>
+
+    <enumsynopsis>
+     <enumname>UrlValidationErrorType</enumname>
+
+     <enumitem>
+      <enumidentifier>DomainToAscii</enumidentifier>
+      <enumitemdescription>ドメイン名を ASCII 文字列に変換する処理中のエラーです。</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>DomainToUnicode</enumidentifier>
+      <enumitemdescription>ドメイン名を Unicode 文字列に変換する処理中のエラーです。</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>DomainInvalidCodePoint</enumidentifier>
+      <enumitemdescription>入力のホストに、禁止されたドメインコードポイントが含まれています。</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>HostInvalidCodePoint</enumidentifier>
+      <enumitemdescription>不透明なホスト（特別ではない URL のホスト）に、禁止されたホストコードポイントが含まれています。</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Ipv4EmptyPart</enumidentifier>
+      <enumitemdescription>IPv4 アドレスが <literal>U+002E</literal> (<literal>.</literal>) で終わっています。</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Ipv4TooManyParts</enumidentifier>
+      <enumitemdescription>IPv4 アドレスがちょうど 4 つのパートで構成されていません。</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Ipv4NonNumericPart</enumidentifier>
+      <enumitemdescription>IPv4 アドレスのパートが数値ではありません。</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Ipv4NonDecimalPart</enumidentifier>
+      <enumitemdescription>IPv4 アドレスに、16 進数または 8 進数で表現された数値が含まれています。</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Ipv4OutOfRangePart</enumidentifier>
+      <enumitemdescription>IPv4 アドレスのパートが <literal>255</literal> を超えています。</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Ipv6Unclosed</enumidentifier>
+      <enumitemdescription>IPv6 アドレスを閉じる <literal>U+005D</literal> (<literal>]</literal>) が欠けています。</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Ipv6InvalidCompression</enumidentifier>
+      <enumitemdescription>IPv6 アドレスが不正な圧縮で始まっています。</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Ipv6TooManyPieces</enumidentifier>
+      <enumitemdescription>IPv6 アドレスに 8 つを超えるピースが含まれています。</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Ipv6MultipleCompression</enumidentifier>
+      <enumitemdescription>IPv6 アドレスが複数箇所で圧縮されています。</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Ipv6InvalidCodePoint</enumidentifier>
+      <enumitemdescription>
+       IPv6 アドレスに、ASCII 16 進数字でも <literal>U+003A</literal> (<literal>:</literal>)
+       でもないコードポイントが含まれています。または、予期せず終了しています。
+      </enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Ipv6TooFewPieces</enumidentifier>
+      <enumitemdescription>圧縮されていない IPv6 アドレスに含まれるピースが 8 つ未満です。</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Ipv4InIpv6TooManyPieces</enumidentifier>
+      <enumitemdescription>IPv4 アドレス構文を持つ IPv6 アドレスにおいて、IPv6 アドレスのピースが 6 つを超えています。</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Ipv4InIpv6InvalidCodePoint</enumidentifier>
+      <enumitemdescription>IPv4 アドレス構文を持つ IPv6 アドレスです。</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Ipv4InIpv6OutOfRangePart</enumidentifier>
+      <enumitemdescription>IPv4 アドレス構文を持つ IPv6 アドレスにおいて、IPv4 のパートが <literal>255</literal> を超えています。</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Ipv4InIpv6TooFewParts</enumidentifier>
+      <enumitemdescription>IPv4 アドレス構文を持つ IPv6 アドレスにおいて、IPv4 アドレスのパートが少なすぎます。</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>InvalidUrlUnit</enumidentifier>
+      <enumitemdescription>URL 単位ではないコードポイントが見つかりました。</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>SpecialSchemeMissingFollowingSolidus</enumidentifier>
+      <enumitemdescription>入力のスキームの後に <literal>//</literal> が続いていません。</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>MissingSchemeNonRelativeUrl</enumidentifier>
+      <enumitemdescription>
+       入力にスキームがありません。これは、入力が ASCII アルファベットで始まっておらず、
+       かつベース URL が指定されていないか、ベース URL が不透明なパスを持つためベース URL として使用できないためです。
+      </enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>InvalidReverseSoldius</enumidentifier>
+      <enumitemdescription>URL が特別なスキームを持ち、<literal>U+002F</literal> (<literal>/</literal>)
+       の代わりに <literal>U+005C</literal> (<literal>\</literal>) を使用しています。</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>InvalidCredentials</enumidentifier>
+      <enumitemdescription>入力に認証情報が含まれています。</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>HostMissing</enumidentifier>
+      <enumitemdescription>入力が特別なスキームを持っていますが、ホストを含んでいません。</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>PortOutOfRange</enumidentifier>
+      <enumitemdescription>入力のポートが大きすぎます。</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>PortInvalid</enumidentifier>
+      <enumitemdescription>入力のポートが不正です。</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>FileInvalidWindowsDriveLetter</enumidentifier>
+      <enumitemdescription>
+       入力が Windows ドライブレターで始まる相対 URL 文字列であり、
+       かつベース URL のスキームが <literal>file</literal> です。
+      </enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>FileInvalidWindowsDriveLetterHost</enumidentifier>
+      <enumitemdescription><literal>file:</literal> URL のホストが Windows ドライブレターになっています。</enumitemdescription>
+     </enumitem>
+    </enumsynopsis>
+   </packagesynopsis>
+  </section>
+ </partintro>
+</reference>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/construct.xml
+++ b/reference/uri/uri/rfc3986/uri/construct.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::__construct</refname>
+  <refpurpose>Uri オブジェクトを構築する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <constructorsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <methodname>Uri\Rfc3986\Uri::__construct</methodname>
+   <methodparam><type>string</type><parameter>uri</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>Uri\Rfc3986\Uri</type><type>null</type></type><parameter>baseUrl</parameter><initializer>&null;</initializer></methodparam>
+  </constructorsynopsis>
+  <simpara>
+   <classname>Uri\Rfc3986\Uri</classname> オブジェクトを構築します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>uri</parameter></term>
+    <listitem>
+     <simpara>
+      パースする URI。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>baseUrl</parameter></term>
+    <listitem>
+     <simpara>
+      &string; が渡された場合、<parameter>uri</parameter> が相対参照であれば、
+      <parameter>uri</parameter> を <parameter>baseUrl</parameter> に適用します。
+      &null; が渡されるか、<parameter>uri</parameter> が相対参照でない場合、
+      <parameter>baseUrl</parameter> は効果を持ちません。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUriException;
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::parse</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::resolve</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::__construct</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/debuginfo.xml
+++ b/reference/uri/uri/rfc3986/uri/debuginfo.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+
+<refentry xml:id="uri-rfc3986-uri.debuginfo" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::__debugInfo</refname>
+  <refpurpose>URI の内部状態を返す</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type>array</type><methodname>Uri\Rfc3986\Uri::__debugInfo</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   URI の内部状態を返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   URI の内部状態を &array; として返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::__debugInfo</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/equals.xml
+++ b/reference/uri/uri/rfc3986/uri/equals.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+
+<refentry xml:id="uri-rfc3986-uri.equals" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::equals</refname>
+  <refpurpose>2 つの URI が等価かを判定する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type>bool</type><methodname>Uri\Rfc3986\Uri::equals</methodname>
+   <methodparam><type>Uri\Rfc3986\Uri</type><parameter>uri</parameter></methodparam>
+   <methodparam choice="opt"><type>Uri\UriComparisonMode</type><parameter>comparisonMode</parameter><initializer><constant>Uri\UriComparisonMode::ExcludeFragment</constant></initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   2 つの URI が等価かを判定します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>uri</parameter></term>
+    <listitem>
+     <simpara>
+      現在の URI と比較する URI。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>comparisonMode</parameter></term>
+    <listitem>
+     <simpara>
+      フラグメントコンポーネントを比較の対象に含めるか
+      (<literal>Uri\UriComparisonMode::IncludeFragment</literal>)、含めないか
+      (<literal>Uri\UriComparisonMode::ExcludeFragment</literal>)。デフォルトでは、フラグメントは除外されます。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   2 つの URI が等価である場合は &true; を、そうでない場合は &false; を返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.equals.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::equals</methodname> の基本的な例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri1 = new \Uri\Rfc3986\Uri("https://example.com");
+$uri2 = new \Uri\Rfc3986\Uri("HTTPS://example.com");
+
+var_dump($uri1->equals($uri2));
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+bool(true)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::equals</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/getfragment.xml
+++ b/reference/uri/uri/rfc3986/uri/getfragment.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+
+<refentry xml:id="uri-rfc3986-uri.getfragment" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::getFragment</refname>
+  <refpurpose>正規化されたフラグメントコンポーネントを取得する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\Rfc3986\Uri::getFragment</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   正規化されたフラグメントコンポーネントを取得します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   フラグメントコンポーネントが存在する場合は正規化されたフラグメントコンポーネントを &string; として返し、存在しない場合は &null; を返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.getfragment.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::getFragment</methodname> の基本的な例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com#foo=bar");
+
+echo $uri->getFragment();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+foo=bar
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getRawFragment</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withFragment</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getFragment</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/gethost.xml
+++ b/reference/uri/uri/rfc3986/uri/gethost.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+
+<refentry xml:id="uri-rfc3986-uri.gethost" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::getHost</refname>
+  <refpurpose>正規化されたホストコンポーネントを取得する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\Rfc3986\Uri::getHost</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   正規化されたホストコンポーネントを取得します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   ホストコンポーネントが存在する場合は正規化されたホストコンポーネントを &string; として返し、存在しない場合は &null; を返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.gethost.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::getHost</methodname> の基本的な例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com");
+
+echo $uri->getHost();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+example.com
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getRawHost</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withHost</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getAsciiHost</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getUnicodeHost</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/getpassword.xml
+++ b/reference/uri/uri/rfc3986/uri/getpassword.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: c5ff5efb9c44487de448c0294af6f6b214f87594 Maintainer: KentarouTakeda Status: ready -->
+
+<refentry xml:id="uri-rfc3986-uri.getpassword" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::getPassword</refname>
+  <refpurpose>正規化されたパスワードを取得する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\Rfc3986\Uri::getPassword</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   ユーザー情報コンポーネントから、正規化されたパスワードの部分（最初の <literal>:</literal> 文字より後ろのテキスト）を取得します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   ユーザー情報コンポーネントが <literal>:</literal> 文字を含む場合は、正規化されたパスワードを &string; として返します。
+   ユーザー情報コンポーネントが <literal>:</literal> 文字を含まない場合は、空文字列を返します。
+   ユーザー情報コンポーネントが存在しない場合は &null; を返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.getpassword.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::getPassword</methodname> の基本的な例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://user:password@example.com");
+
+echo $uri->getPassword();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+password
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getRawPassword</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getRawUserInfo</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getUserInfo</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withPassword</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getPassword</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/getpath.xml
+++ b/reference/uri/uri/rfc3986/uri/getpath.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: c5ff5efb9c44487de448c0294af6f6b214f87594 Maintainer: KentarouTakeda Status: ready -->
+
+<refentry xml:id="uri-rfc3986-uri.getpath" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::getPath</refname>
+  <refpurpose>正規化されたパスコンポーネントを取得する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type>string</type><methodname>Uri\Rfc3986\Uri::getPath</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   正規化されたパスコンポーネントを取得します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   正規化されたパスコンポーネントを &string; として返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.getpath.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::getPath</methodname> の基本的な例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com/foo/bar");
+
+echo $uri->getPath();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+/foo/bar
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getRawPath</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withPath</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getPath</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/getport.xml
+++ b/reference/uri/uri/rfc3986/uri/getport.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: c5ff5efb9c44487de448c0294af6f6b214f87594 Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.getport" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::getPort</refname>
+  <refpurpose>正規化されたポートコンポーネントを取得する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type class="union"><type>int</type><type>null</type></type><methodname>Uri\Rfc3986\Uri::getPort</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   正規化されたポートコンポーネントを取得します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   ポートコンポーネントが存在する場合は正規化されたポートコンポーネントを &integer; として返し、存在しない場合は &null; を返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.getport.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::getPort</methodname> の基本的な例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com:443");
+
+echo $uri->getPort();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+443
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::withPort</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getPort</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/getquery.xml
+++ b/reference/uri/uri/rfc3986/uri/getquery.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: c5ff5efb9c44487de448c0294af6f6b214f87594 Maintainer: KentarouTakeda Status: ready -->
+
+<refentry xml:id="uri-rfc3986-uri.getquery" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::getQuery</refname>
+  <refpurpose>正規化されたクエリコンポーネントを取得する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\Rfc3986\Uri::getQuery</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   正規化されたクエリコンポーネントを取得します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   クエリコンポーネントが存在する場合は正規化されたクエリコンポーネントを &string; として返し、存在しない場合は &null; を返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.getquery.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::getQuery</methodname> の基本的な例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com?foo=bar");
+
+echo $uri->getQuery();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+foo=bar
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getRawQuery</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withQuery</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getQuery</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/getrawfragment.xml
+++ b/reference/uri/uri/rfc3986/uri/getrawfragment.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: c5ff5efb9c44487de448c0294af6f6b214f87594 Maintainer: KentarouTakeda Status: ready -->
+
+<refentry xml:id="uri-rfc3986-uri.getrawfragment" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::getRawFragment</refname>
+  <refpurpose>正規化されていないフラグメントコンポーネントを取得する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\Rfc3986\Uri::getRawFragment</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   正規化されていないフラグメントコンポーネントを取得します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   フラグメントコンポーネントが存在する場合は正規化されていないフラグメントコンポーネントを &string; として返し、存在しない場合は &null; を返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.getrawfragment.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::getRawFragment</methodname> の基本的な例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com#foo=bar");
+
+echo $uri->getRawFragment();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+foo=bar
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getFragment</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withFragment</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getFragment</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/getrawhost.xml
+++ b/reference/uri/uri/rfc3986/uri/getrawhost.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+
+<refentry xml:id="uri-rfc3986-uri.getrawhost" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::getRawHost</refname>
+  <refpurpose>正規化されていないホストコンポーネントを取得する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\Rfc3986\Uri::getRawHost</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   正規化されていないホストコンポーネントを取得します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   ホストコンポーネントが存在する場合は正規化されていないホストコンポーネントを &string; として返し、存在しない場合は &null; を返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.getrawhost.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::getRawHost</methodname> の基本的な例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com");
+
+echo $uri->getRawHost();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+example.com
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getHost</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withHost</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getAsciiHost</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getUnicodeHost</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/getrawpassword.xml
+++ b/reference/uri/uri/rfc3986/uri/getrawpassword.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+
+<refentry xml:id="uri-rfc3986-uri.getrawpassword" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::getRawPassword</refname>
+  <refpurpose>正規化されていないパスワードを取得する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\Rfc3986\Uri::getRawPassword</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   ユーザー情報コンポーネントから、正規化されていないパスワードの部分（最初の <literal>:</literal> 文字より後ろのテキスト）を取得します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   ユーザー情報コンポーネントが <literal>:</literal> 文字を含む場合は、正規化されていないパスワードを &string; として返します。
+   ユーザー情報コンポーネントが <literal>:</literal> 文字を含まない場合は、空文字列を返します。
+   ユーザー情報コンポーネントが存在しない場合は &null; を返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.getrawpassword.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::getRawPassword</methodname> の基本的な例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://user:password@example.com");
+
+echo $uri->getRawPassword();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+password
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getPassword</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withUserInfo</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getPassword</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/getrawpath.xml
+++ b/reference/uri/uri/rfc3986/uri/getrawpath.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+
+<refentry xml:id="uri-rfc3986-uri.getrawpath" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::getRawPath</refname>
+  <refpurpose>正規化されていないパスコンポーネントを取得する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type>string</type><methodname>Uri\Rfc3986\Uri::getRawPath</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   正規化されていないパスコンポーネントを取得します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   正規化されていないパスコンポーネントを &string; として返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.getrawpath.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::getRawPath</methodname> の基本的な例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com/foo/bar");
+
+echo $uri->getRawPath();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+/foo/bar
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getPath</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withPath</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getPath</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/getrawquery.xml
+++ b/reference/uri/uri/rfc3986/uri/getrawquery.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+
+<refentry xml:id="uri-rfc3986-uri.getrawquery" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::getRawQuery</refname>
+  <refpurpose>正規化されていないクエリコンポーネントを取得する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\Rfc3986\Uri::getRawQuery</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   正規化されていないクエリコンポーネントを取得します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   クエリコンポーネントが存在する場合は正規化されていないクエリコンポーネントを &string; として返し、存在しない場合は &null; を返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.getrawquery.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::getRawQuery</methodname> の基本的な例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com?foo=bar");
+
+echo $uri->getRawQuery();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+foo=bar
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getQuery</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withQuery</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getQuery</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/getrawscheme.xml
+++ b/reference/uri/uri/rfc3986/uri/getrawscheme.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+
+<refentry xml:id="uri-rfc3986-uri.getrawscheme" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::getRawScheme</refname>
+  <refpurpose>正規化されていないスキームコンポーネントを取得する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\Rfc3986\Uri::getRawScheme</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   正規化されていないスキームコンポーネントを取得します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   スキームコンポーネントが存在する場合は正規化されていないスキームコンポーネントを &string; として返し、存在しない場合は &null; を返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.getrawscheme.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::getRawScheme</methodname> の基本的な例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com");
+
+echo $uri->getRawScheme();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+https
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getScheme</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withScheme</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getScheme</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/getrawuserinfo.xml
+++ b/reference/uri/uri/rfc3986/uri/getrawuserinfo.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+
+<refentry xml:id="uri-rfc3986-uri.getrawuserinfo" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::getRawUserInfo</refname>
+  <refpurpose>正規化されていないユーザー情報コンポーネントを取得する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\Rfc3986\Uri::getRawUserInfo</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   正規化されていないユーザー情報コンポーネントを取得します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   ユーザー情報コンポーネントが存在する場合は正規化されていないユーザー情報コンポーネントを &string; として返し、存在しない場合は &null; を返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.getrawuserinfo.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::getRawUserInfo</methodname> の基本的な例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://user:password@example.com");
+
+echo $uri->getRawUserInfo();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+user:password
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getUserInfo</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getUsername</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getPassword</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withUserInfo</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getUsername</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getPassword</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/getrawusername.xml
+++ b/reference/uri/uri/rfc3986/uri/getrawusername.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+
+<refentry xml:id="uri-rfc3986-uri.getrawusername" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::getRawUsername</refname>
+  <refpurpose>正規化されていないユーザー名を取得する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\Rfc3986\Uri::getRawUsername</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   ユーザー情報コンポーネントから、正規化されていないユーザー名の部分
+   （最初の <literal>:</literal> 文字より前のテキスト）を取得します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   ユーザー情報コンポーネントが存在する場合は正規化されていないユーザー名を &string; として返し、存在しない場合は &null; を返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.getrawusername.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::getRawUsername</methodname> の基本的な例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://user:password@example.com");
+
+echo $uri->getRawUsername();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+user
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getRawUserInfo</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getUserInfo</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withUserInfo</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getUsername</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/getscheme.xml
+++ b/reference/uri/uri/rfc3986/uri/getscheme.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+
+<refentry xml:id="uri-rfc3986-uri.getscheme" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::getScheme</refname>
+  <refpurpose>正規化されたスキームコンポーネントを取得する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\Rfc3986\Uri::getScheme</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   正規化されたスキームコンポーネントを取得します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   スキームコンポーネントが存在する場合は正規化されたスキームコンポーネントを &string; として返し、存在しない場合は &null; を返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.getscheme.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::getScheme</methodname> の基本的な例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com");
+
+echo $uri->getScheme();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+https
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getRawScheme</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withScheme</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getScheme</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/getuserinfo.xml
+++ b/reference/uri/uri/rfc3986/uri/getuserinfo.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+
+<refentry xml:id="uri-rfc3986-uri.getuserinfo" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::getUserInfo</refname>
+  <refpurpose>正規化されたユーザー情報コンポーネントを取得する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\Rfc3986\Uri::getUserInfo</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   正規化されたユーザー情報コンポーネントを取得します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   ユーザー情報コンポーネントが存在する場合は正規化されたユーザー情報コンポーネントを &string; として返し、存在しない場合は &null; を返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.getuserinfo.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::getUserInfo</methodname> の基本的な例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://user:password@example.com");
+
+echo $uri->getUserInfo();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+user:password
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getRawUserInfo</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getRawUsername</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getUsername</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getRawPassword</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getPassword</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withUserInfo</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getUsername</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getPassword</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/getusername.xml
+++ b/reference/uri/uri/rfc3986/uri/getusername.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+
+<refentry xml:id="uri-rfc3986-uri.getusername" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::getUsername</refname>
+  <refpurpose>正規化されたユーザー名を取得する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\Rfc3986\Uri::getUsername</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   ユーザー情報コンポーネントから、正規化されたユーザー名の部分
+   （最初の <literal>:</literal> 文字より前のテキスト）を取得します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   ユーザー情報コンポーネントが存在する場合は正規化されたユーザー名を &string; として返し、存在しない場合は &null; を返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.getusername.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::getUsername</methodname> の基本的な例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://user:password@example.com");
+
+echo $uri->getUsername();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+user
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getRawUsername</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getRawUserInfo</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getUserInfo</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withUserInfo</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getUsername</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/parse.xml
+++ b/reference/uri/uri/rfc3986/uri/parse.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.parse" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::parse</refname>
+  <refpurpose>URI をパースする</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>static</type><type>null</type></type><methodname>Uri\Rfc3986\Uri::parse</methodname>
+   <methodparam><type>string</type><parameter>uri</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>Uri\Rfc3986\Uri</type><type>null</type></type><parameter>baseUrl</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   URI をパースします。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>uri</parameter></term>
+    <listitem>
+     <simpara>
+      パースする URI。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>baseUrl</parameter></term>
+    <listitem>
+     <simpara>
+      &string; が渡された場合、<parameter>uri</parameter> が相対参照であれば、
+      <parameter>uri</parameter> を <parameter>baseUrl</parameter> に適用します。
+      &null; が渡されるか、<parameter>uri</parameter> が相対参照でない場合、
+      <parameter>baseUrl</parameter> は効果を持ちません。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   成功した場合は <classname>Uri\Rfc3986\Uri</classname> インスタンスを返し、失敗した場合は &null; を返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.parse.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::parse</methodname> の基本的な例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = \Uri\Rfc3986\Uri::parse("https://example.com");
+
+if ($uri !== null) {
+    echo "Valid URI: " . $uri->toString();
+} else {
+    echo "Invalid URI"
+}
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+Valid URI: https://example.com
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::__construct</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::resolve</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::parse</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/resolve.xml
+++ b/reference/uri/uri/rfc3986/uri/resolve.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+
+<refentry xml:id="uri-rfc3986-uri.resolve" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::resolve</refname>
+  <refpurpose>現在のオブジェクトをベース URL として URI を解決する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type>static</type><methodname>Uri\Rfc3986\Uri::resolve</methodname>
+   <methodparam><type>string</type><parameter>uri</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   現在のオブジェクトをベース URL として URI（相対参照である可能性もあります）を解決します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>uri</parameter></term>
+    <listitem>
+     <simpara>
+      現在のオブジェクトに適用する URI。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   新しい <classname>Uri\Rfc3986\Uri</classname> インスタンス。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUriException;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.resolve.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::resolve</methodname> の基本的な例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com");
+$uri = $uri->resolve("/foo");
+
+echo $uri->toRawString();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+https://example.com/foo
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::__construct</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::parse</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::resolve</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/serialize.xml
+++ b/reference/uri/uri/rfc3986/uri/serialize.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+
+<refentry xml:id="uri-rfc3986-uri.serialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::__serialize</refname>
+  <refpurpose>Uri オブジェクトをシリアライズする</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type>array</type><methodname>Uri\Rfc3986\Uri::__serialize</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   <classname>Uri\Rfc3986\Uri</classname> オブジェクトをシリアライズします。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   シリアライズされた URI を &string; として返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::__unserialize</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::__serialize</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/torawstring.xml
+++ b/reference/uri/uri/rfc3986/uri/torawstring.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+
+<refentry xml:id="uri-rfc3986-uri.torawstring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::toRawString</refname>
+  <refpurpose>正規化されていない URI を再構築する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type>string</type><methodname>Uri\Rfc3986\Uri::toRawString</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   正規化されていない URI を &string; として再構築します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   再構築された正規化されていない URI を &string; として返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.torawstring.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::toRawString</methodname> の基本的な例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com/foo/bar?baz");
+
+echo $uri->toRawString();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+https://example.com/foo/bar?baz
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::toString</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::toAsciiString</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::toUnicodeString</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/tostring.xml
+++ b/reference/uri/uri/rfc3986/uri/tostring.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+
+<refentry xml:id="uri-rfc3986-uri.tostring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::toString</refname>
+  <refpurpose>正規化された URI を再構築する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type>string</type><methodname>Uri\Rfc3986\Uri::toString</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   正規化された URI を &string; として再構築します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   再構築された正規化された URI を &string; として返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.tostring.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::toString</methodname> の基本的な例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com/foo/bar?baz");
+
+echo $uri->toString();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+https://example.com/foo/bar?baz
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::toRawString</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::toAsciiString</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::toUnicodeString</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/unserialize.xml
+++ b/reference/uri/uri/rfc3986/uri/unserialize.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+
+<refentry xml:id="uri-rfc3986-uri.unserialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::__unserialize</refname>
+  <refpurpose>data パラメータを Uri オブジェクトにアンシリアライズする</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type>void</type><methodname>Uri\Rfc3986\Uri::__unserialize</methodname>
+   <methodparam><type>array</type><parameter>data</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   <parameter>data</parameter> パラメータを <classname>Uri\Rfc3986\Uri</classname> オブジェクトにアンシリアライズします。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>data</parameter></term>
+    <listitem>
+     <simpara>
+      <type>array</type> 形式の、シリアライズされたデータ。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.void;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   既に初期化済みの URI に対して <methodname>__unserialize</methodname> メソッドが呼ばれた場合、<exceptionname>Error</exceptionname>
+   がスローされます。
+  </simpara>
+
+  &uri.errors.invalidUriException;
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::__serialize</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::__unserialize</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/withfragment.xml
+++ b/reference/uri/uri/rfc3986/uri/withfragment.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+
+<refentry xml:id="uri-rfc3986-uri.withfragment" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::withFragment</refname>
+  <refpurpose>フラグメントコンポーネントを変更する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type>static</type><methodname>Uri\Rfc3986\Uri::withFragment</methodname>
+   <methodparam><type class="union"><type>string</type><type>null</type></type><parameter>fragment</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   新しい URI を作成し、そのフラグメントコンポーネントを変更します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>fragment</parameter></term>
+    <listitem>
+     <simpara>
+      新しいフラグメントコンポーネント。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   変更された <classname>Uri\Rfc3986\Uri</classname> インスタンス。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUriException;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.withfragment.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::withFragment</methodname> の基本的な例</title>
+   <programlisting role="php">
+<![CDATA[
+$uri = new \Uri\Rfc3986\Uri("https://example.com/#foo");
+$uri = $uri->withFragment("bar");
+
+echo $uri->getFragment();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+bar
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getFragment</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getRawFragment</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::withFragment</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/withhost.xml
+++ b/reference/uri/uri/rfc3986/uri/withhost.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+
+<refentry xml:id="uri-rfc3986-uri.withhost" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::withHost</refname>
+  <refpurpose>ホストコンポーネントを変更する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type>static</type><methodname>Uri\Rfc3986\Uri::withHost</methodname>
+   <methodparam><type class="union"><type>string</type><type>null</type></type><parameter>host</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   新しい URI を作成し、そのホストコンポーネントを変更します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>host</parameter></term>
+    <listitem>
+     <simpara>
+      新しいホストコンポーネント。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   変更された <classname>Uri\Rfc3986\Uri</classname> インスタンス。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUriException;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.withhost.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::withHost</methodname> の基本的な例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com");
+$uri = $uri->withHost("example.net");
+
+echo $uri->getHost();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+example.net
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getHost</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getRawHost</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::withHost</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/withpath.xml
+++ b/reference/uri/uri/rfc3986/uri/withpath.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+
+<refentry xml:id="uri-rfc3986-uri.withpath" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::withPath</refname>
+  <refpurpose>パスコンポーネントを変更する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type>static</type><methodname>Uri\Rfc3986\Uri::withPath</methodname>
+   <methodparam><type>string</type><parameter>path</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   新しい URI を作成し、そのパスコンポーネントを変更します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>path</parameter></term>
+    <listitem>
+     <simpara>
+      新しいパスコンポーネント。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   変更された <classname>Uri\Rfc3986\Uri</classname> インスタンス。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUriException;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.withpath.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::withPath</methodname> の基本的な例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com/foo/bar");
+$uri = $uri->withPath("/baz");
+
+echo $uri->getPath();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+/baz
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getPath</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getRawPath</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::withPath</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/withport.xml
+++ b/reference/uri/uri/rfc3986/uri/withport.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.withport" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::withPort</refname>
+  <refpurpose>ポートコンポーネントを変更する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type>static</type><methodname>Uri\Rfc3986\Uri::withPort</methodname>
+   <methodparam><type class="union"><type>int</type><type>null</type></type><parameter>port</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   新しい URI を作成し、そのポートコンポーネントを変更します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>port</parameter></term>
+    <listitem>
+     <simpara>
+      新しいポートコンポーネント。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   変更された <classname>Uri\Rfc3986\Uri</classname> インスタンス。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUriException;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.withport.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::withPort</methodname> の基本的な例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com:8080");
+$uri = $uri->withPort(443);
+
+echo $uri->getPort();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+443
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getPort</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::withPort</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/withquery.xml
+++ b/reference/uri/uri/rfc3986/uri/withquery.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+
+<refentry xml:id="uri-rfc3986-uri.withquery" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::withQuery</refname>
+  <refpurpose>クエリコンポーネントを変更する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type>static</type><methodname>Uri\Rfc3986\Uri::withQuery</methodname>
+   <methodparam><type class="union"><type>string</type><type>null</type></type><parameter>query</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   新しい URI を作成し、そのクエリコンポーネントを変更します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>query</parameter></term>
+    <listitem>
+     <simpara>
+      新しいクエリコンポーネント。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   変更された <classname>Uri\Rfc3986\Uri</classname> インスタンス。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUriException;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.withquery.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::withQuery</methodname> の基本的な例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com?foo=bar");
+$uri = $uri->withQuery("foo=baz");
+
+echo $uri->getQuery();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+foo=baz
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getRawQuery</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getQuery</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::withQuery</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/withscheme.xml
+++ b/reference/uri/uri/rfc3986/uri/withscheme.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="uri-rfc3986-uri.withscheme" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::withScheme</refname>
+  <refpurpose>スキームコンポーネントを変更する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type>static</type><methodname>Uri\Rfc3986\Uri::withScheme</methodname>
+   <methodparam><type class="union"><type>string</type><type>null</type></type><parameter>scheme</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   新しい URI を作成し、そのスキームコンポーネントを変更します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>scheme</parameter></term>
+    <listitem>
+     <simpara>
+      新しいスキームコンポーネント。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   変更された <classname>Uri\Rfc3986\Uri</classname> インスタンス。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUriException;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.withscheme.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::withScheme</methodname> の基本的な例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://example.com");
+$uri = $uri->withScheme("http");
+
+echo $uri->getScheme();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+http
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getRawScheme</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getScheme</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::withScheme</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/rfc3986/uri/withuserinfo.xml
+++ b/reference/uri/uri/rfc3986/uri/withuserinfo.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+
+<refentry xml:id="uri-rfc3986-uri.withuserinfo" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\Rfc3986\Uri::withUserInfo</refname>
+  <refpurpose>ユーザー情報コンポーネントを変更する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\Rfc3986\\Uri">
+   <modifier>public</modifier> <type>static</type><methodname>Uri\Rfc3986\Uri::withUserInfo</methodname>
+   <methodparam><modifier role="attribute">#[\SensitiveParameter]</modifier><type class="union"><type>string</type><type>null</type></type><parameter>userinfo</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   新しい URI を作成し、そのユーザー情報コンポーネントを変更します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>userinfo</parameter></term>
+    <listitem>
+     <simpara>
+      新しいユーザー情報コンポーネント。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   変更された <classname>Uri\Rfc3986\Uri</classname> インスタンス。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUriException;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-rfc3986-uri.withuserinfo.example.basic">
+   <title><methodname>Uri\Rfc3986\Uri::withUserInfo</methodname> の基本的な例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$uri = new \Uri\Rfc3986\Uri("https://user:password@example.com");
+$uri = $uri->withUserInfo("userinfo");
+
+echo $uri->getUserInfo();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+userinfo
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::getRawUserInfo</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getUserInfo</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getRawUsername</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getUsername</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getRawPassword</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getPassword</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::withUsername</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::withPassword</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/invalidurlexception/construct.xml
+++ b/reference/uri/uri/whatwg/invalidurlexception/construct.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="uri-whatwg-invalidurlexception.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\InvalidUrlException::__construct</refname>
+  <refpurpose>InvalidUrlException オブジェクトを構築する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <constructorsynopsis role="Uri\\WhatWg\\InvalidUrlException">
+   <modifier>public</modifier> <methodname>Uri\WhatWg\InvalidUrlException::__construct</methodname>
+   <methodparam choice="opt"><type>string</type><parameter>message</parameter><initializer>""</initializer></methodparam>
+   <methodparam choice="opt"><type>array</type><parameter>errors</parameter><initializer>[]</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>code</parameter><initializer>0</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>Throwable</type><type>null</type></type><parameter>previous</parameter><initializer>&null;</initializer></methodparam>
+  </constructorsynopsis>
+  <simpara>
+   <classname>Uri\WhatWg\InvalidUrlException</classname> オブジェクトを構築します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>message</parameter></term>
+    <listitem>
+     <simpara>
+      例外メッセージ。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>errors</parameter></term>
+    <listitem>
+     <simpara>
+      <classname>Uri\WhatWg\UrlValidationError</classname> オブジェクトの &array;。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>code</parameter></term>
+    <listitem>
+     <simpara>
+      例外コード。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>previous</parameter></term>
+    <listitem>
+     <simpara>
+      例外チェーン用の直前の例外。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/construct.xml
+++ b/reference/uri/uri/whatwg/url/construct.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="uri-whatwg-url.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::__construct</refname>
+  <refpurpose>Url オブジェクトを構築する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <constructorsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <methodname>Uri\WhatWg\Url::__construct</methodname>
+   <methodparam><type>string</type><parameter>uri</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>Uri\WhatWg\Url</type><type>null</type></type><parameter>baseUrl</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type>array</type><parameter role="reference">softErrors</parameter><initializer>&null;</initializer></methodparam>
+  </constructorsynopsis>
+  <simpara>
+   <classname>Uri\Rfc3986\Uri</classname> オブジェクトを構築します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>uri</parameter></term>
+    <listitem>
+     <simpara>
+      パースする有効な URL 文字列（例: <literal>/foo</literal> や (例: <literal>https://example.com/foo</literal>)。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>baseUrl</parameter></term>
+    <listitem>
+     <simpara>
+      &string; が渡された場合、<parameter>uri</parameter> が相対 URL 文字列であれば、
+      <parameter>uri</parameter> を <parameter>baseUrl</parameter> に適用します。
+      &null; が渡されるか、<parameter>uri</parameter> が相対 URL 文字列でない場合、
+      <parameter>baseUrl</parameter> は効果を持ちません。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>softErrors</parameter></term>
+    <listitem>
+     <simpara>
+      パース中に発生したエラーの詳細情報を提供するために、
+      <classname>Uri\WhatWg\UrlValidationError</classname> インスタンスのリストを参照渡しするための &array;。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUrlException;
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::parse</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::resolve</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::__construct</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/debuginfo.xml
+++ b/reference/uri/uri/whatwg/url/debuginfo.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+
+<refentry xml:id="uri-whatwg-url.debuginfo" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::__debugInfo</refname>
+  <refpurpose>URL の内部状態を返す</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type>array</type><methodname>Uri\WhatWg\Url::__debugInfo</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   URL の内部状態を返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   URL の内部状態を &array; として返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::__debugInfo</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/equals.xml
+++ b/reference/uri/uri/whatwg/url/equals.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+
+<refentry xml:id="uri-whatwg-url.equals" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::equals</refname>
+  <refpurpose>2 つの URL が等価かを判定する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type>bool</type><methodname>Uri\WhatWg\Url::equals</methodname>
+   <methodparam><type>Uri\WhatWg\Url</type><parameter>url</parameter></methodparam>
+   <methodparam choice="opt"><type>Uri\UriComparisonMode</type><parameter>comparisonMode</parameter><initializer><constant>Uri\UriComparisonMode::ExcludeFragment</constant></initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   2 つの URL が等価かを判定します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>url</parameter></term>
+    <listitem>
+     <simpara>
+      現在の URL と比較する URL。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>comparisonMode</parameter></term>
+    <listitem>
+     <simpara>
+      フラグメントコンポーネントを比較の対象に含めるか
+      (<literal>Uri\UriComparisonMode::IncludeFragment</literal>)、含めないか
+      (<literal>Uri\UriComparisonMode::ExcludeFragment</literal>)。デフォルトでは、フラグメントは除外されます。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   2 つの URL が等価である場合は &true; を、そうでない場合は &false; を返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.equals.example.basic">
+   <title><methodname>Uri\WhatWg\Url::equals</methodname> の基本的な例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url1 = new \Uri\WhatWg\Url("https://example.com");
+$url2 = new \Uri\WhatWg\Url("HTTPS://example.com");
+
+var_dump($url1->equals($url2));
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+bool(true)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\Rfc3986\Uri::equals</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/getasciihost.xml
+++ b/reference/uri/uri/whatwg/url/getasciihost.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="uri-whatwg-url.getasciihost" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::getAsciiHost</refname>
+  <refpurpose>ホストコンポーネントを ASCII &string; として取得する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\WhatWg\Url::getAsciiHost</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Unicode 文字ではなく Punycode による変換を使用して、ホストコンポーネントを &string; として取得します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   ホストコンポーネントが存在する場合は ASCII &string; としてホストコンポーネントを返し、存在しない場合は &null; を返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.getasciihost.example.basic">
+   <title><methodname>Uri\WhatWg\Url::getAsciiHost</methodname> の基本的な例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://example.com");
+
+echo $url->getAsciiHost();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+example.com
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::getUnicodeHost</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::withHost</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getRawHost</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getHost</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/getfragment.xml
+++ b/reference/uri/uri/whatwg/url/getfragment.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="uri-whatwg-url.getfragment" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::getFragment</refname>
+  <refpurpose>フラグメントコンポーネントを取得する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\WhatWg\Url::getFragment</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   フラグメントコンポーネントを取得します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   フラグメントコンポーネントが存在する場合は &string; としてフラグメントコンポーネントを返し、存在しない場合は &null; を返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.getfragment.example.basic">
+   <title><methodname>Uri\WhatWg\Url::getFragment</methodname> の基本的な例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://example.com#foo");
+
+echo $url->getFragment();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+foo
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::withFragment</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getRawFragment</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getFragment</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/getpassword.xml
+++ b/reference/uri/uri/whatwg/url/getpassword.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="uri-whatwg-url.getpassword" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::getPassword</refname>
+  <refpurpose>パスワードコンポーネントを取得する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\WhatWg\Url::getPassword</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   パスワードコンポーネントを取得します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   パスワードコンポーネントが存在する場合は &string; としてパスワードコンポーネントを返し、存在しない場合は &null; を返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.getpassword.example.basic">
+   <title><methodname>Uri\WhatWg\Url::getPassword</methodname> の基本的な例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://user:password@example.com");
+
+echo $url->getPassword();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+password
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::withPassword</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getRawPassword</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getPassword</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/getpath.xml
+++ b/reference/uri/uri/whatwg/url/getpath.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="uri-whatwg-url.getpath" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::getPath</refname>
+  <refpurpose>パスコンポーネントを取得する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type>string</type><methodname>Uri\WhatWg\Url::getPath</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   パスコンポーネントを取得します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   パスコンポーネントを &string; として返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.getpath.example.basic">
+   <title><methodname>Uri\WhatWg\Url::getPath</methodname> の基本的な例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://example.com/foo/bar");
+
+echo $url->getPath();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+/foo/bar
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::withPath</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getRawPath</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getPath</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/getport.xml
+++ b/reference/uri/uri/whatwg/url/getport.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: a00f03a6131b0b74c851b06879c528fc9537da8c Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="uri-whatwg-url.getport" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::getPort</refname>
+  <refpurpose>ポートコンポーネントを取得する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type class="union"><type>int</type><type>null</type></type><methodname>Uri\WhatWg\Url::getPort</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   ポートコンポーネントを取得します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   ポートコンポーネントが存在する場合は &integer; としてポートコンポーネントを返し、存在しない場合は &null; を返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.getport.example.basic">
+   <title><methodname>Uri\WhatWg\Url::getPort</methodname> の基本的な例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://example.com:443");
+
+echo $url->getPort();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+443
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::withPort</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getPort</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/getquery.xml
+++ b/reference/uri/uri/whatwg/url/getquery.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="uri-whatwg-url.getquery" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::getQuery</refname>
+  <refpurpose>クエリコンポーネントを取得する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\WhatWg\Url::getQuery</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   クエリコンポーネントを取得します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   クエリコンポーネントが存在する場合は &string; としてクエリコンポーネントを返し、存在しない場合は &null; を返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.getquery.example.basic">
+   <title><methodname>Uri\WhatWg\Url::getQuery</methodname> の基本的な例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://example.com?foo/bar");
+
+echo $url->getQuery();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+foo=bar
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::withQuery</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getRawQuery</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getQuery</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/getscheme.xml
+++ b/reference/uri/uri/whatwg/url/getscheme.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="uri-whatwg-url.getscheme" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::getScheme</refname>
+  <refpurpose>スキームコンポーネントを取得する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type>string</type><methodname>Uri\WhatWg\Url::getScheme</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   スキームコンポーネントを取得します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   スキームコンポーネントが存在する場合は &string; としてスキームコンポーネントを返し、存在しない場合は &null; を返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.getscheme.example.basic">
+   <title><methodname>Uri\WhatWg\Url::getScheme</methodname> の基本的な例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://example.com");
+
+echo $url->getScheme();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+https
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::withScheme</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getRawScheme</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getScheme</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/getunicodehost.xml
+++ b/reference/uri/uri/whatwg/url/getunicodehost.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="uri-whatwg-url.getunicodehost" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::getUnicodeHost</refname>
+  <refpurpose>ホストコンポーネントを Unicode &string; として取得する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\WhatWg\Url::getUnicodeHost</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   ホストコンポーネントを &string; として取得します。Unicode 文字を含む可能性があります。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   ホストコンポーネントが存在する場合は Unicode &string; としてホストコンポーネントを返し、存在しない場合は &null; を返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.getunicodehost.example.basic">
+   <title><methodname>Uri\WhatWg\Url::getUnicodeHost</methodname> の基本的な例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://example.com");
+
+echo $url->getUnicodeHost();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+example.com
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::getAsciiHost</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::withHost</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getRawHost</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getHost</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/getusername.xml
+++ b/reference/uri/uri/whatwg/url/getusername.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="uri-whatwg-url.getusername" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::getUsername</refname>
+  <refpurpose>ユーザー名コンポーネントを取得する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\WhatWg\Url::getUsername</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   ユーザー名コンポーネントを取得します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   ユーザー名コンポーネントが存在する場合は &string; としてユーザー名コンポーネントを返し、存在しない場合は &null; を返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.getusername.example.basic">
+   <title><methodname>Uri\WhatWg\Url::getUsername</methodname> の基本的な例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://username:password@example.com");
+
+echo $url->getUsername();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+username
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::withUsername</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getRawUsername</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getUsername</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/parse.xml
+++ b/reference/uri/uri/whatwg/url/parse.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="uri-whatwg-url.parse" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::parse</refname>
+  <refpurpose>URL をパースする</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>static</type><type>null</type></type><methodname>Uri\WhatWg\Url::parse</methodname>
+   <methodparam><type>string</type><parameter>uri</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>Uri\WhatWg\Url</type><type>null</type></type><parameter>baseUrl</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type>array</type><parameter role="reference">errors</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   URL をパースします。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>uri</parameter></term>
+    <listitem>
+     <simpara>
+      パースする有効な URL 文字列（例: <literal>/foo</literal> や (例: <literal>https://example.com/foo</literal>)。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>baseUrl</parameter></term>
+    <listitem>
+     <simpara>
+      &string; が渡された場合、<parameter>uri</parameter> が相対 URL 文字列であれば、
+      <parameter>uri</parameter> を <parameter>baseUrl</parameter> に適用します。
+      &null; が渡されるか、<parameter>uri</parameter> が相対 URL 文字列でない場合、
+      <parameter>baseUrl</parameter> は効果を持ちません。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>errors</parameter></term>
+    <listitem>
+     <simpara>
+      パース中に発生したエラーの詳細情報を提供するために、
+      <classname>Uri\WhatWg\UrlValidationError</classname> インスタンスのリストを参照渡しするための &array;。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   成功した場合は <classname>Uri\WhatWg\Url</classname> インスタンスを返し、失敗した場合は &null; を返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.parse.example.basic">
+   <title><methodname>Uri\WhatWg\Url::parse</methodname> の基本的な例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = \Uri\WhatWg\Url::parse("https://example.com");
+
+if ($url !== null) {
+    echo "Valid URL: " . $url->toAsciiString();
+} else {
+    echo "Invalid URL"
+}
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+Valid URL: https://example.com
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::__construct</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::resolve</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::parse</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/resolve.xml
+++ b/reference/uri/uri/whatwg/url/resolve.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+
+<refentry xml:id="uri-whatwg-url.resolve" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::resolve</refname>
+  <refpurpose>現在のオブジェクトをベース URL として URL を解決する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type>static</type><methodname>Uri\WhatWg\Url::resolve</methodname>
+   <methodparam><type>string</type><parameter>uri</parameter></methodparam>
+   <methodparam choice="opt"><type>array</type><parameter role="reference">softErrors</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   現在のオブジェクトをベース URL として、有効な URL 文字列（相対 URL 文字列である可能性もあります）を解決します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>uri</parameter></term>
+    <listitem>
+     <simpara>
+      現在のオブジェクトに適用する有効な URL 文字列（例: <literal>/foo</literal> や <literal>https://example.com/foo</literal>）。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>softErrors</parameter></term>
+    <listitem>
+     <simpara>
+      参照解決中に発生したソフトエラーの詳細情報を提供するために、
+      <classname>Uri\WhatWg\UrlValidationError</classname> インスタンスのリストを参照渡しするための &array;。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   新しい <classname>Uri\WhatWg\Url</classname> インスタンス。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUrlException;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.resolve.example.basic">
+   <title><methodname>Uri\WhatWg\Url::resolve</methodname> の基本的な例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://example.com");
+$url = $url->resolve("/foo");
+
+echo $url->toAsciiString();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+https://example.com/foo
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::__construct</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::parse</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::resolve</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/serialize.xml
+++ b/reference/uri/uri/whatwg/url/serialize.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+
+<refentry xml:id="uri-whatwg-url.serialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::__serialize</refname>
+  <refpurpose>Url オブジェクトをシリアライズする</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type>array</type><methodname>Uri\WhatWg\Url::__serialize</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   <classname>Uri\WhatWg\Url</classname> オブジェクトをシリアライズします。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   シリアライズされた URL を &array; として返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::__unserialize</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::__serialize</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/toasciistring.xml
+++ b/reference/uri/uri/whatwg/url/toasciistring.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="uri-whatwg-url.toasciistring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::toAsciiString</refname>
+  <refpurpose>URL を ASCII &string; として再構築する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type>string</type><methodname>Uri\WhatWg\Url::toAsciiString</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   ホストコンポーネントで Unicode 文字ではなく Punycode による変換を使用して、URL を ASCII &string; として再構築します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   再構築された URL を ASCII &string; として返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.toasciistring.example.basic">
+   <title><methodname>Uri\WhatWg\Url::toAsciiString</methodname> の基本的な例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://example.com/foo/bar?baz");
+
+echo $url->toAsciiString();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+https://example.com/foo/bar?baz
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::toUnicodeString</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::toRawString</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::toString</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/tounicodestring.xml
+++ b/reference/uri/uri/whatwg/url/tounicodestring.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="uri-whatwg-url.tounicodestring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::toUnicodeString</refname>
+  <refpurpose>URL を Unicode &string; として再構築する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type>string</type><methodname>Uri\WhatWg\Url::toUnicodeString</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   URL を &string; として再構築します。ホストコンポーネントには Unicode 文字が含まれる可能性があります。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   再構築された URL を Unicode &string; として返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.tounicodestring.example.basic">
+   <title><methodname>Uri\WhatWg\Url::toUnicodeString</methodname> の基本的な例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://example.com/foo/bar?baz");
+
+echo $url->toUnicodeString();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+https://example.com/foo/bar?baz
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::toAsciiString</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::toRawString</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::toString</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/unserialize.xml
+++ b/reference/uri/uri/whatwg/url/unserialize.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+
+<refentry xml:id="uri-whatwg-url.unserialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::__unserialize</refname>
+  <refpurpose>data パラメータを Url オブジェクトにアンシリアライズする</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type>void</type><methodname>Uri\WhatWg\Url::__unserialize</methodname>
+   <methodparam><type>array</type><parameter>data</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   <parameter>data</parameter> パラメータを <classname>Uri\WhatWg\Url</classname> オブジェクトにアンシリアライズします。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>data</parameter></term>
+    <listitem>
+     <simpara>
+      <type>array</type> 形式の、シリアライズされたデータ。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.void;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   既に初期化済みの URL に対して <methodname>__unserialize</methodname> メソッドが呼ばれた場合、<exceptionname>Error</exceptionname>
+   がスローされます。
+  </simpara>
+
+  &uri.errors.invalidUriException;
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::__serialize</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::__unserialize</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/withfragment.xml
+++ b/reference/uri/uri/whatwg/url/withfragment.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="uri-whatwg-url.withfragment" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::withFragment</refname>
+  <refpurpose>フラグメントコンポーネントを変更する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type>static</type><methodname>Uri\WhatWg\Url::withFragment</methodname>
+   <methodparam><type class="union"><type>string</type><type>null</type></type><parameter>fragment</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   新しい URL を作成し、そのフラグメントコンポーネントを変更します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>fragment</parameter></term>
+    <listitem>
+     <simpara>
+      新しいフラグメントコンポーネント。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   変更された <classname>Uri\WhatWg\Url</classname> インスタンス。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUrlException;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.withfragment.example.basic">
+   <title><methodname>Uri\WhatWg\Url::withFragment</methodname> の基本的な例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://example.com/#foo");
+$url = $url->withFragment("bar");
+
+echo $url->getFragment();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+bar
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::getFragment</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withFragment</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/withhost.xml
+++ b/reference/uri/uri/whatwg/url/withhost.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+
+<refentry xml:id="uri-whatwg-url.withhost" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::withHost</refname>
+  <refpurpose>ホストコンポーネントを変更する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type>static</type><methodname>Uri\WhatWg\Url::withHost</methodname>
+   <methodparam><type class="union"><type>string</type><type>null</type></type><parameter>host</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   新しい URL を作成し、そのホストコンポーネントを変更します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>host</parameter></term>
+    <listitem>
+     <simpara>
+      新しいホストコンポーネント。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   変更された <classname>Uri\WhatWg\Url</classname> インスタンス。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUrlException;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.withhost.example.basic">
+   <title><methodname>Uri\WhatWg\Url::withHost</methodname> の基本的な例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://example.com");
+$url = $url->withHost("example.net");
+
+echo $url->getAsciiHost();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+example.net
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::getAsciiHost</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getUnicodeHost</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withHost</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/withpassword.xml
+++ b/reference/uri/uri/whatwg/url/withpassword.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+
+<refentry xml:id="uri-whatwg-url.withpassword" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::withPassword</refname>
+  <refpurpose>パスワードコンポーネントを変更する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type>static</type><methodname>Uri\WhatWg\Url::withPassword</methodname>
+   <methodparam><modifier role="attribute">#[\SensitiveParameter]</modifier><type class="union"><type>string</type><type>null</type></type><parameter>password</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   新しい URL を作成し、そのパスワードコンポーネントを変更します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>password</parameter></term>
+    <listitem>
+     <simpara>
+      新しいパスワードコンポーネント。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   変更された <classname>Uri\WhatWg\Url</classname> インスタンス。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUrlException;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.withpassword.example.basic">
+   <title><methodname>Uri\WhatWg\Url::withPassword</methodname> の基本的な例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://user:password@example.com");
+$url = $url->withPassword("pass");
+
+echo $url->getPassword();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+pass
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::getPassword</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getUsername</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withUserInfo</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/withpath.xml
+++ b/reference/uri/uri/whatwg/url/withpath.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+
+<refentry xml:id="uri-whatwg-url.withpath" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::withPath</refname>
+  <refpurpose>パスコンポーネントを変更する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type>static</type><methodname>Uri\WhatWg\Url::withPath</methodname>
+   <methodparam><type>string</type><parameter>path</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   新しい URL を作成し、そのパスコンポーネントを変更します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>path</parameter></term>
+    <listitem>
+     <simpara>
+      新しいパスコンポーネント。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   変更された <classname>Uri\WhatWg\Url</classname> インスタンス。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUrlException;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.withpath.example.basic">
+   <title><methodname>Uri\WhatWg\Url::withPath</methodname> の基本的な例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://example.com/foo/bar");
+$url = $url->withPath("/baz");
+
+echo $url->getPath();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+/baz
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::getPath</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withPath</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/withport.xml
+++ b/reference/uri/uri/whatwg/url/withport.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+
+<refentry xml:id="uri-whatwg-url.withport" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::withPort</refname>
+  <refpurpose>ポートコンポーネントを変更する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type>static</type><methodname>Uri\WhatWg\Url::withPort</methodname>
+   <methodparam><type class="union"><type>int</type><type>null</type></type><parameter>port</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   新しい URL を作成し、そのポートコンポーネントを変更します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>port</parameter></term>
+    <listitem>
+     <simpara>
+      新しいポートコンポーネント。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   変更された <classname>Uri\WhatWg\Url</classname> インスタンス。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUrlException;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.withport.example.basic">
+   <title><methodname>Uri\WhatWg\Url::withPort</methodname> の基本的な例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://example.com:8080");
+$url = $url->withPort(443);
+
+echo $url->getPort();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+443
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::getPort</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withPort</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/withquery.xml
+++ b/reference/uri/uri/whatwg/url/withquery.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="uri-whatwg-url.withquery" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::withQuery</refname>
+  <refpurpose>クエリコンポーネントを変更する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type>static</type><methodname>Uri\WhatWg\Url::withQuery</methodname>
+   <methodparam><type class="union"><type>string</type><type>null</type></type><parameter>query</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   新しい URL を作成し、そのクエリコンポーネントを変更します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>query</parameter></term>
+    <listitem>
+     <simpara>
+      新しいクエリコンポーネント。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   変更された <classname>Uri\WhatWg\Url</classname> インスタンス。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUrlException;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.withquery.example.basic">
+   <title><methodname>Uri\WhatWg\Url::withQuery</methodname> の基本的な例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://example.com?foo=bar");
+$url = $url->withQuery("foo=baz");
+
+echo $url->getQuery();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+foo=baz
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::getQuery</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withQuery</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/withscheme.xml
+++ b/reference/uri/uri/whatwg/url/withscheme.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+
+<refentry xml:id="uri-whatwg-url.withscheme" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::withScheme</refname>
+  <refpurpose>スキームコンポーネントを変更する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type>static</type><methodname>Uri\WhatWg\Url::withScheme</methodname>
+   <methodparam><type>string</type><parameter>scheme</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   新しい URL を作成し、そのスキームコンポーネントを変更します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>scheme</parameter></term>
+    <listitem>
+     <simpara>
+      新しいスキームコンポーネント。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   変更された <classname>Uri\WhatWg\Url</classname> インスタンス。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUrlException;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.withscheme.example.basic">
+   <title><methodname>Uri\WhatWg\Url::withScheme</methodname> の基本的な例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://example.com");
+$url = $url->withScheme("http");
+
+echo $url->getScheme();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+http
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::getScheme</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withScheme</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/url/withusername.xml
+++ b/reference/uri/uri/whatwg/url/withusername.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="uri-whatwg-url.withusername" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\Url::withUsername</refname>
+  <refpurpose>ユーザー名コンポーネントを変更する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Uri\\WhatWg\\Url">
+   <modifier>public</modifier> <type>static</type><methodname>Uri\WhatWg\Url::withUsername</methodname>
+   <methodparam><type class="union"><type>string</type><type>null</type></type><parameter>username</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   新しい URL を作成し、そのユーザー名コンポーネントを変更します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>username</parameter></term>
+    <listitem>
+     <simpara>
+      新しいユーザー名コンポーネント。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   変更された <classname>Uri\WhatWg\Url</classname> インスタンス。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &uri.errors.invalidUrlException;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uri-whatwg-url.withusername.example.basic">
+   <title><methodname>Uri\WhatWg\Url::withUsername</methodname> の基本的な例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$url = new \Uri\WhatWg\Url("https://user:password@example.com");
+$url = $url->withUsername("usr");
+
+echo $url->getUsername();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+usr
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Uri\WhatWg\Url::getUsername</methodname></member>
+   <member><methodname>Uri\WhatWg\Url::getPassword</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::withUserInfo</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uri/uri/whatwg/urlvalidationerror/construct.xml
+++ b/reference/uri/uri/whatwg/urlvalidationerror/construct.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: ab4cf5ea8b49c1dac6b09fe6b6fee31eb12c3adc Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="uri-whatwg-urlvalidationerror.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Uri\WhatWg\UrlValidationError::__construct</refname>
+  <refpurpose>UrlValidationError オブジェクトを構築する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <constructorsynopsis role="Uri\\WhatWg\\UrlValidationError">
+   <modifier>public</modifier> <methodname>Uri\WhatWg\UrlValidationError::__construct</methodname>
+   <methodparam><type>string</type><parameter>context</parameter></methodparam>
+   <methodparam><type>Uri\WhatWg\UrlValidationErrorType</type><parameter>type</parameter></methodparam>
+   <methodparam><type>bool</type><parameter>failure</parameter></methodparam>
+  </constructorsynopsis>
+  <simpara>
+   <classname>Uri\WhatWg\UrlValidationError</classname> オブジェクトを構築します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>context</parameter></term>
+    <listitem>
+     <simpara>
+      エラーが検出された時点での入力 URL。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>type</parameter></term>
+    <listitem>
+     <simpara>
+      エラーの種類。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>failure</parameter></term>
+    <listitem>
+     <simpara>
+      &true; の場合、エラーにより URL は不正として拒否されます。&false; の場合、
+      エラーはパース中に自動的に修正されたソフトエラーです。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/url/functions/parse-url.xml
+++ b/reference/url/functions/parse-url.xml
@@ -46,7 +46,7 @@
    </simpara>
    <simpara>
     <classname>Uri\Rfc3986\Uri</classname> クラスと <classname>Uri\WhatWg\Url</classname>
-    クラスは、それぞれ RFC 3986 と WHATWG URL 標準に厳密に従います。
+    クラスは、それぞれ RFC 3986 と WHATWG URL Standard に厳密に従います。
     新しく書くすべてのコードでこれらのクラスを使用し、
     <function>parse_url</function> 関数の既存の使用箇所もこれらのクラスに
     移行することを強く推奨します。


### PR DESCRIPTION
## 概要

PHP 8.5 で追加された URI 拡張モジュール（ext/uri）の新規作成、完訳。

## 内容

- URI 拡張モジュールを完訳: `reference/uri/` 配下に 71 ファイルを新規追加
- 既存翻訳の表記統一: `reference/url/functions/parse-url.xml` 「WHATWG URL 標準」→「WHATWG URL Standard」
- 用語集の追加:
  - `README_Glossary.md` に「WHATWG URL Standard」項目を追加
  - `build/prh.yml` に textlint の prh ルールを追加（「WHATWG URL 標準」を検出して「WHATWG URL Standard」へ自動修正）
- `language-snippets.ent` の同期: `uri.errors.invalidUriException` / `uri.errors.invalidUrlException` の日本語訳を追加（EN-Revision を `330903cf` に追従）