### PR TITLE
gmstrftime の例を doc-en の最新に同期

### DIFF
--- a/reference/datetime/functions/gmstrftime.xml
+++ b/reference/datetime/functions/gmstrftime.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 6c27f7044c7d42c23685afa916e7d7a44cf2bbb2 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: shimooka -->
 <refentry xml:id="function.gmstrftime" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -97,19 +97,30 @@
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example>
-    <title><function>gmstrftime</function> の例</title>
-    <programlisting role="php">
+  <example>
+   <title><function>gmstrftime</function> の例</title>
+   <programlisting role="php">
 <![CDATA[
 <?php
-setlocale(LC_TIME, 'en_US');
-echo strftime("%b %d %Y %H:%M:%S", mktime(20, 0, 0, 12, 31, 98)) . "\n";
-echo gmstrftime("%b %d %Y %H:%M:%S", mktime(20, 0, 0, 12, 31, 98)) . "\n";
+
+setlocale(LC_TIME, 'es_ES.UTF-8');
+date_default_timezone_set('EST');
+
+echo strftime("%B %d %Y %H:%M:%S",   mktime(20, 0, 0, 12, 31, 98)) . "\n";
+echo gmstrftime("%B %d %Y %H:%M:%S", mktime(20, 0, 0, 12, 31, 98));
 ]]>
-    </programlisting>
-   </example>
-  </para>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in script on line 6
+diciembre 31 1998 20:00:00
+
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in script on line 7
+enero 01 1999 01:00:00
+]]>
+   </screen>
+  </example>
  </refsect1>
 
  <refsect1 role="seealso">


### PR DESCRIPTION
[php/doc-en#5014](https://github.com/php/doc-en/pull/5014)（commit [`6c27f7044c`](https://github.com/php/doc-en/commit/6c27f7044c7d42c23685afa916e7d7a44cf2bbb2)）の取り込みです。

## 変更内容

`reference/datetime/functions/gmstrftime.xml` の examples セクションを英語版の最新に追従:

- ロケール設定を `'en_US'` から `'es_ES.UTF-8'` に変更
- `date_default_timezone_set('EST')` を明示し、`strftime`（ローカル）と `gmstrftime`（GMT）の対比を再現可能にした
- フォーマット指定子を `%b`（省略月名）から `%B`（完全月名）に変更し、ロケールの効果をより明確に示した
- `<example>` を囲んでいた `<para>` ラッパーを撤去（英語版に追随）
- `&example.outputs;` と `<screen>` ブロックを追加し、PHP 8.1 以降の deprecation 通知を含む実際の出力を表示

## EN-Revision

- 旧: `3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3`
- 新: `6c27f7044c7d42c23685afa916e7d7a44cf2bbb2`

## 検証

`php doc-base/configure.php --with-lang=ja --enable-xml-details` を実行し、XML バリデーションが通ることを確認しました（"All good. Saved .manual.xml"）。