### PR TITLE
拡張モジュール (posix/snmp/sockets/apache/ldap) を upstream に同期

### DIFF
--- a/reference/apache/book.xml
+++ b/reference/apache/book.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 46a9cdd2dbef4ec89bf65fad9930e2feb78bbb98 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 8a0888aeb20d187289664eb1116fa30228837478 Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa -->
  
 <book xml:id="book.apache" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -10,9 +10,11 @@
  <!-- {{{ preface -->
  <preface xml:id="intro.apache">
   &reftitle.intro;
-  <para>
-   これらの関数は、Apacheモジュール版のPHPを実行している場合のみ利用可能です。
-  </para>
+  <simpara>
+   これらの関数は、Apache モジュール版の PHP を実行している場合に利用可能です。
+   一部の関数は、他のウェブサーバー API で実行している場合にも利用できることがあります。
+   詳細は個々の関数のドキュメントを確認してください。
+  </simpara>
  </preface>
  <!-- }}} -->
 

--- a/reference/apache/functions/apache-request-headers.xml
+++ b/reference/apache/functions/apache-request-headers.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 68e52ef14de33f6752a8fdda1ae83c861c5babdb Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 8a0888aeb20d187289664eb1116fa30228837478 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: shimooka,mumumu -->
 <refentry xml:id="function.apache-request-headers" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -14,10 +14,10 @@
    <type>array</type><methodname>apache_request_headers</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    現在のリクエストにおけるすべての HTTP リクエストヘッダを取得します。
-   Apache, FastCGI, CLI, FPM ウェブサーバーで動作します。
-  </para>
+   Apache, LiteSpeed, FastCGI, CLI, FPM ウェブサーバーで動作します。
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,9 +27,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    現在のリクエストにおけるすべての HTTP ヘッダの連想配列を返します。
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -55,7 +55,7 @@
    </informaltable>
   </para>
  </refsect1>
- 
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -90,14 +90,14 @@ Connection: Keep-Alive
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     環境変数を読み込むことにより、共通の <acronym>CGI</acronym>
     変数の値を取得することも可能です。
     これは、PHPが<productname>Apache</productname>モジュール
     として使用されているかどうかにはよらず動作します。
     利用可能な<link linkend="language.variables.predefined">環境変数
     </link>の一覧を見るには、<function>phpinfo</function>を使用してください。
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/apache/functions/apache-response-headers.xml
+++ b/reference/apache/functions/apache-response-headers.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 68e52ef14de33f6752a8fdda1ae83c861c5babdb Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 8a0888aeb20d187289664eb1116fa30228837478 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: shimooka,mumumu -->
 <refentry xml:id="function.apache-response-headers" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -16,10 +16,10 @@
    <type>array</type><methodname>apache_response_headers</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    全てのApacheレスポンスヘッダを配列として取得します。
-   Apache, FastCGI, CLI, FPM ウェブサーバーで動作します。
-  </para>
+   Apache, LiteSpeed, FastCGI, CLI, FPM ウェブサーバーで動作します。
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -29,9 +29,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    全てのApacheレスポンスヘッダの配列を返します。
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/ldap/functions/ldap-exop-sync.xml
+++ b/reference/ldap/functions/ldap-exop-sync.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: db22a7cfcbc3af221f67e228336ac3e2d62aaf2c Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 9faf0215daa7a2b5d84525d7d2b3d6b066cc85ec Maintainer: mumumu Status: ready -->
 <refentry xml:id="function.ldap-exop-sync" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ldap_exop_sync</refname>
@@ -18,84 +18,95 @@
    <methodparam choice="opt"><type>string</type><parameter role="reference">response_data</parameter><initializer>&null;</initializer></methodparam>
    <methodparam choice="opt"><type>string</type><parameter role="reference">response_oid</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
