### PR TITLE
doc-en と同期し INI ディレクティブの PHP 8.5.0 変更を反映（7ファイル）

### DIFF
--- a/appendices/ini.core.xml
+++ b/appendices/ini.core.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 185dda85976e5ed392664db011abda0110726c0d Maintainer: takagi Status: ready -->
+<!-- EN-Revision: a52e3d27cca786940272d0ae8efc21b5d6739070 Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa,shimooka,mumumu -->
 
  <section xml:id="ini.core" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -64,7 +64,7 @@
         <entry><link linkend="ini.disable-classes">disable_classes</link></entry>
         <entry>""</entry>
         <entry>&php.ini; のみ</entry>
-        <entry></entry>
+        <entry>PHP 8.5.0 以降は削除されています。</entry>
        </row>
        <row>
         <entry><link linkend="ini.exit-on-timeout">exit_on_timeout</link></entry>
@@ -237,15 +237,15 @@
        <type>string</type>
       </term>
       <listitem>
-       <para>
+       <simpara>
         このディレクティブを使うと、特定のクラスを無効にすることができます。
         クラス名の一覧をカンマ区切りで指定します。
         クラスを無効にすると、クラスのインスタンス化ができなくなります。
-       </para>
-       <para>
+       </simpara>
+       <simpara>
         このディレクティブを使って無効にできるのは、内部クラスのみです。
         ユーザーが定義したクラスは影響を受けません。
-       </para>
+       </simpara>
        <simpara>
         このディレクティブは &php.ini; で設定しなければなりません。
         &httpd.conf; では設定できません。
@@ -256,6 +256,7 @@
          十分なセキュリティ対策とはみなすべきではありません。
         </simpara>
        </warning>
+       &warn.removed.feature-8-5-0;
       </listitem>
      </varlistentry>
 
@@ -611,7 +612,7 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
         <entry><link linkend="ini.register-argc-argv">register_argc_argv</link></entry>
          <entry>"1"</entry>
          <entry><constant>INI_PERDIR</constant></entry>
-         <entry></entry>
+         <entry>PHP 8.5.0 以降は非推奨です。</entry>
        </row>
        <row>
         <entry><link linkend="ini.enable-post-data-reading">enable_post_data_reading</link></entry>
@@ -805,6 +806,18 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
         <link linkend="features.commandline">コマンドライン</link>
         も参照ください。
         </simpara>
+        &warn.deprecated.feature-8-5-0;
+        <note>
+         <simpara>
+          CLI 以外の SAPI において、クエリ文字列から
+          <code>$_SERVER['argc']</code> および <code>$_SERVER['argv']</code>
+          を導出する挙動は非推奨になりました。
+          <literal>register_argc_argv=0</literal> を設定し、
+          その使い方が安全であることを確認した上で、
+          <varname>$_GET</varname> または <code>$_SERVER['QUERY_STRING']</code>
+          のいずれかに切り替えて情報を取得するようにしてください。
+         </simpara>
+        </note>
        </listitem>
       </varlistentry>
 

--- a/appendices/ini.list.xml
+++ b/appendices/ini.list.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: b1116af46680f7baf89c46610430a3b63ce9a1f0 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: a52e3d27cca786940272d0ae8efc21b5d6739070 Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa,shimooka,mumumu -->
 
  <section xml:id="ini.list" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
@@ -210,7 +210,7 @@
        <entry><link linkend="ini.disable-classes">disable_classes</link></entry>
        <entry><literal>""</literal></entry>
        <entry>&php.ini; のみ</entry>
-       <entry></entry>
+       <entry>PHP 8.5.0 以降では削除されました</entry>
       </row>
       <row>
        <entry><link linkend="ini.disable-functions">disable_functions</link></entry>
@@ -554,13 +554,13 @@
        <entry><link linkend="ini.register-argc-argv">register_argc_argv</link></entry>
        <entry><literal>"1"</literal></entry>
        <entry><constant>INI_PERDIR</constant></entry>
-       <entry></entry>
+       <entry>PHP 8.5.0 以降は非推奨</entry>
       </row>
       <row>
        <entry><link linkend="ini.report-memleaks">report_memleaks</link></entry>
        <entry><literal>"1"</literal></entry>
        <entry><constant>INI_ALL</constant></entry>
-       <entry></entry>
+       <entry>PHP 8.5.0 以降は非推奨</entry>
       </row>
       <row>
        <entry>report_zend_debug</entry>

