### PR TITLE
doc-en と同期し PHP 8.5.0 の非推奨 changelog ほかを反映（15ファイル）

### DIFF
--- a/language/constants.xml
+++ b/language/constants.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: f4f96ef8b2a95283c92ea2183fe1dedf06f3ad22 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 6e885e52412ad979aa5fbb620bb84e886fc0ebe8 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi,mumumu -->
 
- <chapter xml:id="language.constants" xmlns="http://docbook.org/ns/docbook">
+ <chapter xml:id="language.constants" xmlns="http://docbook.org/ns/docbook" annotations="interactive">
   <title>定数</title>
 
   <simpara>
@@ -40,7 +40,7 @@
 <!-- TODO Move into syntax section? -->
    <example>
     <title>有効/無効な定数名の例</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 
@@ -56,8 +56,6 @@ define("2FOO",    "something");
 // 将来 PHP に定数の予約語が追加された場合に
 // スクリプトが動作しなくなる可能性がある
 define("__FOO__", "something"); 
-
-?>
 ]]>
     </programlisting>
    </example>
@@ -181,7 +179,6 @@ define("CONSTANT", "Hello world.");
 echo CONSTANT; // "Hello world."を出力
 echo Constant; // エラーが発生: Undefined constant "Constant"
                // PHP 8.0.0 より前のバージョンでは、"Constant" を出力し、警告が発生
-?>
 ]]>
      </programlisting>
     </example>
@@ -196,23 +193,22 @@ echo Constant; // エラーが発生: Undefined constant "Constant"
 // 単純なスカラー値
 const CONSTANT = 'Hello World';
 
-echo CONSTANT;
+echo CONSTANT . "\n";
 
 // スカラー式
-const ANOTHER_CONST = CONSTANT.'; Goodbye World';
-echo ANOTHER_CONST;
+const ANOTHER_CONST = CONSTANT . '; Goodbye World';
+echo ANOTHER_CONST . "\n";
 
 const ANIMALS = array('dog', 'cat', 'bird');
-echo ANIMALS[1]; // 出力は "cat"
+echo ANIMALS[1] . "\n"; // 出力は "cat"
 
 // 配列の定数
-define('ANIMALS', array(
+define('ANIMALS_DEF', array(
     'dog',
     'cat',
     'bird'
 ));
-echo ANIMALS[1]; // 出力は "cat"
-?>
+echo ANIMALS_DEF[1] . "\n"; // 出力は "cat"
 ]]>
      </programlisting>
     </example>

--- a/language/exceptions.xml
+++ b/language/exceptions.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c81a48e58fc530a74827316027fae74668d17a1d Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi,mumumu -->
 
-<chapter xml:id="language.exceptions" xmlns="http://docbook.org/ns/docbook">
+<chapter xml:id="language.exceptions" xmlns="http://docbook.org/ns/docbook" annotations="interactive">
  <title>例外(exceptions)</title>
+ <note>
+  <simpara><exceptionname>Exception</exceptionname> クラスも参照ください</simpara>
+ </note>
   <para>
    PHP は、他のプログラミング言語に似た例外モデルを持っています。
    PHP 内で例外がスローされ (&throw; され)、それが
@@ -134,7 +137,7 @@
     </para>
     <example>
      <title>エラーを例外に変換する</title>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 function exceptions_error_handler($severity, $message, $filename, $lineno) {
@@ -142,7 +145,6 @@ function exceptions_error_handler($severity, $message, $filename, $lineno) {
 }
 
 set_error_handler('exceptions_error_handler');
-?>
 ]]>
      </programlisting>
     </example>