-
-  </para>
-
-  &warn.undocumented.func;
-
+  <simpara>
+   指定された <parameter>ldap</parameter> で
+   オペレーションの <acronym>OID</acronym> を <parameter>request_oid</parameter> で指定し、
+   データを <parameter>request_data</parameter> で指定して拡張されたオペレーションを実行します。
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>ldap</parameter></term>
-     <listitem>
-      <para>
-       &ldap.parameter.ldap;
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>request_oid</parameter></term>
-     <listitem>
-      <para>
-
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>request_data</parameter></term>
-     <listitem>
-      <para>
-
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>controls</parameter></term>
-     <listitem>
-      <para>
-
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>response_data</parameter></term>
-     <listitem>
-      <para>
-
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>response_oid</parameter></term>
-     <listitem>
-      <para>
-
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  <variablelist>
+   <varlistentry>
+    <term><parameter>ldap</parameter></term>
+    <listitem>
+     <simpara>
+      &ldap.parameter.ldap;
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>request_oid</parameter></term>
+    <listitem>
+     <simpara>
+      拡張オペレーションリクエストの <acronym>OID</acronym>。
+      <constant>LDAP_EXOP_<replaceable>*</replaceable></constant>
+      定数のいずれか、
+      または操作の <acronym>OID</acronym> を示す文字列。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>request_data</parameter></term>
+    <listitem>
+     <simpara>
+      拡張オペレーションリクエストのデータ。
+      <constant>LDAP_EXOP_WHO_AM_I</constant> のように、
+      操作によっては &null; で問題ない場合もありますし、
+      <acronym>BER</acronym> エンコードが必要な場合もあります。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>controls</parameter></term>
+    <listitem>
+     <simpara>
+      リクエストと一緒に送信する <link linkend="ldap.controls">LDAP コントロール</link> の配列。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>response_data</parameter></term>
+    <listitem>
+     <simpara>
+      この値を指定すると、拡張オペレーションレスポンスの値で埋められます。
+      指定しなかった場合に後でこのデータを取得するには、
+      結果オブジェクトに対して <function>ldap_parse_exop</function> を使います。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>response_oid</parameter></term>
+    <listitem>
+     <simpara>
+      この値を指定すると、レスポンスの <acronym>OID</acronym> で埋められます。
+      これは通常、リクエストの <acronym>OID</acronym> と等しい値です。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-
-  </para>
+  <simpara>
+   <parameter>response_data</parameter> を指定した場合、成功時に &true; を返し、エラー時に &false; を返します。
+   <parameter>response_data</parameter> を指定しなかった場合、結果識別子を返し、
+   エラー時に &false; を返します。
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>ldap_exop</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>ldap_exop</function></member>
+   <member><function>ldap_exop_whoami</function></member>
+   <member><function>ldap_exop_refresh</function></member>
+   <member><function>ldap_exop_passwd</function></member>
+   <member><function>ldap_parse_result</function></member>
+   <member><function>ldap_parse_exop</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/ldap/functions/ldap-exop.xml
+++ b/reference/ldap/functions/ldap-exop.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: b37727abaf0e731a05c516fd85b44e86f4bf5c75 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 9faf0215daa7a2b5d84525d7d2b3d6b066cc85ec Maintainer: mumumu Status: ready -->
 
 <refentry xml:id="function.ldap-exop" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -19,11 +19,17 @@
    <methodparam choice="opt"><type>string</type><parameter role="reference">response_data</parameter></methodparam>
    <methodparam choice="opt"><type>string</type><parameter role="reference">response_oid</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    指定された <parameter>ldap</parameter> で
-   オペレーションの OID を <parameter>request_oid</parameter> で指定し、
+   オペレーションの <acronym>OID</acronym> を <parameter>request_oid</parameter> で指定し、
    データを <parameter>request_data</parameter> で指定して拡張されたオペレーションを実行します。
