### PR TITLE
doc-en と同期し 11 モジュールを完訳（既訳更新 15 件・新規翻訳 2 件）

### DIFF
--- a/appendices/migration85/constants.xml
+++ b/appendices/migration85/constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ec45af749649dc0d6a23eaedeed1b601f7460813 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: f8bab1dfb5246788f144103de56208dd133e9461 Maintainer: mumumu Status: ready -->
 <sect1 xml:id="migration85.constants">
  <title>新しいグローバル定数</title>
 
@@ -162,6 +162,9 @@
   <title>Standard</title>
 
   <simplelist>
+   <member>
+    <constant>IMAGETYPE_HEIF</constant>
+   </member>
    <member>
     <constant>IMAGETYPE_SVG</constant>
     when libxml is loaded.

--- a/reference/exec/functions/proc-close.xml
+++ b/reference/exec/functions/proc-close.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 350d95443aeb0ea8751d71f262aac56d3ad48f83 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: ef623ccf442df416da4e5bc254b4c5d4f6df9475 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: shimooka,mumumu -->
 <!-- splitted from ./en/functions/exec.xml, last change in rev 1.28 -->
 <refentry xml:id='function.proc-close' xmlns="http://docbook.org/ns/docbook">
@@ -51,7 +51,29 @@
   </para>
   &note.sigchild;
  </refsect1>
-
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.3.0</entry>
+      <entry>
+       先に <function>proc_get_status</function> が呼び出された後でも、
+       <function>proc_close</function> は正しい終了コードを返すようになりました。
+       これより前のバージョンでは、<literal>-1</literal> を返していました。
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
 </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/reference/exif/functions/exif-imagetype.xml
+++ b/reference/exif/functions/exif-imagetype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 6a08181be1706dfebdb3ad6e45620bceb08019ba Maintainer: takagi Status: ready -->
+<!-- EN-Revision: f8bab1dfb5246788f144103de56208dd133e9461 Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.exif-imagetype">
   <refnamediv>
@@ -137,6 +137,10 @@
         <entry>19</entry>
         <entry><constant>IMAGETYPE_AVIF</constant></entry>
        </row>
+       <row>
+        <entry>20</entry>
+        <entry><constant>IMAGETYPE_HEIF</constant></entry>
+       </row>
       </tbody>
      </tgroup>
     </table>
@@ -173,6 +177,12 @@
        <entry>8.1.0</entry>
        <entry>
         AVIF をサポートしました。
+       </entry>
+      </row>
+      <row>
+       <entry>8.5.0</entry>
+       <entry>
+        HEIF をサポートしました。
        </entry>
       </row>
      </tbody>

--- a/reference/filesystem/functions/fscanf.xml
+++ b/reference/filesystem/functions/fscanf.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4225e50bc391ddba99e367c231463da0dc04357d Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 9947012f745f0fb6e083bce5a8c920213ff468b7 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: shimooka,mumumu -->
 <refentry xml:id="function.fscanf" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -16,66 +16,69 @@
    <methodparam><type>string</type><parameter>format</parameter></methodparam>
    <methodparam rep="repeat"><type>mixed</type><parameter role="reference">vars</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    関数<function>fscanf</function> は <function>sscanf</function>
    に似ていますが、<parameter>stream</parameter> が指すファイルから入力を取得し、
    指定したフォーマット <parameter>format</parameter> に基づき解釈を行います。
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    フォーマット文字列におけるあらゆる空白は
    入力ストリームのあらゆる空白にマッチします。
    これはつまりフォーマット文字列のタブ (<literal>\t</literal>) すらも
    入力ストリームの空白1個にマッチしてしまうことを意味します。
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    <function>fscanf</function> をコールするたびに、ファイルから 1 行ずつ読み込みます。
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>stream</parameter></term>
-     <listitem>
-      &fs.file.pointer;
-     </listitem>
-    </varlistentry>
-    &strings.scanf.parameter.format;
-    <varlistentry>
-     <term><parameter>vars</parameter></term>
-     <listitem>
-      <para>
-       オプションで代入する値。
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  <variablelist>
+   <varlistentry>
+    <term><parameter>stream</parameter></term>
+    <listitem>
+     &fs.file.pointer;
+    </listitem>
+   </varlistentry>
+   &strings.scanf.parameter.format;
+   <varlistentry>
+    <term><parameter>vars</parameter></term>
+    <listitem>
+     <simpara>
+      オプションで代入する値。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    この関数のパラメータが二つだけの場合、処理された値は配列として返されます。
    他方、オプションのパラメータが指定された場合、
    この関数は、代入された値の数を返します。
    オプション引数は参照渡しとする必要があります。
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    <parameter>string</parameter> で利用可能な部分文字列よりも、
    <parameter>format</parameter> で期待された部分文字列の数が多い場合は、&null; が返されます。
    その他のエラーが発生した場合は、&false; が返されます。