--- a/features/commandline.xml
+++ b/features/commandline.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 96b10a98853e3b8236504e5775f95eb4a15c82c3 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: b08b472de7041be8dbae153556b714efa93f20c0 Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa,shimooka,mumumu -->
 <chapter xml:id="features.commandline" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>PHP をコマンドラインから使用する</title>
@@ -206,6 +206,7 @@ if (php_sapi_name() === 'cli') {
             </informalexample>
            </para>
           </warning>
+          &warn.deprecated.feature-8-5-0;
           </entry>
          </row>
          <row>
@@ -363,7 +364,6 @@ Usage: php [options] [-f] <file> [--] [args...]
   -s               Output HTML syntax highlighted source.
   -v               Version number
   -w               Output source with stripped comments and whitespace.
-  -z <file>        Load Zend extension <file>.
 
   args...          Arguments passed to script. Use -- args when first argument
                    starts with - or script is read from stdin
@@ -844,29 +844,13 @@ Zend Engine v2.3.0, Copyright (c) 1998-2009 Zend Technologies
        </entry>
       </row>
       <row>
-       <entry>-z</entry>
-       <entry>--zend-extension</entry>
-       <entry>
-        <para>
-         Zend 拡張モジュールをロードします。ファイル名のみが指定された場合、
-         PHP はこの拡張をカレントのシステムのデフォルトライブラリパスから
-         ロードしようとします
-         (Linux システムの場合は <filename>/etc/ld.so.conf</filename> で
-         指定されています)。
-         ファイル名を絶対パスで指定した場合、システムのライブラリサーチパスを
-         使用しません。ディレクトリ情報を有する相対ファイル名を
-         指定すると、PHP は
-         カレントのディレクトリの相対パスから拡張モジュールをロードする
-         ことのみを行ないます。
-        </para>
-       </entry>
-      </row>
-      <row>
        <entry></entry>
        <entry>--ini</entry>
        <entry>
         <para>
          設定ファイルの名前、設定ファイルを検索するディレクトリを表示します。
+         オプションで <literal>--ini=diff</literal> を渡すと、
+         ロードされた設定ファイルとデフォルトの設定との差分を表示します。
          <example>
           <title><literal>--ini</literal> の例</title>
           <programlisting role="shell">
@@ -879,6 +863,11 @@ Additional .ini files parsed:      (none)
 ]]>
           </programlisting>
          </example>
+         <note>
+          <simpara>
+           <literal>--ini=diff</literal> オプションは PHP 8.5.0 より前では使用できません。
+          </simpara>
+         </note>
         </para>
        </entry>
       </row>

--- a/install/fpm/configuration.xml
+++ b/install/fpm/configuration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: f0149750aedec8b2eaa46338d90213dc4767d8b3 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 1f01e2a8e478c63bd6598cde09235ec027b23dd5 Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 
   <sect1 xml:id="install.fpm.configuration" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -395,17 +395,17 @@
        <para>
         <literal>static</literal> - 子プロセスの数は固定 (<literal>pm.max_children</literal>) です。
        </para>
-       <para>
+       <simpara>
         <literal>ondemand</literal> - プロセスを必要に応じて立ち上げます。
         dynamic とは対照的に、リクエストされると
         <literal>pm.start_servers</literal> で指定しただけサービスを開始します。
-       </para>
-       <para>
+       </simpara>
+       <simpara>
         <literal>dynamic</literal> - 子プロセスの数は、
         <literal>pm.max_children</literal>、<literal>pm.start_servers</literal>、
         <literal>pm.min_spare_servers</literal>、<literal>pm.max_spare_servers</literal>
         の内容に基づいて動的に設定されます。
-       </para>
+       </simpara>
       </listitem>
      </varlistentry>
      <varlistentry xml:id="pm.max-children">
@@ -414,11 +414,11 @@
        <type>int</type>
       </term>
       <listitem>
-       <para>
+       <simpara>
         <literal>pm</literal> が <literal>static</literal> の場合は作成される子プロセスの数、
-        <literal>pm</literal> が <literal>dynamic</literal> の場合は作成される子プロセスの最大数。
+        <literal>pm</literal> が <literal>dynamic</literal> または <literal>ondemand</literal> の場合は作成される子プロセスの最大数。
         このオプションは必須です。
-       </para>
+       </simpara>
        <para>
         このオプションは、同時に処理できるリクエストの最大数を設定します。 
         mpm_prefork での ApacheMaxClients ディレクティブや、