-  </para>
+  </simpara>
+  <warning>
+   <simpara>
+    4 個を超えるパラメータの使用は推奨されなくなりました。
+    代わりに <function>ldap_exop_sync</function> を使ってください。
+   </simpara>
+  </warning>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -32,61 +38,58 @@
    <varlistentry>
     <term><parameter>ldap</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       &ldap.parameter.ldap;
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>request_oid</parameter></term>
     <listitem>
-     <para>
-       拡張オペレーションリクエストのOID。
-       <constant>LDAP_EXOP_START_TLS</constant>,
-       <constant>LDAP_EXOP_MODIFY_PASSWD</constant>,
-       <constant>LDAP_EXOP_REFRESH</constant>,
-       <constant>LDAP_EXOP_WHO_AM_I</constant>,
-       <constant>LDAP_EXOP_TURN</constant> のいずれか、
-       または送信したい操作のOIDを示す文字列。
-     </para>
+     <simpara>
+      拡張オペレーションリクエストの <acronym>OID</acronym>。
+      <constant>LDAP_EXOP_<replaceable>*</replaceable></constant>
+      定数のいずれか、
+      または操作の <acronym>OID</acronym> を示す文字列。
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>request_data</parameter></term>
     <listitem>
-     <para>
+     <simpara>
        拡張オペレーションリクエストのデータ。
        <constant>LDAP_EXOP_WHO_AM_I</constant> のように、
        操作によってはNULLで問題ない場合もありますし、
-       BERエンコードが必要な場合もあります。
-     </para>
+       <acronym>BER</acronym> エンコードが必要な場合もあります。
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>controls</parameter></term>
     <listitem>
-     <para>
-      リクエストと一緒に送信する <link linkend="ldap.controls">LDAP コントロール</link> の配列
-     </para>
+     <simpara>
+      リクエストと一緒に送信する <link linkend="ldap.controls">LDAP コントロール</link> の配列。
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>response_data</parameter></term>
     <listitem>
-     <para>
+     <simpara>
        この値を指定すると、拡張オペレーションレスポンスの値で埋められます。
        指定しなかった場合に後でこのデータを取得するには、
-       結果オブジェクトに対して ldap_parse_exop を使います。
-     </para>
+       結果オブジェクトに対して <function>ldap_parse_exop</function> を使います。
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>response_oid</parameter></term>
     <listitem>
