### PR TITLE
pm.process_idle_timeout の漏れを修正

### DIFF
--- a/install/fpm/configuration.xml
+++ b/install/fpm/configuration.xml
@@ -488,6 +488,7 @@
        <para>
         アイドルなプロセスがkillされた後の秒数。
         <literal>pm</literal> の値が
+        <literal>ondemand</literal> である場合にのみ使えます。
         使用可能な単位: s(秒)(デフォルト)、m(分)、h(時間)、または d(日)。
         デフォルト値: 10 秒
        </para>


### PR DESCRIPTION
en: https://www.php.net/manual/en/install.fpm.configuration.php#pm.process-idle-timeout
ja: https://www.php.net/manual/ja/install.fpm.configuration.php#pm.process-idle-timeout

pm.process_idle_timeout の説明で「pm の値が」の先が欠損しているのを修正しました