@@ -1060,8 +1060,7 @@ php_admin_value[memory_limit] = 32M
      <literal>php_value</literal> や
      <literal>php_flag</literal> で渡した PHP の設定は、その前に設定されていた内容を上書きします。
      ただし
-     <link linkend="ini.disable-functions">disable_functions</link> や
-     <link linkend="ini.disable-classes">disable_classes</link> は別で、
+     <link linkend="ini.disable-functions">disable_functions</link> は別で、
      <filename>php.ini</filename> で定義された値を上書きするのではなく、
      新たに指定した値を追記することになります。
     </para>

--- a/reference/errorfunc/ini.xml
+++ b/reference/errorfunc/ini.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 72a6f3d35e914602703b698a5d8f52732b61ed3e Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: e5ff446c832aded712d45c885609ffdd277e6a49 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi,mumumu -->
 <section xml:id="errorfunc.configuration" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.runtime;
@@ -66,7 +66,7 @@
      <entry><link linkend="ini.report-memleaks">report_memleaks</link></entry>
      <entry>"1"</entry>
      <entry><constant>INI_ALL</constant></entry>
-     <entry></entry>
+     <entry>PHP 8.5.0 以降で非推奨です。</entry>
     </row>
     <row>
      <entry><link linkend="ini.track-errors">track_errors</link></entry>
@@ -201,7 +201,6 @@
      </note>
     </listitem>
    </varlistentry>
-
    <varlistentry xml:id="ini.display-errors">
     <term>
      <parameter>display_errors</parameter>
@@ -209,18 +208,35 @@
     </term>
     <listitem>
      <para>
-      エラーをHTML出力の一部として画面に出力するかどうかを定義します。
+      エラーを出力の一部として画面に表示するか、ユーザーから隠すかを決めます。
+      <itemizedlist>
+       <listitem>
+        <simpara>
+         <literal>Off</literal> - エラーを一切表示しません。
+        </simpara>
+       </listitem>
+       <listitem>
+        <simpara>
+         <literal>On</literal> または <literal>stdout</literal> - エラーを <literal>stdout</literal> に表示します。これがデフォルトです。
+        </simpara>
+       </listitem>
+       <listitem>
+        <simpara>
+         <literal>stderr</literal> - エラーを <literal>stderr</literal> に表示します。<literal>CLI</literal>、<literal>phpdbg</literal>、<literal>CGI</literal> の SAPI でのみ有効です。
+        </simpara>
+       </listitem>
+      </itemizedlist>
      </para>
-     <para>
-      "stderr" を指定すると、エラーの内容を <literal>stdout</literal>
-      (標準出力) ではなく <literal>stderr</literal> (標準エラー出力)
-      に送ります。
-     </para>
+     <simpara>
+       同梱されている <literal>php.ini-development</literal> ではこれを
+       <literal>On</literal> に、<literal>php.ini-production</literal> では
+       <literal>Off</literal> に設定しています。
+     </simpara>
      <note>
-      <para>
+      <simpara>
       開発をサポートする仕組みであり、本番のシステムでは
       使用すべきではありません (例えばインターネットに接続されたシステムなど)。
-      </para>
+      </simpara>
      </note>
      <note>
       <para>
@@ -325,14 +341,15 @@
      <type>bool</type>
     </term>
     <listitem>
-     <para>
+     <simpara>
       このパラメータを On (デフォルト) にすると、Zend メモリマネージャーが検出した
       メモリリークの報告を表示します。この報告は、Posix プラットフォームでは標準エラー出力に送られます。
       Windows では、デバッガに OutputDebugString() を使って送られ、
       <link xlink:href="&url.dbgview;">DbgView</link> のようなツールで見ることができます。
       このパラメータが使えるのはデバッグビルドだけであり、かつ
       error_reporting で <constant>E_WARNING</constant> を有効にしている場合のみです。
-     </para>
+     </simpara>
+     &warn.deprecated.feature-8-5-0;
     </listitem>
    </varlistentry>
 

--- a/reference/info/functions/cli-set-process-title.xml
+++ b/reference/info/functions/cli-set-process-title.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 2df224f44552cfc88fad705cca33c4cdb01d62ed Maintainer: takagi Status: ready -->
+<!-- EN-Revision: b08b472de7041be8dbae153556b714efa93f20c0 Maintainer: takagi Status: ready -->
 
 <refentry xml:id="function.cli-set-process-title" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,12 +15,12 @@
    <methodparam><type>string</type><parameter>title</parameter></methodparam>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    プロセスのタイトルを設定します。これは <command>top</command> や
    <command>ps</command> といったツールで表示されます。
    この関数は、
    <link linkend="features.commandline">CLI</link> モードでしか使えません。
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -30,9 +30,9 @@
    <varlistentry>
     <term><parameter>title</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       新しいタイトル。
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -40,26 +40,49 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
    