-     <para>
-       この値を指定すると、レスポンスのOIDで埋められます。
-       これは通常、リクエストのOIDと等しい値です。
-     </para>
+     <simpara>
+       この値を指定すると、レスポンスの <acronym>OID</acronym> で埋められます。
+       これは通常、リクエストの <acronym>OID</acronym> と等しい値です。
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -94,42 +97,46 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    <parameter>response_data</parameter> を指定した場合、成功時に &true; を返し、エラー時に &false; を返します。
    <parameter>response_data</parameter> を指定しなかった場合、結果識別子を返し、
    エラー時に &false; を返します。
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      &ldap.changelog.ldap-object;
-      <row>
-       <entry>7.3.0</entry>
-       <entry>
-        <parameter>controls</parameter> のサポートが追加されました。
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       4 個を超えるパラメータの使用は推奨されなくなりました。
+       代わりに <function>ldap_exop_sync</function> を使ってください。
+      </entry>
+     </row>
+     &ldap.changelog.ldap-object;
+     <row>
+      <entry>7.3.0</entry>
+      <entry>
+       <parameter>controls</parameter> のサポートが追加されました。
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example>
+  <example>
     <title>Whoami 拡張オペレーション</title>
     <programlisting role="php">
 <![CDATA[
@@ -165,23 +172,20 @@ if ($ds) {
 ?>
 ]]>
     </programlisting>
-   </example>
-  </para>
+  </example>
  </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>ldap_parse_result</function></member>
-    <member><function>ldap_parse_exop</function></member>
-    <member><function>ldap_exop_whoami</function></member>
-    <member><function>ldap_exop_refresh</function></member>
-    <member><function>ldap_exop_passwd</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>ldap_exop_sync</function></member>
+   <member><function>ldap_exop_whoami</function></member>
+   <member><function>ldap_exop_refresh</function></member>
+   <member><function>ldap_exop_passwd</function></member>
+   <member><function>ldap_parse_result</function></member>
+   <member><function>ldap_parse_exop</function></member>
+  </simplelist>
  </refsect1>
-
 
 </refentry>
 

--- a/reference/posix/functions/posix-fpathconf.xml
+++ b/reference/posix/functions/posix-fpathconf.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 8d417bd83842efbde90dbb51c31f99f474437ce4 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 42ed815ea41bc1ceb3c1417e1aa8778d327e314a Maintainer: mumumu Status: ready -->
 <refentry xml:id="function.posix-fpathconf" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>posix_fpathconf</refname>
@@ -57,6 +57,30 @@
    <parameter>resource</parameter> 
    が無効な場合、<classname>ValueError</classname> がスローされます。
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       無効なファイル記述子に遭遇した場合に、
+       <varname>last_error</varname> に <constant>EBADF</constant> を設定し、
+       <constant>E_WARNING</constant> が発生するようになりました。
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/posix/functions/posix-isatty.xml
+++ b/reference/posix/functions/posix-isatty.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 394815225713c1aad0007d80f2c3c3592d085084 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 42ed815ea41bc1ceb3c1417e1aa8778d327e314a Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi,mumumu -->
 <refentry xml:id="function.posix-isatty" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -49,6 +49,13 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       無効な <parameter>file_descriptor</parameter> に遭遇した場合に、
+       <constant>E_WARNING</constant> が発生するようになりました。
+      </entry>
+     </row>
      <row>
       <entry>8.4.0</entry>
       <entry>

--- a/reference/posix/functions/posix-kill.xml
+++ b/reference/posix/functions/posix-kill.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 265acc36ee4a1f4553a52030bf1717521c24dfb4 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 42ed815ea41bc1ceb3c1417e1aa8778d327e314a Maintainer: hirokawa Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="function.posix-kill" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -51,6 +51,30 @@
   <para>
    &return.success;
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       <parameter>process_id</parameter> がプラットフォームのサポートする範囲
+       (符号付き integer もしくは long の範囲) より小さいか大きい場合に、
+       <exceptionname>ValueError</exceptionname> をスローするようになりました。
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/posix/functions/posix-setpgid.xml
+++ b/reference/posix/functions/posix-setpgid.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 265acc36ee4a1f4553a52030bf1717521c24dfb4 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 42ed815ea41bc1ceb3c1417e1aa8778d327e314a Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi,mumumu -->
 <refentry xml:id="function.posix-setpgid" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -50,6 +50,30 @@
   <para>
    &return.success;
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       <parameter>process_id</parameter> または <parameter>process_group_id</parameter>
+       がゼロより小さいか、プラットフォームのサポートする範囲を超える場合に、
+       <exceptionname>ValueError</exceptionname> をスローするようになりました。
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/posix/functions/posix-setrlimit.xml
+++ b/reference/posix/functions/posix-setrlimit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 265acc36ee4a1f4553a52030bf1717521c24dfb4 Maintainer: satoruyoshida Status: ready -->
+<!-- EN-Revision: 42ed815ea41bc1ceb3c1417e1aa8778d327e314a Maintainer: satoruyoshida Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="function.posix-setrlimit" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -62,6 +62,31 @@
   <para>
    &return.success;
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       <parameter>hard_limit</parameter> または <parameter>soft_limit</parameter>
+       が -1 より小さい場合、もしくは <parameter>soft_limit</parameter> が
+       <parameter>hard_limit</parameter> より大きい場合に、
+       <exceptionname>ValueError</exceptionname> をスローするようになりました。
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/posix/functions/posix-ttyname.xml
+++ b/reference/posix/functions/posix-ttyname.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9c166423255b3d5e02f74232f2d05fd3b59d5d62 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 42ed815ea41bc1ceb3c1417e1aa8778d327e314a Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi,mumumu -->
 <refentry xml:id="function.posix-ttyname" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -56,6 +56,14 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       無効な <parameter>file_descriptor</parameter> に遭遇した場合に、
+       <varname>last_error</varname> に <constant>EBADF</constant>
+       を設定するようになりました。
+      </entry>
+     </row>
      <row>
       <entry>8.3.0</entry>
       <entry>

--- a/reference/snmp/functions/snmp2-get.xml
+++ b/reference/snmp/functions/snmp2-get.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 40906725410aac6fe8cac4913a557a1784bf04b9 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: dd22c782164c9f8d79f5de8991876d1588a21015 Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.snmp2-get">
  <refnamediv>
@@ -76,6 +76,30 @@
   <simpara>
    成功した場合に <acronym>SNMP</acronym> オブジェクトの値、エラー時に &false; を返します。
   </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       hostname の長さが 128 バイト以上の場合、port が負の数または 65535 より大きい場合、
+       または timeout や retries の値が -1 より小さいか大きすぎる場合に、
+       <exceptionname>ValueError</exceptionname> をスローするようになりました。
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/snmp/functions/snmp2-set.xml
+++ b/reference/snmp/functions/snmp2-set.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 40906725410aac6fe8cac4913a557a1784bf04b9 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: dd22c782164c9f8d79f5de8991876d1588a21015 Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.snmp2-set">
  <refnamediv>
@@ -104,7 +104,29 @@
   </simpara>
  </refsect1>
 
-
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       hostname の長さが 128 バイト以上の場合、port が負の数または 65535 より大きい場合、
+       または timeout や retries の値が -1 より小さいか大きすぎる場合に、
+       <exceptionname>ValueError</exceptionname> をスローするようになりました。
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/snmp/functions/snmp3-get.xml
+++ b/reference/snmp/functions/snmp3-get.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 40906725410aac6fe8cac4913a557a1784bf04b9 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: dd22c782164c9f8d79f5de8991876d1588a21015 Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.snmp3-get">
  <refnamediv>
@@ -135,6 +135,14 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       hostname の長さが 128 バイト以上の場合、port が負の数または 65535 より大きい場合、
+       または timeout や retries の値が -1 より小さいか大きすぎる場合に、
+       <exceptionname>ValueError</exceptionname> をスローするようになりました。
+      </entry>
+     </row>
      <row>
       <entry>8.1.0</entry>
       <entry>

--- a/reference/snmp/functions/snmp3-set.xml
+++ b/reference/snmp/functions/snmp3-set.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 40906725410aac6fe8cac4913a557a1784bf04b9 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: dd22c782164c9f8d79f5de8991876d1588a21015 Maintainer: takagi Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.snmp3-set">
  <refnamediv>
   <refname>snmp3_set</refname>
@@ -150,6 +150,30 @@
    E_WARNING メッセージが表示されます。未知の OID あるいは無効な OID
    を指定した場合は、おそらく "Could not add variable" のような警告となります。
   </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       hostname の長さが 128 バイト以上の場合、port が負の数または 65535 より大きい場合、
+       または timeout や retries の値が -1 より小さいか大きすぎる場合に、
+       <exceptionname>ValueError</exceptionname> をスローするようになりました。
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/snmp/functions/snmpget.xml
+++ b/reference/snmp/functions/snmpget.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 40906725410aac6fe8cac4913a557a1784bf04b9 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: dd22c782164c9f8d79f5de8991876d1588a21015 Maintainer: hirokawa Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.snmpget">
  <refnamediv>
   <refname>snmpget</refname>
@@ -74,6 +74,30 @@
   <simpara>
    成功した場合に <acronym>SNMP</acronym> オブジェクトの値、失敗した場合に &false; を返します。
   </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       hostname の長さが 128 バイト以上の場合、port が負の数または 65535 より大きい場合、
+       または timeout や retries の値が -1 より小さいか大きすぎる場合に、
+       <exceptionname>ValueError</exceptionname> をスローするようになりました。
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/snmp/functions/snmpset.xml
+++ b/reference/snmp/functions/snmpset.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 40906725410aac6fe8cac4913a557a1784bf04b9 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: dd22c782164c9f8d79f5de8991876d1588a21015 Maintainer: hirokawa Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.snmpset">
  <refnamediv>
   <refname>snmpset</refname>
@@ -102,6 +102,30 @@
    E_WARNING メッセージが表示されます。未知の OID あるいは無効な OID
    を指定した場合は、おそらく "Could not add variable" のような警告となります。
   </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       hostname の長さが 128 バイト以上の場合、port が負の数または 65535 より大きい場合、
+       または timeout や retries の値が -1 より小さいか大きすぎる場合に、
+       <exceptionname>ValueError</exceptionname> をスローするようになりました。
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/sockets/constants.xml
+++ b/reference/sockets/constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 42402941bba0208a919e03e1320ca4732330eafa Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 890cc22d38fa747c9930fd0d5984c170f2490c1b Maintainer: takagi Status: ready -->
 <appendix xml:id="sockets.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
  &extension.constants;
@@ -47,7 +47,22 @@
    </term>
    <listitem>
     <simpara>
-     PHP 8.3.0 以降で利用可能(FreeBSD のみ)
+     FreeBSD の <literal>divert(4)</literal> インターフェイス用のソケットアドレスファミリで、
+     ファイアウォールによって divert されたパケットを受信するために使用します。
+     PHP 8.3.0 以降で利用可能(FreeBSD のみ)。
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.af-packet">
+   <term>
+    <constant>AF_PACKET</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     低レベルのパケットソケット用のソケットアドレスファミリで、
+     デバイスドライバ(OSI 第 2 層)レベルで生のパケットを送受信するために使用します。
+     PHP 8.5.0 以降で利用可能(Linux のみ)。
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/sockets/functions/socket-addrinfo-lookup.xml
+++ b/reference/sockets/functions/socket-addrinfo-lookup.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e2f2172bf114599926878017ab2dce356956fa9e Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 890cc22d38fa747c9930fd0d5984c170f2490c1b Maintainer: mumumu Status: ready -->
 
 <refentry xml:id="function.socket-addrinfo-lookup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -77,6 +77,15 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       <parameter>hints</parameter> 配列のいずれかの値が
+       int にキャストできない場合は、<exceptionname>TypeError</exceptionname>
+       をスローするようになりました。また、これらの値のいずれかがオーバーフローする場合は、
+       <exceptionname>ValueError</exceptionname> をスローすることがあります。
+      </entry>
+     </row>
      <row>
       <entry>8.0.0</entry>
       <entry>

--- a/reference/sockets/functions/socket-atmark.xml
+++ b/reference/sockets/functions/socket-atmark.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: eef7fb60d16864b253aa3aa95a57f8b1cfd41451 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 2c357a0dd6cc195bce10fa974ea14a2e30eb4b5b Maintainer: mumumu Status: ready -->
 <refentry xml:id="function.socket-atmark" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>socket_atmark</refname>
@@ -46,18 +46,54 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>ソースアドレスを設定するために <function>socket_atmark</function> を使う例</title>
+    <title>ソケットが帯域外データを読み取る準備ができているかを調べるために <function>socket_atmark</function> を使う例</title>
     <programlisting role="php">
 <![CDATA[
 <?php
-// Create a new socket
-$sock = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
-var_dump(socket_atmark($sock));
-// Close
-socket_close($sock);
+$socketServer = socket_create( AF_INET, SOCK_STREAM, SOL_TCP );
+socket_set_option( $socketServer, SOL_SOCKET, SO_REUSEADDR, 1 );
+socket_bind( $socketServer, '127.0.0.1' );
+socket_listen( $socketServer );
+
+$socketClient = socket_create( AF_INET, SOCK_STREAM, SOL_TCP );
+socket_getsockname( $socketServer, $stAddr, $uPort );
+socket_connect( $socketClient, $stAddr, $uPort );
+
+$socket = socket_accept( $socketServer );
+socket_shutdown( $socket, 1 );
+
+$st = 'This is normal data.';
+socket_send( $socketClient, $st, strlen( $st ), 0 );
+$st = '!'; # TCP では緊急データは 1 バイトしか送れません。
+socket_send( $socketClient, $st, strlen( $st ), MSG_OOB );
+$st = 'Not so urgent.';
+socket_send( $socketClient, $st, strlen( $st ), 0 );
+socket_shutdown( $socketClient );
+
+do {
+    if ( socket_atmark( $socket ) ) {
+        $rc = socket_recv( $socket, $st, 65536, MSG_OOB );
+        echo "Received urgent data: ({$rc}) {$st}\n";
+    } else {
+        $rc = socket_recv( $socket, $st, 1024, 0 );
+        echo "Received normal data: ({$rc}) {$st}\n";
+    }
+} while ( $rc > 0 );
+socket_close( $socketServer );
+socket_close( $socketClient );
+socket_close( $socket );
 ?>
 ]]>
     </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+Received normal data: (20) This is normal data.
+Received urgent data: (1) !
+Received normal data: (14) Not so urgent.
+Received normal data: (0)
+]]>
+    </screen>
    </example>
   </para>
  </refsect1>