-  </para>
+  </simpara>
+  <simpara>
+   オプションのパラメータを使用していて、
+   いずれかの値がパースされる前に
+   <parameter>stream</parameter> から読み込んだ入力の終端に達した場合は、
+   <literal>-1</literal> が返されます。
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example>
-    <title><function>fscanf</function> の例</title>
-    <programlisting role="php">
+  <example>
+   <title><function>fscanf</function> の例</title>
+   <programlisting role="php">
 <![CDATA[
 <?php
 $handle = fopen("users.txt", "r");
@@ -86,36 +89,31 @@ while ($userinfo = fscanf($handle, "%s\t%s\t%s\n")) {
 fclose($handle);
 ?>
 ]]>
-    </programlisting>
-   </example>
-  </para>
-  <para>
-   <example>
-    <title>users.txt の内容</title>
-    <programlisting role="txt">
+   </programlisting>
+  </example>
+  <example>
+   <title>users.txt の内容</title>
+   <programlisting role="txt">
 <![CDATA[
 javier  argonaut        pe
 hiroshi sculptor        jp
 robert  slacker us
 luigi   florist it
 ]]>
-    </programlisting>
-   </example>
-  </para>
+   </programlisting>
+  </example>
  </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>fread</function></member>
-    <member><function>fgets</function></member>
-    <member><function>fgetss</function></member>
-    <member><function>sscanf</function></member>
-    <member><function>printf</function></member>
-    <member><function>sprintf</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>fread</function></member>
+   <member><function>fgets</function></member>
+   <member><function>fgetss</function></member>
+   <member><function>sscanf</function></member>
+   <member><function>printf</function></member>
+   <member><function>sprintf</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/funchand/functions/register-shutdown-function.xml
+++ b/reference/funchand/functions/register-shutdown-function.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: b412bbd26214f7281ac7dd858710e09952a275f2 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 2312f826e5fdedbef87c6288c2c20f9f904b4d0b Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa -->
 <refentry xml:id="function.register-shutdown-function" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -25,6 +25,15 @@
    登録した関数内で <function>exit</function> をコールした場合、
    処理はそこで終了してその他のシャットダウン関数はコールされません。
   </para>
+  <caution>
+   <simpara>
+    PHP 8.4.0 以降は、登録したシャットダウン関数内で引数なしの
+    <function>exit</function> をコールすると、終了コードが
+    <literal>0</literal> にリセットされます。
+    明示的にステータスを指定して <function>exit</function> をコールした場合は、
+    すべてのバージョンで、それ以前の終了コードが上書きされます。
+   </simpara>
+  </caution>
   <para>
    シャットダウン関数は、
    別のシャットダウン関数をキューの最後に追加するために、

--- a/reference/hash/functions/hash.xml
+++ b/reference/hash/functions/hash.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 539a9823a805ac29cab7fa4baf3ae3a28116a2f5 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: df2a77acbbb9d381426b863fcfa4d66ac7f5ab6d Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="function.hash" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -71,7 +71,15 @@
    そのままのバイナリ形式で返されます。
   </para>
  </refsect1>
- 
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   <parameter>algo</parameter> が不明な場合、
+   <exceptionname>ValueError</exceptionname> がスローされます。
+  </simpara>
+ </refsect1>
+
  <refsect1 role="changelog">
   &reftitle.changelog;
   <para>
@@ -90,10 +98,10 @@
       <row>
        <entry>8.0.0</entry>
        <entry>
-        <function>hash</function> は、
         <parameter>algo</parameter> が未知の場合に、
-        <classname>ValueError</classname> をスローするようになりました。
-        これより前のバージョンでは、&false; を返していました。
+        <exceptionname>ValueError</exceptionname> をスローするようになりました。
+        これより前のバージョンでは、&false; を返し、
+        <constant>E_WARNING</constant> メッセージを発行していました。
        </entry>
       </row>
      </tbody>

--- a/reference/image/constants.xml
+++ b/reference/image/constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 7f5d646f3ee39231150e767fb876b56610f56c2b Maintainer: takagi Status: ready -->
+<!-- EN-Revision: f8bab1dfb5246788f144103de56208dd133e9461 Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <appendix xml:id="image.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
@@ -700,6 +700,18 @@
     &gd.constants.type;
     <simpara>
      (PHP 8.1.0 以降で利用可能です)
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.imagetype-heif">
+   <term>
+    <constant>IMAGETYPE_HEIF</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    &gd.constants.type;
+    <simpara>
+     (PHP 8.5.0 以降で利用可能です)
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/image/functions/image-type-to-mime-type.xml
+++ b/reference/image/functions/image-type-to-mime-type.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 89ae180a851621c308f0ea4604ff2e919aa57a7f Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: f8bab1dfb5246788f144103de56208dd133e9461 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: shimooka,mumumu -->
 <refentry xml:id="function.image-type-to-mime-type" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -129,6 +129,10 @@
       <row>
        <entry><constant>IMAGETYPE_AVIF</constant></entry>
        <entry><literal>image/avif</literal></entry>
+      </row>
+      <row>
+       <entry><constant>IMAGETYPE_HEIF</constant></entry>
+       <entry><literal>image/heif</literal></entry>
       </row>
      </tbody>
     </tgroup>

--- a/reference/image/functions/imagecopyresampled.xml
+++ b/reference/image/functions/imagecopyresampled.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 16b6c3466bb70f2300b236273003f509638ebb90 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: shimooka,mumumu -->
 <refentry xml:id="function.imagecopyresampled" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -143,6 +143,12 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       戻り値の型が、&true; になりました。これより前のバージョンでは、<type>bool</type> でした。
+      </entry>
+     </row>
      <row>
       <entry>8.0.0</entry>
       <entry>

--- a/reference/memcached/memcached/construct.xml
+++ b/reference/memcached/memcached/construct.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 1d8068ecb070fdc360d750e0c1f3f15796e61ec0 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: c49d175bb3853b8851e961ac01a6f0b24de42269 Maintainer: takagi Status: ready -->
 <refentry xml:id="memcached.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Memcached::__construct</refname>
@@ -39,16 +39,25 @@
     <varlistentry>
      <term><parameter>callback</parameter></term>
      <listitem>
-      <para>
-       <!-- TODO Document constructor params -->
-      </para>
+      <methodsynopsis>
+       <type>void</type><methodname><replaceable>callback</replaceable></methodname>
+       <methodparam><type>Memcached</type><parameter>memcached</parameter></methodparam>
+       <methodparam><type class="union"><type>string</type><type>null</type></type><parameter>persistent_id</parameter></methodparam>
+      </methodsynopsis>
+      <simpara>
+       <parameter>callback</parameter> パラメータは、接続が確立されたときに呼ばれます。
+       これは、有効な PHP の <type>callable</type> でなければならず、
+       一番目のパラメータとして <classname>Memcached</classname> オブジェクトを、
+       二番目のパラメータとして <parameter>persistent_id</parameter> を受け取ります。
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>connection_str</parameter></term>
      <listitem>
       <para>
-       <!-- TODO Document constructor params -->
+       このパラメータは、クラスタ内でのサーバーの重みなど、
+       memcache サーバーへの追加の接続オプションを渡すために使います。
       </para>
      </listitem>
     </varlistentry>

--- a/reference/misc/functions/exit.xml
+++ b/reference/misc/functions/exit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 2aaaf1967f2510471b694daf8e41a419fc98b751 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 2312f826e5fdedbef87c6288c2c20f9f904b4d0b Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi -->
 <refentry xml:id="function.exit" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -106,6 +106,16 @@
        宣言も適用されるようになりました。また、名前付き引数や
        <link linkend="functions.variable-functions">可変関数</link>
        によって呼び出すこともできるようになりました。
+      </entry>
+     </row>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       <link linkend="function.register-shutdown-function">シャットダウン関数</link>
+       や <link linkend="language.oop5.decon.destructor">オブジェクトのデストラクタ</link>
+       の中で引数なしの <function>exit</function> をコールすると、
+       終了コードが <literal>0</literal> にリセットされるようになりました。
+       これより前は、それ以前の <function>exit</function> のコールで設定された終了コードが保持されていました。
       </entry>
      </row>
     </tbody>

--- a/reference/soap/soap.sdl.xml
+++ b/reference/soap/soap.sdl.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 89205c88a79fcaad39fd043ed5ef695cd7bf813e Maintainer: KentarouTakeda Status: ready -->
+<reference xmlns="http://docbook.org/ns/docbook" xml:id="class.soap-sdl" role="class">
+ <title>Soap\Sdl クラス</title>
+ <titleabbrev>Soap\Sdl</titleabbrev>
+
+ <partintro>
+
+  <!-- {{{ Soap\Sdl intro -->
+  <section xml:id="soap-sdl.intro">
+   &reftitle.intro;
+   <simpara>
+    PHP 8.4.0 以降、<literal>soap_sdl</literal> &resource; を置き換える完全不透明クラスです。
+   </simpara>
+  </section>
+  <!-- }}} -->
+
+  <section xml:id="soap-sdl.synopsis">
+   &reftitle.classsynopsis;
+
+   <!-- {{{ Synopsis -->
+   <packagesynopsis>
+    <package>Soap</package>
+
+    <classsynopsis class="class">
+     <ooclass>
+      <modifier>final</modifier>
+      <classname>Sdl</classname>
+     </ooclass>
+    </classsynopsis>
+   </packagesynopsis>
+   <!-- }}} -->
+
+  </section>
+
+ </partintro>
+
+</reference>
+ <!-- Keep this comment at the end of the file
+  Local variables:
+  mode: sgml
+  sgml-omittag:t
+  sgml-shorttag:t
+  sgml-minimize-attributes:nil
+  sgml-always-quote-attributes:t
+  sgml-indent-step:1
+  sgml-indent-data:t
+  indent-tabs-mode:nil
+  sgml-parent-document:nil
+  sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+  sgml-exposed-tags:nil
+  sgml-local-catalogs:nil
+  sgml-local-ecat-files:nil
+  End:
+  vim600: syn=xml fen fdm=syntax fdl=2 si
+  vim: et tw=78 syn=sgml
+  vi: ts=1 sw=1
+  -->

--- a/reference/soap/soap.url.xml
+++ b/reference/soap/soap.url.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 89205c88a79fcaad39fd043ed5ef695cd7bf813e Maintainer: KentarouTakeda Status: ready -->
+<reference xmlns="http://docbook.org/ns/docbook" xml:id="class.soap-url" role="class">
+ <title>Soap\Url クラス</title>
+ <titleabbrev>Soap\Url</titleabbrev>
+
+ <partintro>
+
+  <!-- {{{ Soap\Url intro -->
+  <section xml:id="soap-url.intro">
+   &reftitle.intro;
+   <simpara>
+    PHP 8.4.0 以降、<literal>soap_url</literal> &resource; を置き換える完全不透明クラスです。
+   </simpara>
+  </section>
+  <!-- }}} -->
+
+  <section xml:id="soap-url.synopsis">
+   &reftitle.classsynopsis;
+
+   <!-- {{{ Synopsis -->
+   <packagesynopsis>
+    <package>Soap</package>
+
+    <classsynopsis class="class">
+     <ooclass>
+      <modifier>final</modifier>
+      <classname>Url</classname>
+     </ooclass>
+    </classsynopsis>
+   </packagesynopsis>
+   <!-- }}} -->
+
+  </section>
+
+ </partintro>
+
+</reference>
+ <!-- Keep this comment at the end of the file
+  Local variables:
+  mode: sgml
+  sgml-omittag:t
+  sgml-shorttag:t
+  sgml-minimize-attributes:nil
+  sgml-always-quote-attributes:t
+  sgml-indent-step:1
+  sgml-indent-data:t
+  indent-tabs-mode:nil
+  sgml-parent-document:nil
+  sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+  sgml-exposed-tags:nil
+  sgml-local-catalogs:nil
+  sgml-local-ecat-files:nil
+  End:
+  vim600: syn=xml fen fdm=syntax fdl=2 si
+  vim: et tw=78 syn=sgml
+  vi: ts=1 sw=1
+  -->

--- a/reference/spl/splfileobject/fscanf.xml
+++ b/reference/spl/splfileobject/fscanf.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d51166ca16fda8e766849505b84f9306ef443f71 Maintainer: masakielastic Status: ready -->
+<!-- EN-Revision: 9947012f745f0fb6e083bce5a8c920213ff468b7 Maintainer: masakielastic Status: ready -->
 <refentry xml:id="splfileobject.fscanf" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SplFileObject::fscanf</refname>
@@ -14,77 +14,81 @@
    <methodparam><type>string</type><parameter>format</parameter></methodparam>
    <methodparam rep="repeat"><type>mixed</type><parameter role="reference">vars</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    ファイルから 1 行読み込み、<parameter>format</parameter> に従って解釈します。
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    <parameter>format</parameter> 文字列のホワイトスペースはファイルからの行のホワイトスペースとマッチします。このことが意味するのはフォーマット文字列のタブ (<literal>\t</literal>) でさえも入力ストリームの 1 つのスペース文字とマッチしてしまうということです。
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    &strings.scanf.parameter.format;
-    <varlistentry>
-     <term><parameter>vars</parameter></term>
-     <listitem>
-      <para>
-       オプションの割り当て値。
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  <variablelist>
+   &strings.scanf.parameter.format;
+   <varlistentry>
+    <term><parameter>vars</parameter></term>
+    <listitem>
+     <simpara>
+      オプションの割り当て値。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    このメソッドに渡される引数がひとつしかない場合、処理される値は配列として返されます。そうでなければ、オプションパラメータが渡される場合、メソッドは割り当て値の個数を返します。オプションパラメータは参照渡しでなければなりません。
-  </para>
+  </simpara>
+  <simpara>
+   <parameter>format</parameter> で期待する部分文字列のほうが
+   ファイルから読み込んだ行に存在するものより多い場合は
+   &null; を返します。
+  </simpara>
+  <simpara>
+   オプションのパラメータを使用していて、
+   いずれかの値がパースされる前にファイルから読み込んだ行の
+   終端に達した場合は、<literal>-1</literal> を返します。
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example>
-    <title><methodname>SplFileObject::fscanf</methodname> の例</title>
-    <programlisting role="php">
+  <example>
+   <title><methodname>SplFileObject::fscanf</methodname> の例</title>
+   <programlisting role="php">
 <![CDATA[
 <?php
 $file = new SplFileObject("misc.txt");
 while ($userinfo = $file->fscanf("%s %s %s")) {
-    list ($name, $profession, $countrycode) = $userinfo;
-    // $name $profession $countrycode で何かを行う
+   list ($name, $profession, $countrycode) = $userinfo;
+   // $name $profession $countrycode で何かを行う
 }
 ?>
 ]]>
-    </programlisting>
-    <para>users.txt の内容</para>
-    <programlisting role="txt">
+   </programlisting>
+   <simpara>users.txt の内容</simpara>
+   <programlisting role="txt">
 <![CDATA[
 javier   argonaut    pe
 hiroshi  sculptor    jp
 robert   slacker     us
 luigi    florist     it
 ]]>
-    </programlisting>
-   </example>
-  </para>
+   </programlisting>
+  </example>
  </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>fscanf</function></member>
-    <member><function>sscanf</function></member>
-    <member><function>printf</function></member>
-    <member><function>sprintf</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>fscanf</function></member>
+   <member><function>sscanf</function></member>
+   <member><function>printf</function></member>
+   <member><function>sprintf</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/stream/streamwrapper/stream-lock.xml
+++ b/reference/stream/streamwrapper/stream-lock.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: fa5ef560a6ea59e32de1e383969ac728526a1335 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 38231ac293eaabd5161c7276a72b9683ad02fd3c Maintainer: takagi Status: ready -->
 
 <refentry xml:id="streamwrapper.stream-lock" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -14,13 +14,13 @@
    <modifier>public</modifier> <type>bool</type><methodname>streamWrapper::stream_lock</methodname>
    <methodparam><type>int</type><parameter>operation</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    このメソッドは、<function>flock</function> に対応してコールされます。また
    <function>file_put_contents</function> (<parameter>flags</parameter>
    が <constant>LOCK_EX</constant> を含む場合)、
    <function>stream_set_blocking</function> がコールされたときやストリームを閉じるとき
    (<constant>LOCK_UN</constant>) にもコールされます。
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -48,15 +48,14 @@
           <constant>LOCK_UN</constant> ロック (共有あるいは排他) を開放します。
          </simpara>
         </listitem>
-        <listitem>
-         <simpara>
-          <constant>LOCK_NB</constant>
-          <function>flock</function> によるロック中にブロックしない
-          (Windows ではサポートしていません)。
-         </simpara>
-        </listitem>
        </itemizedlist>
       </para>
+      <simpara>
+       上記の操作のいずれかに、ビットマスクとして
+       <constant>LOCK_NB</constant> を追加することもできます。
+       ロック取得の試行中にブロックさせたくない場合に使います
+       (Windows ではサポートしていません)。
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -65,16 +64,16 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors"><!-- {{{ -->
   &reftitle.errors;
-  <para>
+  <simpara>
    このメソッドのコールに失敗した場合 (実装されていないなど) は <constant>E_WARNING</constant> を発行します。
-  </para>
+  </simpara>
  </refsect1><!-- }}} -->
  
 

