### PR TITLE
既訳のインラインタグ構造の誤りを原文に合わせて修正

### DIFF
--- a/faq/build.xml
+++ b/faq/build.xml
@@ -20,7 +20,7 @@
     </question>
     <answer>
      <para>
-      configure.inからconfigureスクリプトを生成するためには、GNU
+      <filename>configure.in</filename>からconfigureスクリプトを生成するためには、GNU
       autoconfパッケージが必要です。Gitサーバーからソースを入手した後、
       最上位のディレクトリで<command>./buildconf</command>を実行して下
       さい。(また、<command>configure</command> に
@@ -261,7 +261,7 @@
     </question>
     <answer>
      <para>
-      libphp4.aファイルはこの時点では存在しない、ということに気をつけてください。
+      <filename>libphp4.a</filename>ファイルはこの時点では存在しない、ということに気をつけてください。
       このファイルは、Apacheの構築時に自動的に作成されます。
      </para>
     </answer>
@@ -367,7 +367,7 @@ make: *** [all-recursive] Error 1
      </para>
      <para>
       あなたのシステムは壊れています。使用しているglibcと同じバージョンの
-      glibc-develパッケージをインストールして、/usr/include ファイルを修正
+      glibc-develパッケージをインストールして、<filename>/usr/include</filename> ファイルを修正
       する必要があります。この問題は、PHPの動作とは全く関係ありません。
       これを示すには、次のような簡単なテストを行ってみてください。
      <programlisting>

--- a/reference/image/functions/imagecopymergegray.xml
+++ b/reference/image/functions/imagecopymergegray.xml
@@ -104,7 +104,7 @@
       <simpara>
         <parameter>src_image</parameter> が <parameter>pct</parameter>
         にしたがってグレースケールに変換されます。
-        <parameter>pct</parameter> が 0 の場合は完全なグレースケール、
+        pct が 0 の場合は完全なグレースケール、
         100 の場合は何も変わらない状態となります。
         <parameter>pct</parameter> = 100 の場合、パレット画像に対してはこの関数は
         <function>imagecopy</function> と同じ動作となります

--- a/reference/stream/functions/stream-socket-server.xml
+++ b/reference/stream/functions/stream-socket-server.xml
@@ -43,7 +43,7 @@
        には、<parameter>remote_socket</parameter> パラメータの
        <literal>ターゲット</literal> の部分は、ホスト名または IP アドレスと、
        それに続くコロンで区切られたポート番号から構成されていなければなりません。
-       Unix ドメインのソケットの場合は、<parameter>ターゲット</parameter>
+       Unix ドメインのソケットの場合は、<literal>ターゲット</literal>
        の部分は、ファイルシステムにおけるソケットのファイルを指定しなくては
        いけません。
       </para>

--- a/reference/zip/configure.xml
+++ b/reference/zip/configure.xml
@@ -34,7 +34,7 @@
   <title>Windows</title>
   <simpara>
    PHP 8.2.0 以降では、
-   <filename>php_zip.dll</filename> を &php.ini; で有効にする必要があります。
+   <filename>php_zip.dll</filename> を &php.ini; で<link linkend="install.pecl.windows.loading">有効にする</link>必要があります。
    それより前のバージョンでは、この拡張モジュールは標準で PHP に組み込まれていました。
   </simpara>
  </section>

--- a/reference/zip/ziparchive/getarchiveflag.xml
+++ b/reference/zip/ziparchive/getarchiveflag.xml
@@ -31,22 +31,22 @@
        <itemizedlist>
         <listitem>
          <simpara>
-          <constant><link linkend="ziparchive.constants.afl-rdonly">ZipArchive::AFL_RDONLY</link></constant>
+          <constant>ZipArchive::AFL_RDONLY</constant>
          </simpara>
         </listitem>
         <listitem>
          <simpara>
-          <constant><link linkend="ziparchive.constants.afl-is-torrentzip">ZipArchive::AFL_IS_TORRENTZIP</link></constant>
+          <constant>ZipArchive::AFL_IS_TORRENTZIP</constant>
          </simpara>
         </listitem>
         <listitem>
          <simpara>
-          <constant><link linkend="ziparchive.constants.afl-want-torrentzip">ZipArchive::AFL_WANT_TORRENTZIP</link></constant>
+          <constant>ZipArchive::AFL_WANT_TORRENTZIP</constant>
          </simpara>
         </listitem>
         <listitem>
          <simpara>
-          <constant><link linkend="ziparchive.constants.afl-create-or-keep-file-for-empty-archive">ZipArchive::AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE</link></constant>
+          <constant>ZipArchive::AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE</constant>
          </simpara>
         </listitem>
        </itemizedlist>


### PR DESCRIPTION
原文 (doc-en) とインラインタグの種類・個数が食い違っていた既訳 5 ファイルを、
タグ構造が一致するよう修正します。翻訳文・EN-Revision ヘッダは変更していません
（マークアップのみの修正）。

## 欠落タグの補完（原文にあって訳文で抜けていたタグを追加）

- `<filename>`: faq/build.xml (configure.in, libphp4.a, /usr/include の 3 箇所)
- `<link>`: reference/zip/configure.xml (install.pecl.windows.loading へのリンク)

## 過剰タグの除去（訳文にあって原文にない余分なタグを削除）

- `<link>`: reference/zip/ziparchive/getarchiveflag.xml (constants 内の余分なリンク 4 箇所)
- `<parameter>`: reference/image/functions/imagecopymergegray.xml (余分な 1 箇所)

## タグ種別の修正（別タグに化けていたものを正す）

- `<parameter>` → `<literal>`: reference/stream/functions/stream-socket-server.xml (target を literal に統一)