--- a/reference/sockets/functions/socket-bind.xml
+++ b/reference/sockets/functions/socket-bind.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 35883800e764cccacf5772330bc007b6b08ffc6e Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 890cc22d38fa747c9930fd0d5984c170f2490c1b Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi -->
 <refentry xml:id="function.socket-bind" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -89,6 +89,13 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       <parameter>port</parameter> が 0 未満または 65535 より大きい場合、
+       <exceptionname>ValueError</exceptionname> をスローするようになりました。
+      </entry>
+     </row>
      &sockets.changelog.socket-param;
     </tbody>
    </tgroup>

--- a/reference/sockets/functions/socket-create-listen.xml
+++ b/reference/sockets/functions/socket-create-listen.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 0e097419a847a077c7d8a74ebc5237ba9d8ddc90 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi,jdkfx -->
 <refentry xml:id="function.socket-create-listen" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -77,9 +77,16 @@
     </thead>
     <tbody>
      <row>
+      <entry>8.5.0</entry>
+      <entry>
+       <parameter>port</parameter> が 0 未満または 65535 より大きい場合、
+       <exceptionname>ValueError</exceptionname> をスローするようになりました。
+      </entry>
+     </row>
+     <row>
       <entry>8.4.0</entry>
       <entry>
-       デフォルトの値は <constant>SOMAXCONN</constant> に設定されています。
+       <parameter>backlog</parameter> のデフォルトの値は <constant>SOMAXCONN</constant> に設定されています。
        以前のバージョンでは <literal>128</literal> でした。
       </entry>
      </row>

