### PR TITLE
Pdo\Sqlite::loadExtension と Pdo\Sqlite::openBlob の新規翻訳

### DIFF
--- a/reference/pdo_sqlite/pdo/sqlite/loadextension.xml
+++ b/reference/pdo_sqlite/pdo/sqlite/loadextension.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 2527c5e374710b5f0db46048d48019eee30c2a94 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="pdo-sqlite.loadextension" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Pdo\Sqlite::loadExtension</refname>
+  <refpurpose>SQLite 拡張ライブラリの読み込みを試みる</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Pdo\\Sqlite">
+   <modifier>public</modifier> <type>void</type><methodname>Pdo\Sqlite::loadExtension</methodname>
+   <methodparam><type>string</type><parameter>name</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   SQLite 拡張ライブラリの読み込みを試みます。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>name</parameter></term>
+    <listitem>
+     <simpara>
+      読み込みたい拡張ライブラリのパス。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.void;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   <parameter>name</parameter> が空文字列だった場合、
+   <classname>ValueError</classname> をスローします。
+  </simpara>
+  <simpara>
+   拡張ライブラリの読み込みに失敗した場合、
+   <classname>PDOException</classname> をスローします。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="pdo-sqlite.loadextension.example.basic">
+   <title><methodname>Pdo\Sqlite::loadExtension</methodname> の例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$db = new Pdo\Sqlite('sqlite::memory:');
+$db->loadExtension('/path/to/libagg.so');
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>SQLite3::loadExtension</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pdo_sqlite/pdo/sqlite/openblob.xml
+++ b/reference/pdo_sqlite/pdo/sqlite/openblob.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 2527c5e374710b5f0db46048d48019eee30c2a94 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="pdo-sqlite.openblob" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Pdo\Sqlite::openBlob</refname>
+  <refpurpose>BLOB を読み書きするためのストリームリソースを開く</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Pdo\\Sqlite">
+   <modifier>public</modifier> <type class="union"><type>resource</type><type>false</type></type><methodname>Pdo\Sqlite::openBlob</methodname>
+   <methodparam><type>string</type><parameter>table</parameter></methodparam>
+   <methodparam><type>string</type><parameter>column</parameter></methodparam>
+   <methodparam><type>int</type><parameter>rowid</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>dbname</parameter><initializer>"main"</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer><constant>Pdo\Sqlite::OPEN_READONLY</constant></initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   BLOB を読み書きするためのストリームリソースを開きます。
+   これは、以下によって選択されます:
+  </simpara>
+  <simpara>
+   SELECT <parameter>column</parameter> FROM <parameter>dbname</parameter>.<parameter>table</parameter> WHERE rowid = <parameter>rowid</parameter>
+  </simpara>
+  <note>
+   <simpara>
+    ストリームに書き込むことで BLOB のサイズを変更することはできません。
+    BLOB のサイズを希望のサイズに設定するには、代わりに UPDATE 文を実行するか、
+    SQLite の zeroblob() 関数を使ってください。
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>table</parameter></term>
+    <listitem>
+     <simpara>
+      テーブル名。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>column</parameter></term>
+    <listitem>
+     <simpara>
+      カラム名。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>rowid</parameter></term>
+    <listitem>
+     <simpara>
+      行 ID。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>dbname</parameter></term>
+    <listitem>
+     <simpara>
+      データベースのシンボリック名。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>flags</parameter></term>
+    <listitem>
+     <simpara>
+      <constant>Pdo\Sqlite::OPEN_<replaceable>*</replaceable></constant>
+      定数のいずれか。
+      <constant>Pdo\Sqlite::OPEN_READONLY</constant> を指定するとストリームを読み取り専用で開き、
+      <constant>Pdo\Sqlite::OPEN_READWRITE</constant> を指定すると読み取りと書き込みができるように開きます。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   ストリームリソースを返します。
+   失敗時には &false; を返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   BLOB を開けない場合、<constant>E_WARNING</constant> レベルのエラーが発生します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="pdo-sqlite.openblob.example.basic">
+   <title><methodname>Pdo\Sqlite::openBlob</methodname> の例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$db = new Pdo\Sqlite('sqlite::memory:');
+$db->exec('CREATE TABLE test (text text)');
+$db->exec("INSERT INTO test VALUES ('Lorem ipsum')");
+$stream = $db->openBlob('test', 'text', 1);
+echo stream_get_contents($stream);
+fclose($stream);
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+Lorem ipsum
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>SQLite3::openBlob</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
PHP 8.4 で `Pdo\Sqlite` クラスに追加された 2 つのメソッドの新規翻訳です。

- `reference/pdo_sqlite/pdo/sqlite/loadextension.xml`
- `reference/pdo_sqlite/pdo/sqlite/openblob.xml`

doc-en の現状はスタブ (php/doc-en@2527c5e3、`Description.` のみ + `&warn.undocumented.func;`) のため、`SQLite3::loadExtension` / `SQLite3::openBlob` の既訳と php-src (`ext/pdo_sqlite/pdo_sqlite.c`、`pdo_sqlite.stub.php`) の挙動を参考に、最小限の説明で翻訳しました。

- `loadExtension` は戻り値が `void` で、失敗時は `PDOException` がスローされます。
- `openBlob` はほぼ `SQLite3::openBlob` と同等で、失敗時に `E_WARNING` が発生し `false` を返します。

ご確認のほど、よろしくお願いいたします。