### PR TITLE
intl/Collator: classname と link が併用された場合の二重アンカータグを修正 (#5547)

### DIFF
--- a/reference/intl/collator/asort.xml
+++ b/reference/intl/collator/asort.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c142be811735a5542c8a2e4c4ed2f81e8cc3acc6 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: e290572f2599305beb62b13988024b5da187979d Maintainer: takagi Status: ready -->
 <refentry xml:id="collator.asort" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>Collator::asort</refname>
@@ -143,7 +143,7 @@ array (
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><link linkend="intl.collator-constants"><classname>Collator</classname> の定数</link></member>
+    <member><link linkend="intl.collator-constants">Collator の定数</link></member>
     <member><function>collator_sort</function></member>
     <member><function>collator_sort_with_sort_keys</function></member>
    </simplelist>

--- a/reference/intl/collator/get-attribute.xml
+++ b/reference/intl/collator/get-attribute.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: e290572f2599305beb62b13988024b5da187979d Maintainer: takagi Status: ready -->
 <refentry xml:id="collator.getattribute" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>Collator::getAttribute</refname>
@@ -88,7 +88,7 @@ if( $val === false )
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><link linkend="intl.collator-constants"><classname>Collator</classname> の定数</link></member>
+    <member><link linkend="intl.collator-constants">Collator の定数</link></member>
     <member><function>collator_set_attribute</function></member>
     <member><function>collator_get_strength</function></member>
    </simplelist>

--- a/reference/intl/collator/get-strength.xml
+++ b/reference/intl/collator/get-strength.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: e290572f2599305beb62b13988024b5da187979d Maintainer: takagi Status: ready -->
 <refentry xml:id="collator.getstrength" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>Collator::getStrength</refname>
@@ -83,7 +83,7 @@ $strength = collator_get_strength( $coll );
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><link linkend="intl.collator-constants"><classname>Collator</classname> の定数</link></member>
+    <member><link linkend="intl.collator-constants">Collator の定数</link></member>
     <member><function>collator_set_strength</function></member>
     <member><function>collator_get_attribute</function></member>
    </simplelist>

--- a/reference/intl/collator/set-attribute.xml
+++ b/reference/intl/collator/set-attribute.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 0194deb3cec8d79ae6b13700f3cd031d14597838 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: e290572f2599305beb62b13988024b5da187979d Maintainer: takagi Status: ready -->
 <refentry xml:id="collator.setattribute" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>Collator::setAttribute</refname>
@@ -90,7 +90,7 @@ collator_set_attribute($coll, Collator::NORMALIZATION_MODE, Collator::ON);
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><link linkend="intl.collator-constants"><classname>Collator</classname> の定数</link></member>
+    <member><link linkend="intl.collator-constants">Collator の定数</link></member>
     <member><function>collator_get_attribute</function></member>
     <member><function>collator_set_strength</function></member>
    </simplelist>

--- a/reference/intl/collator/set-strength.xml
+++ b/reference/intl/collator/set-strength.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 679cf93fa1e54cde82fc9cf545966eb13bcb0638 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: e290572f2599305beb62b13988024b5da187979d Maintainer: takagi Status: ready -->
 <refentry xml:id="collator.setstrength" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Collator::setStrength</refname>
@@ -238,7 +238,7 @@ array (
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><link linkend="intl.collator-constants"><classname>Collator</classname> の定数</link></member>
+    <member><link linkend="intl.collator-constants">Collator の定数</link></member>
     <member><function>collator_get_strength</function></member>
    </simplelist>
   </para>

--- a/reference/intl/collator/sort-with-sort-keys.xml
+++ b/reference/intl/collator/sort-with-sort-keys.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: e290572f2599305beb62b13988024b5da187979d Maintainer: takagi Status: ready -->
 <refentry xml:id="collator.sortwithsortkeys" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>Collator::sortWithSortKeys</refname>
@@ -95,7 +95,7 @@ array (
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><link linkend="intl.collator-constants"><classname>Collator</classname> の定数</link></member>
+    <member><link linkend="intl.collator-constants">Collator の定数</link></member>
     <member><function>collator_sort</function></member>
     <member><function>collator_asort</function></member>
    </simplelist>

--- a/reference/intl/collator/sort.xml
+++ b/reference/intl/collator/sort.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c142be811735a5542c8a2e4c4ed2f81e8cc3acc6 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: e290572f2599305beb62b13988024b5da187979d Maintainer: takagi Status: ready -->
 <refentry xml:id="collator.sort" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>Collator::sort</refname>
@@ -137,7 +137,7 @@ array (
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><link linkend="intl.collator-constants"><classname>Collator</classname> の定数</link></member>
+    <member><link linkend="intl.collator-constants">Collator の定数</link></member>
     <member><function>collator_asort</function></member>
     <member><function>collator_sort_with_sort_keys</function></member>
    </simplelist>


### PR DESCRIPTION
doc-en@e290572f25 で `<classname>` と `<link>` が併用されたときに二重のアンカータグが生成される問題が修正されました。
このため、`Collator::*` の seealso セクションで参照している `intl.collator-constants` のリンクから `<classname>...</classname>` を取り除いて同期します。

対象ファイル (7 件):

- `reference/intl/collator/asort.xml`
- `reference/intl/collator/get-attribute.xml`
- `reference/intl/collator/get-strength.xml`
- `reference/intl/collator/set-attribute.xml`
- `reference/intl/collator/set-strength.xml`
- `reference/intl/collator/sort-with-sort-keys.xml`
- `reference/intl/collator/sort.xml`

該当 PR: https://github.com/php/doc-en/pull/5547

ご確認のほど、よろしくお願いいたします。