--- a/reference/sockets/functions/socket-create.xml
+++ b/reference/sockets/functions/socket-create.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: a871ef72edf436c59422dedd538594db2541d5f1 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 890cc22d38fa747c9930fd0d5984c170f2490c1b Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi -->
 <refentry xml:id="function.socket-create" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -229,6 +229,12 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       <constant>AF_PACKET</constant> ファミリーのソケットの作成をサポートするようになりました。
+      </entry>
+     </row>
      <row>
       <entry>8.0.0</entry>
       <entry>

--- a/reference/sockets/functions/socket-getsockname.xml
+++ b/reference/sockets/functions/socket-getsockname.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14dc7c47365f2b71f6c907a5ba5bccf42534d5a9 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 890cc22d38fa747c9930fd0d5984c170f2490c1b Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi -->
 <refentry xml:id="function.socket-getsockname" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -94,6 +94,13 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       <constant>AF_PACKET</constant> ファミリーのソケットで使用した場合に、
+       インターフェイスのインデックスとその文字列表現を取得するようになりました。
+      </entry>
+     </row>
      &sockets.changelog.socket-param;
     </tbody>
    </tgroup>

--- a/reference/sockets/functions/socket-sendto.xml
+++ b/reference/sockets/functions/socket-sendto.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e50e79746736dbdfbabe9bd3566793b3ddf38f58 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 890cc22d38fa747c9930fd0d5984c170f2490c1b Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi -->
 <refentry xml:id="function.socket-sendto" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -139,6 +139,13 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       <parameter>port</parameter> が 0 未満または 65535 より大きい場合に、