--- a/reference/strings/functions/sscanf.xml
+++ b/reference/strings/functions/sscanf.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4225e50bc391ddba99e367c231463da0dc04357d Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 9947012f745f0fb6e083bce5a8c920213ff468b7 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi,mumumu -->
 <refentry xml:id="function.sscanf" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -16,67 +16,69 @@
    <methodparam><type>string</type><parameter>format</parameter></methodparam>
    <methodparam rep="repeat"><type>mixed</type><parameter role="reference">vars</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    関数 <function>sscanf</function> は、<function>printf</function>
    の入力版です。<function>sscanf</function> は、文字列
    <parameter>string</parameter> を読み込み、これを指定したフォーマット
    <parameter>format</parameter> に基づき解釈します。
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    フォーマット文字列の中のあらゆる空白文字は、入力文字列の中の
    空白文字列にマッチします。つまり、フォーマット文字列の中にタブ文字
    (<literal>\t</literal>) が含まれていても、
    それは入力中の半角スペースにマッチしてしまうということです。
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>string</parameter></term>
-     <listitem>
-      <para>
-       入力文字列。
-      </para>
-     </listitem>
-    </varlistentry>
-    &strings.scanf.parameter.format;
-    <varlistentry>
-     <term><parameter>vars</parameter></term>
-     <listitem>
-      <para>
-       オプションで指定する参照渡しの変数に、
-       パースされた値が格納されます。
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  <variablelist>
+   <varlistentry>
+    <term><parameter>string</parameter></term>
+    <listitem>
+     <simpara>
+      入力文字列。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   &strings.scanf.parameter.format;
+   <varlistentry>
+    <term><parameter>vars</parameter></term>
+    <listitem>
+     <simpara>
+      オプションで指定する参照渡しの変数に、
+      パースされた値が格納されます。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
  
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   この関数のパラメータが二つだけの場合、処理された値は配列として返されます。
+  <simpara>
+   この関数のパラメータが二つだけの場合、処理された値は <type>array</type> として返されます。
    それ以外の場合は、もしオプションのパラメータが渡されればこの関数は
    割り当てられた値の数を返します。オプションのパラメータは
    参照渡しにする必要があります。
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    <parameter>format</parameter> で期待する部分文字列のほうが
    実際に <parameter>string</parameter> に存在するものより多い場合は
    &null; を返します。