-  <para>
+  <simpara>
    OS がこの機能に対応していない場合に <constant>E_WARNING</constant>
    が発生します。
-  </para>
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       長すぎるプロセスのタイトルを設定しようとすると、
+       <function>cli_set_process_title</function> は
+       <constant>E_WARNING</constant> を発生させるようになりました。
+       以前は、タイトルは切り詰められていました。
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example>
-    <title><function>cli_set_process_title</function> の例</title>
-    <programlisting role="php">
+  <informalexample>
+   <programlisting role="php">
 <![CDATA[
 <?php
 $title = "My Amazing PHP Script";
@@ -74,18 +97,15 @@ if (!cli_set_process_title($title)) {
 }
 ?>
 ]]>
-    </programlisting>
-   </example>
-  </para>
+   </programlisting>
+  </informalexample>
  </refsect1>
  
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>cli_get_process_title</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>cli_get_process_title</function></member>
+  </simplelist>
  </refsect1>
 </refentry>
 

--- a/reference/opcache/ini.xml
+++ b/reference/opcache/ini.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 8ea24dc32374bf4f6b04005e317101e4c65a0214 Maintainer: satoruyoshida Status: ready -->
+<!-- EN-Revision: f2cdcd5af4558c22db95463b6ccdd25e4cea3cf5 Maintainer: satoruyoshida Status: ready -->
 <!-- CREDITS: mumumu -->
 <sect1 xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="opcache.configuration">
  &reftitle.runtime;
@@ -308,9 +308,9 @@
      </row>
      <row>
       <entry><link linkend="ini.opcache.jit-hot-loop">opcache.jit_hot_loop</link></entry>
-      <entry>64</entry>
+      <entry>61</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
-      <entry>PHP 8.0.0 以降で利用可能</entry>
+      <entry>PHP 8.0.0 以降で利用可能。PHP 8.5.0 より前のバージョンでは、デフォルト値は 64 でした。</entry>
      </row>
      <row>
       <entry><link linkend="ini.opcache.jit-hot-func">opcache.jit_hot_func</link></entry>
@@ -1329,6 +1329,12 @@ function getA() { return A; }
      デフォルトの値が使われます。特に <literal>0</literal> を設定すると、
      JIT はどのイテレーションにおいてもコンパイルとトレースをしなくなります。
     </simpara>
+    <note>
+     <simpara>
+      このパラメータには素数を設定することを推奨します。
+      こうすることで、ループのイテレーション回数の倍数になるのを防げます。
+     </simpara>
+    </note>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="ini.opcache.jit-hot-func">


### PR DESCRIPTION
## 翻訳内容

### INI ディレクティブの PHP 8.5.0 同期（7件）

- appendices/ini.core.xml — disable_classes（8.5.0 削除）/register_argc_argv（8.5.0 非推奨）を追記
  1. php/doc-en@a52e3d2
- appendices/ini.list.xml — disable_classes/register_argc_argv/report_memleaks の 8.5.0 非推奨・削除を一覧表に追記
  1. php/doc-en@a52e3d2
- install/fpm/configuration.xml — pm 説明の構造調整、pm.max_children に ondemand を追記、disable_classes 言及を削除
  1. php/doc-en@a52e3d2
  2. php/doc-en@1f01e2a
- features/commandline.xml — -z/--zend-extension 削除、--ini=diff 追加、max_execution_time の 8.5.0 非推奨警告
  1. php/doc-en@a52e3d2
  2. php/doc-en@b08b472
- reference/errorfunc/ini.xml — display_errors の値説明を箇条書き化、report_memleaks の 8.5.0 非推奨追記
  1. php/doc-en@d4d5216
  2. php/doc-en@a52e3d2
  3. php/doc-en@8c2b31a
  4. php/doc-en@65c33d8
  5. php/doc-en@e5ff446
- reference/info/functions/cli-set-process-title.xml — 8.5.0 changelog（長すぎるタイトルで E_WARNING）を追加
  1. php/doc-en@b08b472
- reference/opcache/ini.xml — opcache.jit_hot_loop のデフォルト値 64→61、changelog、素数推奨の note を追加
  1. php/doc-en@f2cdcd5