+       <exceptionname>ValueError</exceptionname> をスローするようになりました。
+      </entry>
+     </row>
      &sockets.changelog.socket-param;
      <row>
       <entry>8.0.0</entry>

--- a/reference/sockets/functions/socket-set-option.xml
+++ b/reference/sockets/functions/socket-set-option.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 93105c67e470df72333493cc2e534635dd16422d Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 890cc22d38fa747c9930fd0d5984c170f2490c1b Maintainer: takagi Status: ready -->
 <refentry xml:id="function.socket-set-option" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>socket_set_option</refname>
@@ -88,6 +88,17 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       <constant>MCAST_LEAVE_GROUP</constant> または
+       <constant>MCAST_LEAVE_SOURCE_GROUP</constant> を使用し、
+       値が有効なオブジェクトまたは配列でない場合に、例外をスローするようになりました。
+       また、マルチキャストオプションを <constant>AF_INET</constant> または
+       <constant>AF_INET6</constant> ファミリーでないソケットに対して使用した場合に、
+       <exceptionname>ValueError</exceptionname> をスローするようになりました。
+      </entry>
+     </row>
      &sockets.changelog.socket-param;
     </tbody>
    </tgroup>


### PR DESCRIPTION
posix・snmp・sockets・apache・ldap の 5 モジュール計 26 ファイルを英語版の最新に同期。各モジュールが完訳になります。