-  </para>
+  </simpara>
+  <simpara>
+   オプションのパラメータを使用していて、
+   いずれかの値がパースされる前に入力文字列 <parameter>string</parameter>
+   の終端に達した場合は、<literal>-1</literal> を返します。
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example>
-    <title><function>sscanf</function> の例</title>
-    <programlisting role="php">
+  <example>
+   <title><function>sscanf</function> の例</title>
+   <programlisting role="php">
 <![CDATA[
 <?php
 // シリアル番号を得る
@@ -87,16 +89,14 @@ list($month, $day, $year) = sscanf($mandate, "%s %d %d");
 echo "Item $serial was manufactured on: $year-" . substr($month, 0, 3) . "-$day\n";
 ?>
 ]]>
-    </programlisting>
-   </example>
-  </para>
-  <para>
+   </programlisting>
+  </example>
+  <simpara>
    オプションのパラメータが指定された場合、この関数は、代入された値の数を返します。
-  </para>
-  <para>
-   <example>
-    <title><function>sscanf</function> - オプションパラメータの使用法</title>
-    <programlisting role="php">
+  </simpara>
+  <example>
+   <title><function>sscanf</function> - オプションパラメータの使用法</title>
+   <programlisting role="php">
 <![CDATA[
 <?php
 // author 情報を取得し、DocBook エントリを生成
@@ -108,26 +108,23 @@ echo "<author id='$id'>
 </author>\n";
 ?>
 ]]>