@@ -179,7 +181,6 @@ try {
 
 // 実行は継続される
 echo "Hello World\n";
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -222,7 +223,6 @@ try {
 
 // 実行は継続される
 echo "Hello World\n";
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -253,7 +253,6 @@ function test() {
 }
 
 echo test();
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -288,8 +287,6 @@ class Test {
 
 $foo = new Test;
 $foo->testing();
-
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -321,8 +318,6 @@ class Test {
 
 $foo = new Test;
 $foo->testing();
-
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -348,7 +343,6 @@ try {
 } catch (SpecificException) {
     print "A SpecificException was thrown, but we don't care about the details.";
 }
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -380,7 +374,6 @@ try {
 } catch (Exception $e) {
     print $e->getMessage();
 }
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -427,13 +420,13 @@ string(6) "Fourth"
  <sect1 xml:id="language.exceptions.extending">
   <title>例外を拡張する</title>
   <para>
-   組み込みの Exception クラスを拡張することで、例外クラスをユーザーが
+   組み込みの <exceptionname>Exception</exceptionname> クラスを拡張することで、例外クラスをユーザーが
    定義することが可能です。以下のメンバーおよびプロパティは、
    組み込みの Exception クラスから派生した子クラスの中でアクセス可能です。
   </para>
   <example>
    <title>組み込みの例外クラス</title>
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
     <![CDATA[
 <?php
 class Exception implements Throwable
@@ -458,15 +451,14 @@ class Exception implements Throwable
     final public  function getPrevious();       // previous exception
     final public  function getTraceAsString();  // formatted string of trace
 
-    // Overrideable
+    // Overridable
     public function __toString();               // formatted string for display
 }
-?>
 ]]>
    </programlisting>
   </example>
   <para>
-   クラスが、組み込みの Exception クラスを拡張し、
+   クラスが、組み込みの <exceptionname>Exception</exceptionname> クラスを拡張し、
    <link linkend="language.oop5.decon">コンストラクタ</link>を再定義した場合、
    全ての利用可能なデータが正しく代入されることを保証するために
    <link linkend="language.oop5.paamayim-nekudotayim">
@@ -544,7 +536,7 @@ class TestException
 }
 
 
-// 例1
+echo "# Example 1\n";
 try {
     $o = new TestException(TestException::THROW_CUSTOM);
 } catch (MyException $e) {      // ここでキャッチされる
@@ -556,10 +548,9 @@ try {
 
 // 実行を継続する
 var_dump($o); // Null
-echo "\n\n";
 
 
-// 例2
+echo "\n\n# Example 2\n";
 try {
     $o = new TestException(TestException::THROW_DEFAULT);
 } catch (MyException $e) {      // この型にはマッチしない
@@ -571,10 +562,9 @@ try {
 
 // 実行を継続する
 var_dump($o); // Null
-echo "\n\n";
 
 
-// 例3
+echo "\n\n# Example 3\n";
 try {
     $o = new TestException(TestException::THROW_CUSTOM);
 } catch (Exception $e) {        // ここでキャッチされる
@@ -583,10 +573,9 @@ try {
 
 // 実行を継続する
 var_dump($o); // Null
-echo "\n\n";
 
 
-// 例4
+echo "\n\n# Example 4\n";
 try {
     $o = new TestException();
 } catch (Exception $e) {        //  スキップされる、例外は発生しない
@@ -595,8 +584,6 @@ try {
 
 // 実行を継続する
 var_dump($o); // TestException
-echo "\n\n";
-?>
 ]]>
    </programlisting>
   </example>

--- a/language/expressions.xml
+++ b/language/expressions.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: f4f96ef8b2a95283c92ea2183fe1dedf06f3ad22 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 6e885e52412ad979aa5fbb620bb84e886fc0ebe8 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi,mumumu -->
- <chapter xml:id="language.expressions" xmlns="http://docbook.org/ns/docbook">
+ <chapter xml:id="language.expressions" xmlns="http://docbook.org/ns/docbook" annotations="interactive">
   <title>式</title>
   
   <simpara>
@@ -32,7 +32,7 @@
    例えば、次の関数を考えてみましょう。
    
    <informalexample>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 function foo () {
@@ -155,7 +155,7 @@ function foo () {
   </para>
   <para>
    <informalexample>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 $first ? $second : $third
@@ -179,24 +179,34 @@ $first ? $second : $third
     <programlisting role="php">
 <![CDATA[
 <?php
-function double($i) {
-    return $i*2;
+function double($i)
+{
+    return $i * 2;
 }
+
 $b = $a = 5;        /* 値 5 を $a と $b に代入します */
 $c = $a++;          /* 後置加算なので、$c に代入される値は、$a の
                        元の値 (5) です */
+print "a = {$a}; b = {$b}; c = {$c}" . PHP_EOL;
+
 $e = $d = ++$b;     /* 前置加算なので、$d と $e に代入される値は、
                        加算後の $b の値 (6) です */
+print "b = {$b}; d = {$d}; e = {$e}" . PHP_EOL;
 
 /* ここまでで、$d と $e は、6 です */
 
 $f = double($d++);  /* $f には、$d が加算される前の値を2倍した値、
                        つまり 2*6 = 12 が、代入されます。 */
+print "d = {$d}; f = {$f}" . PHP_EOL;
+
 $g = double(++$e);  /* $g には、$e が加算された後の値を2倍した値、
                         つまり 2*7 = 14 が、代入されます。 */
+print "e = {$e}; g = {$g}" . PHP_EOL;
+
 $h = $g += 10;      /* まず、$g に 10 が加算され、24 になります。
                        代入値 (24) は、$h に代入されます。
                        そして、$h も同様に 24 になります。 */
+print "g = {$g}; h = {$h}" . PHP_EOL;
 ?>
 ]]>
     </programlisting>

--- a/reference/curl/constants_curl_setopt.xml
+++ b/reference/curl/constants_curl_setopt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d7d6dd60085409b295916649e4bd7107742659a2 Maintainer: nsfisis Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: nsfisis Status: ready -->
  <variablelist role="constant_list">
   <title><function>curl_setopt</function></title>
   <varlistentry xml:id="constant.curlopt-abstract-unix-socket">
@@ -185,7 +185,7 @@
    </term>
    <listitem>
     <para>
-     相手を検証するための証明書を格納した PEM ファイル名を <type>string</type> で指定します。
+     相手を検証するための証明書を含む、PEM 形式でエンコードされたコンテンツを、バイナリ <type>string</type> で指定します。
      このオプションは <constant>CURLOPT_CAINFO</constant> を上書きします。
      PHP 8.2.0 以降かつ cURL 7.77.0 以降で利用可能です。
     </para>
@@ -1727,12 +1727,12 @@
     (<type>int</type>)
    </term>
    <listitem>
-    <para>
+    <simpara>
      HTTP リダイレクトの最大回数を指定します。<constant>CURLOPT_FOLLOWLOCATION</constant> と合わせて使用してください。
      デフォルト値の <literal>20</literal> は、無限リダイレクトを防ぐために設定されています。
      <literal>-1</literal> を指定すると何度でもリダイレクトするようになります。<literal>0</literal> を指定すると一切リダイレクトしなくなります。
      cURL 7.5.0 以降で利用可能です。
-    </para>
+    </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.curlopt-max-recv-speed-large">

--- a/reference/fileinfo/functions/finfo-buffer.xml
+++ b/reference/fileinfo/functions/finfo-buffer.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 82ddd2ec8ad195035dcb57dd8f97d27b83ddc126 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: e5c8e7add9291c70be2ecd046de6ecfd034545a9 Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.finfo-buffer">
  <refnamediv>
@@ -85,6 +85,12 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       <parameter>context</parameter> パラメータは、無視されるため非推奨になりました。
+      </entry>
+     </row>
      &fileinfo.changelog.finfo-object;
      <row>
       <entry>8.0.0</entry>

--- a/reference/reflection/reflectionclass/getconstant.xml
+++ b/reference/reflection/reflectionclass/getconstant.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ec2fe9a592f794978114ef5021db9f1d00c2e05d Maintainer: takagi Status: ready -->
+<!-- EN-Revision: e5c8e7add9291c70be2ecd046de6ecfd034545a9 Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 
 <refentry xml:id="reflectionclass.getconstant" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -43,7 +43,31 @@
    そのクラスに定数が見つからなかった場合は、&false; を返します。
   </para>
  </refsect1>
- 
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       存在しない定数に対して
+       <methodname>ReflectionClass::getConstant</methodname>
+       を呼び出すのは非推奨となりました。
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/reflection/reflectionmethod/setaccessible.xml
+++ b/reference/reflection/reflectionmethod/setaccessible.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ce98b568f85353c4bf263133f09c4db9294833f9 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: e5c8e7add9291c70be2ecd046de6ecfd034545a9 Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 
 <refentry xml:id="reflectionmethod.setaccessible" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -53,6 +53,35 @@
   <para>
    &return.void;
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       効果がなくなったため、このメソッドは非推奨になりました。
+      </entry>
+     </row>
+     <row>
+      <entry>8.1.0</entry>
+      <entry>
+       このメソッドをコールしても何も起こりません。
+       全てのメソッドはデフォルトで呼び出し可能です。
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/reflection/reflectionproperty/getdefaultvalue.xml
+++ b/reference/reflection/reflectionproperty/getdefaultvalue.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9f89eee340331eb13a38a95ea64f47dfe866d46e Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: mumumu Status: ready -->
 
 <refentry xml:id="reflectionproperty.getdefaultvalue" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -26,12 +26,36 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    プロパティに何かしらデフォルト値が存在する場合(&null;も含みます)、
    それを返します。デフォルト値がない場合、&null; を返します。
-   デフォルト値が &null; の場合と、型付きプロパティが初期化されてない場合は区別できません。 
+   デフォルト値が &null; の場合と、型付きプロパティが初期化されてない場合は区別できません。
    それらを区別するには、<methodname>ReflectionProperty::hasDefaultValue</methodname> を使って下さい。
-  </para>
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       デフォルト値を持たないプロパティに対して
+       <methodname>ReflectionProperty::getDefaultValue</methodname>
+       を呼び出すのは非推奨となりました。
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/reflection/reflectionproperty/setaccessible.xml
+++ b/reference/reflection/reflectionproperty/setaccessible.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ce98b568f85353c4bf263133f09c4db9294833f9 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: e5c8e7add9291c70be2ecd046de6ecfd034545a9 Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 
 <refentry xml:id="reflectionproperty.setaccessible" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -54,6 +54,35 @@
   <para>
    &return.void;
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       効果がなくなったため、このメソッドは非推奨になりました。
+      </entry>
+     </row>
+     <row>
+      <entry>8.1.0</entry>
+      <entry>
+       このメソッドをコールしても何も起こりません。
+       全てのプロパティはデフォルトでアクセス可能です。
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/spl/functions/spl-autoload-unregister.xml
+++ b/reference/spl/functions/spl-autoload-unregister.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 60809ebcf7d0c261b2f00e093e4fab70326ffc7b Maintainer: takagi Status: ready -->
+<!-- EN-Revision: e5c8e7add9291c70be2ecd046de6ecfd034545a9 Maintainer: takagi Status: ready -->
 <!-- CREDITS: shimooka -->
 <refentry xml:id="function.spl-autoload-unregister" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -45,6 +45,32 @@
   <para>
    &return.success;
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       全てのオートローダの登録を解除するために、
+       <function>spl_autoload_call</function> 関数をコールバック引数として渡すことは
+       非推奨になりました。
+       代わりに <function>spl_autoload_functions</function> の戻り値を反復処理し、
+       それぞれの値に対して <function>spl_autoload_unregister</function> を呼び出してください。
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
 </refentry>

--- a/reference/spl/splobjectstorage/attach.xml
+++ b/reference/spl/splobjectstorage/attach.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: a0d62151102e4bf83e2bb4068782757d20ba086d Maintainer: takagi Status: ready -->
+<!-- EN-Revision: e5c8e7add9291c70be2ecd046de6ecfd034545a9 Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="splobjectstorage.attach" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -61,6 +61,30 @@
   <para>
    &return.void;
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       このメソッドは非推奨となりました。
+       代わりに <methodname>SplObjectStorage::offsetSet</methodname>
+       を使用してください。
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/spl/splobjectstorage/contains.xml
+++ b/reference/spl/splobjectstorage/contains.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ce98b568f85353c4bf263133f09c4db9294833f9 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: e5c8e7add9291c70be2ecd046de6ecfd034545a9 Maintainer: takagi Status: ready -->
 <refentry xml:id="splobjectstorage.contains" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SplObjectStorage::contains</refname>
@@ -44,6 +44,29 @@
   <para>
    <type>object</type> がストレージに存在する場合に &true;、それ以外の場合に &false; を返します。
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       このメソッドは非推奨となりました。代わりに
+       <methodname>SplObjectStorage::offsetExists</methodname> を使用してください。
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/spl/splobjectstorage/detach.xml
+++ b/reference/spl/splobjectstorage/detach.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ce98b568f85353c4bf263133f09c4db9294833f9 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: e5c8e7add9291c70be2ecd046de6ecfd034545a9 Maintainer: takagi Status: ready -->
 <refentry xml:id="splobjectstorage.detach" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SplObjectStorage::detach</refname>
@@ -44,6 +44,30 @@
   <para>
    &return.void;
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       このメソッドは非推奨となりました。
+       代わりに <methodname>SplObjectStorage::offsetUnset</methodname>
+       を使用してください。
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/strings/functions/chr.xml
+++ b/reference/strings/functions/chr.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 45042fef652f1b4e904e809fcbfcf31f6c60670b Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: e5c8e7add9291c70be2ecd046de6ecfd034545a9 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: shimooka,mumumu -->
 <refentry xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://docbook.org/ns/docbook" xml:id="function.chr">
  <refnamediv>
@@ -79,6 +79,12 @@ $bytevalue %= 256;
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       <literal>[0, 255]</literal> の範囲外の整数を渡すことは非推奨になりました。
+      </entry>
+     </row>
      <row>
       <entry>7.4.0</entry>
       <entry>

--- a/reference/strings/functions/ord.xml
+++ b/reference/strings/functions/ord.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 45042fef652f1b4e904e809fcbfcf31f6c60670b Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: e5c8e7add9291c70be2ecd046de6ecfd034545a9 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: shimooka,mumumu -->
 <refentry xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://docbook.org/ns/docbook" xml:id="function.ord">
  <refnamediv>
@@ -52,6 +52,28 @@
   <para>
    0 から 255 までの整数値を返します。
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       シングルバイトではない文字列を渡すことは非推奨になりました。
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">


### PR DESCRIPTION
doc-en と同期し、PHP 8.5.0 の非推奨 changelog を中心に反映しました（既訳更新 15 件）。
これにより **spl / reflection / strings / fileinfo / curl の 5 モジュールが完訳**になります。

## 翻訳内容

### language（3件）
- language/expressions.xml — WASM 実行可能サンプルの有効化（annotations 属性・コード例の同期、訳文変更なし）
  1. php/doc-en@6e885e5
- language/constants.xml — WASM 実行可能サンプルの有効化（訳文変更なし）
  1. php/doc-en@6e885e5
- language/exceptions.xml — WASM 実行可能サンプルの有効化 + Exception クラス参照 note の追加
  1. php/doc-en@6e885e5
  2. php/doc-en@525aa5f

### reference/reflection（4件）— PHP 8.5.0 非推奨 changelog の追加
- reference/reflection/reflectionproperty/setaccessible.xml
  1. php/doc-en@e5c8e7a
- reference/reflection/reflectionmethod/setaccessible.xml
  1. php/doc-en@e5c8e7a
- reference/reflection/reflectionclass/getconstant.xml
  1. php/doc-en@e5c8e7a
- reference/reflection/reflectionproperty/getdefaultvalue.xml
  1. php/doc-en@e5c8e7a
  2. php/doc-en@525aa5f

### reference/spl（4件）— PHP 8.5.0 非推奨 changelog の追加
- reference/spl/functions/spl-autoload-unregister.xml — spl_autoload_call 引数の非推奨
  1. php/doc-en@e5c8e7a
- reference/spl/splobjectstorage/attach.xml — offsetSet を推奨
  1. php/doc-en@e5c8e7a
- reference/spl/splobjectstorage/contains.xml — offsetExists を推奨
  1. php/doc-en@e5c8e7a
- reference/spl/splobjectstorage/detach.xml — offsetUnset を推奨
  1. php/doc-en@e5c8e7a

### reference/strings/functions（2件）— PHP 8.5.0 非推奨 changelog の追加
- reference/strings/functions/ord.xml — シングルバイト以外の文字列が非推奨
  1. php/doc-en@e5c8e7a
- reference/strings/functions/chr.xml — [0, 255] 範囲外の整数が非推奨
  1. php/doc-en@e5c8e7a

### 独立ファイル
- reference/fileinfo/functions/finfo-buffer.xml — PHP 8.5.0 で context パラメータ非推奨の changelog 追加
  1. php/doc-en@e5c8e7a
- reference/curl/constants_curl_setopt.xml — CURLOPT_CAINFO_BLOB の説明の誤り（旧訳「PEM ファイル名を指定」）を、原文 "A binary string of PEM encoded content" に合わせて「PEM エンコードされたコンテンツをバイナリ string で指定」に修正
  1. php/doc-en@e38c916
  2. php/doc-en@525aa5f