### reference/posix（6件）— PHP 8.5 changelog 追加
posix_setrlimit / posix_fpathconf / posix_kill / posix_setpgid / posix_isatty / posix_ttyname に、無効な引数・ファイル記述子に対する ValueError・E_WARNING・last_error(EBADF) の 8.5.0 changelog を追加。
- php/doc-en@42ed815

### reference/snmp（6件）— PHP 8.5 ValueError changelog 追加
snmpget / snmpset / snmp2_get / snmp2_set / snmp3_get / snmp3_set に、hostname 長・port 範囲・timeout/retries 値に対する ValueError バリデーションの 8.5.0 changelog を追加。
- php/doc-en@dd22c78

### reference/sockets（9件）— PHP 8.5 changelog + AF_PACKET + 例改善
constants / socket_set_option / socket_addrinfo_lookup / socket_bind / socket_getsockname / socket_sendto / socket_create に 8.5.0 changelog（ValueError、AF_PACKET 対応）を追加。socket_create_listen は changelog 追加と backlog 行の原文修正に追従。socket_atmark のサンプルを帯域外データ読み取り判定の新例に差し替え。
- php/doc-en@890cc22
- php/doc-en@dfd68fd
- php/doc-en@2c357a0

### reference/apache（3件）— LiteSpeed SAPI 対応 + simpara 移行
apache_request_headers / apache_response_headers / book に LiteSpeed を追記し、para→simpara の構造変更に追従。
- php/doc-en@8a0888a

### reference/ldap（2件）— PHP 8.4 LDAP 変更
ldap_exop_sync の未文書化スタブを全面翻訳（説明・全パラメータ・戻り値・seealso）。ldap_exop に 4 引数超の非推奨警告と changelog を追加し、request_oid を LDAP_EXOP_* の総称に更新。
- php/doc-en@9faf021