-    </programlisting>
-   </example>
-  </para>
+   </programlisting>
+  </example>
  </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>printf</function></member>
-    <member><function>sprintf</function></member>
-    <member><function>fprintf</function></member>
-    <member><function>vprintf</function></member>
-    <member><function>vsprintf</function></member>
-    <member><function>vfprintf</function></member>
-    <member><function>fscanf</function></member>
-    <member><function>number_format</function></member>
-    <member><function>date</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>printf</function></member>
+   <member><function>sprintf</function></member>
+   <member><function>fprintf</function></member>
+   <member><function>vprintf</function></member>
+   <member><function>vsprintf</function></member>
+   <member><function>vfprintf</function></member>
+   <member><function>fscanf</function></member>
+   <member><function>number_format</function></member>
+   <member><function>date</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/url/functions/http-build-query.xml
+++ b/reference/url/functions/http-build-query.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e80ef2394f0c64be66917a5d4335736ae05b774f Maintainer: shimooka Status: ready -->
+<!-- EN-Revision: f72c6031982a6f8152ef351d20f8e0d90e8f1612 Maintainer: shimooka Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="function.http-build-query" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -42,6 +42,14 @@
        <parameter>data</parameter> がオブジェクトの場合、
        public プロパティだけが結果に含められます。
       </para>
+      <note>
+       <simpara>
+        オブジェクトが評価される際に
+        <link linkend="object.tostring">__toString()</link> マジックメソッドが
+        呼び出されることはありません。クエリ文字列でオブジェクトの文字列表現を
+        使用するには、オブジェクトを明示的に文字列にキャストする必要があります。
+       </simpara>
+      </note>
      </listitem>
     </varlistentry>
     <varlistentry>
@@ -267,6 +275,44 @@ echo http_build_query($parent);
    <screen>
 <![CDATA[
 pub=publicParent&pub_bar%5Bpub%5D=publicChild
+]]>
+   </screen>
+  </example>
+
+  <example>
+   <title><link linkend="object.tostring">__toString()</link> を含むオブジェクトでの
+    <function>http_build_query</function> の使用
+   </title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+class Foo {
+    public $publicProperty = 'visible';
+
+    public function __toString() {
+        return "bar";
+    }
+}
+
+$params = array(
+    'a' => 'b',
+    'foo' => new Foo()
+);
+
+// キャストしない場合、http_build_query は public プロパティを読み取ります
+echo http_build_query($params) . "\n";
+
+// 明示的にキャストすると、http_build_query は __toString() の出力を使用します
+$params['foo'] = (string) new Foo();
+echo http_build_query($params) . "\n";
+?>
+]]>
+   </programlisting>
+ &example.outputs;
+   <screen>
+<![CDATA[
+a=b&foo%5BpublicProperty%5D=visible
+a=b&foo=bar
 ]]>
    </screen>
   </example>


### PR DESCRIPTION
doc-en の最新に同期し、あと数件で完訳になるモジュールをまとめて仕上げました。既訳更新 15 件・新規翻訳 2 件で、**11 モジュールが完訳**になります。

## 翻訳内容

### sscanf/fscanf 系（3件）— 負の戻り値 -1 の明確化
- reference/strings/functions/sscanf.xml
  1. php/doc-en@9947012
- reference/spl/splfileobject/fscanf.xml
  1. php/doc-en@9947012
- reference/filesystem/functions/fscanf.xml
  1. php/doc-en@9947012

### IMAGETYPE_HEIF 定数追加（4件・PHP 8.5）
- appendices/migration85/constants.xml
  1. php/doc-en@f8bab1d
- reference/image/constants.xml
  1. php/doc-en@f8bab1d
- reference/image/functions/image-type-to-mime-type.xml
  1. php/doc-en@f8bab1d
- reference/exif/functions/exif-imagetype.xml
  1. php/doc-en@f8bab1d

### exit 終了コード挙動（2件・PHP 8.4.0）
- reference/misc/functions/exit.xml
  1. php/doc-en@2312f82
- reference/funchand/functions/register-shutdown-function.xml
  1. php/doc-en@2312f82

### reference/soap（2件・新規翻訳）— PHP 8.4 resource→Object 変換
- reference/soap/soap.sdl.xml
  1. php/doc-en@89205c8
- reference/soap/soap.url.xml
  1. php/doc-en@89205c8

### 独立ファイル（6件）
- reference/image/functions/imagecopyresampled.xml — 戻り値型の 8.5.0 changelog を追加
  1. php/doc-en@16b6c34
- reference/url/functions/http-build-query.xml — オブジェクトと __toString() の挙動を明確化
  1. php/doc-en@f72c603
- reference/exec/functions/proc-close.xml — proc_get_status との終了ステータスの関係を明確化
  1. php/doc-en@ef623cc
- reference/hash/functions/hash.xml — changelog に E_WARNING を追記
  1. php/doc-en@df2a77a
- reference/stream/streamwrapper/stream-lock.xml — LOCK_NB を単独モードとして記述
  1. php/doc-en@38231ac
- reference/memcached/memcached/construct.xml — __construct() のパラメータ説明を補完
  1. php/doc-en@c49d175

### 完訳になったモジュール（11）
filesystem / image / exif / soap / url / exec / hash / stream / memcached / misc / funchand

---
ビルド検証（`configure.php --with-lang=ja`）OK、EN-Revision 整合性チェック 17/17 OK 済み。
