### PR TITLE
9モジュールを完訳: PHP 8.4/8.5 の更新を同期し未訳3件を新規翻訳

### DIFF
--- a/reference/errorfunc/functions/debug-backtrace.xml
+++ b/reference/errorfunc/functions/debug-backtrace.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: a124543dd3f6b1e5567b07420d23899e582514dc Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: a8dfc2c067cbaadab174f0470e3d0dd0bc811d73 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi,mumumu -->
 <refentry xml:id="function.debug-backtrace" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -58,7 +58,7 @@
            <tbody>
             <row>
              <entry><code>debug_backtrace()</code></entry>
-             <entry morerows="2" valign="middle">
+             <entry morerows="1" valign="middle">
               インデックスを両方収集します。
              </entry>
             </row>
@@ -66,13 +66,13 @@
              <entry><code>debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT)</code></entry>
             </row>
             <row>
-             <entry><code>debug_backtrace(1)</code></entry>
+             <entry><code>debug_backtrace(~DEBUG_BACKTRACE_PROVIDE_OBJECT)</code></entry>
+             <entry morerows="1" valign="middle">
+              インデックス <literal>"object"</literal> を省略し、<literal>"args"</literal> を収集します。
+             </entry>
             </row>
             <row>
              <entry><code>debug_backtrace(0)</code></entry>
-             <entry valign="middle">
-              インデックス <literal>"object"</literal> を省略し、<literal>"args"</literal> を収集します。
-             </entry>
             </row>
             <row>
              <entry><code>debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS)</code></entry>
@@ -81,16 +81,13 @@
              </entry>
             </row>
             <row>
-             <entry><code>debug_backtrace(2)</code></entry>
+             <entry><code>debug_backtrace(~DEBUG_BACKTRACE_PROVIDE_OBJECT | DEBUG_BACKTRACE_IGNORE_ARGS)</code></entry>
             </row>
             <row>
              <entry><code>debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT|DEBUG_BACKTRACE_IGNORE_ARGS)</code></entry>
-             <entry morerows="1" valign="middle">
+             <entry valign="middle">
               インデックス <literal>"object"</literal> を収集し、<literal>"args"</literal> を省略します。
              </entry>
-            </row>
-            <row>
-             <entry><code>debug_backtrace(3)</code></entry>
             </row>
            </tbody>
           </tgroup>
@@ -173,7 +170,7 @@
        <entry>object</entry>
        <entry><type>object</type></entry>
        <entry>
-        カレントの<link linkend="language.oop5">オブジェクト</link>。
+        <constant>DEBUG_BACKTRACE_PROVIDE_OBJECT</constant> が指定されている場合、カレントの<link linkend="language.oop5">オブジェクト</link>。
        </entry>
       </row>
       <row>
@@ -192,6 +189,7 @@
         関数の内部の場合、関数の引数のリストとなります。
         インクルードされたファイル内では、
         読み込まれたファイルの名前となります。
+        ただし、<constant>DEBUG_BACKTRACE_IGNORE_ARGS</constant> が指定されている場合を除きます。
        </entry>
       </row>
      </tbody>

--- a/reference/image/functions/imagedashedline.xml
+++ b/reference/image/functions/imagedashedline.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: d56953fc8d508615279a2220f21d7fb6c3298417 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: shimooka,mumumu -->
 <refentry xml:id="function.imagedashedline" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -20,7 +20,7 @@
   </methodsynopsis>
   <para>
    これは古い関数です。代わりに <function>imagesetstyle</function> と
-   <function>imageline</function> の組み合せを使用してください。
+   <function>imageline</function> の組み合せを使用してください。0, 0 は画像の左上の角です。
   </para>
  </refsect1>
  <refsect1 role="parameters">
@@ -32,7 +32,7 @@
      <term><parameter>x1</parameter></term>
      <listitem>
       <para>
-       左上の x 座標。
+       1 つ目の点の x 座標。
       </para>
      </listitem>
     </varlistentry>
@@ -40,7 +40,7 @@
      <term><parameter>y1</parameter></term>
      <listitem>
       <para>
-       左上の y 座標 0。0 は画像の左上の角です。
+       1 つ目の点の y 座標。
       </para>
      </listitem>
     </varlistentry>
@@ -48,7 +48,7 @@
      <term><parameter>x2</parameter></term>
      <listitem>
       <para>
-       右下の x 座標。
+       2 つ目の点の x 座標。
       </para>
      </listitem>
     </varlistentry>
@@ -56,7 +56,7 @@
      <term><parameter>y2</parameter></term>
      <listitem>
       <para>
-       右下の y 座標。
+       2 つ目の点の y 座標。
       </para>
      </listitem>
     </varlistentry>

--- a/reference/image/functions/imagerectangle.xml
+++ b/reference/image/functions/imagerectangle.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: d56953fc8d508615279a2220f21d7fb6c3298417 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: shimooka -->
 <refentry xml:id="function.imagerectangle" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -20,6 +20,7 @@
   </methodsynopsis>
   <para>
    <function>imagerectangle</function> は、指定した座標から始まる矩形を作成します。
+   0, 0 が画像の左上隅を表します。
   </para>
  </refsect1>
  <refsect1 role="parameters">
@@ -40,7 +41,6 @@
      <listitem>
       <para>
        左上の y 座標。
-       0, 0 が画像の左上隅を表します。
       </para>
      </listitem>
     </varlistentry>

--- a/reference/image/functions/imagesetbrush.xml
+++ b/reference/image/functions/imagesetbrush.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: d56953fc8d508615279a2220f21d7fb6c3298417 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: shimooka -->
 <refentry xml:id="function.imagesetbrush" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -90,6 +90,7 @@
     <programlisting role="php">
 <![CDATA[
 <?php
+
 // 小さい php ロゴを読み込みます
 $php = imagecreatefrompng('./php.png');
 
@@ -98,7 +99,7 @@ $im = imagecreatetruecolor(100, 100);
 
 // 背景を白で塗りつぶします
 $white = imagecolorallocate($im, 255, 255, 255);
-imagefilledrectangle($im, 0, 0, 299, 99, $white);
+imagefilledrectangle($im, 0, 0, 99, 99, $white);
 
 // ブラシを設定します
 imagesetbrush($im, $php);

--- a/reference/image/functions/imagesetthickness.xml
+++ b/reference/image/functions/imagesetthickness.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: d56953fc8d508615279a2220f21d7fb6c3298417 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: shimooka -->
 <refentry xml:id="function.imagesetthickness" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -67,13 +67,14 @@
     <programlisting role="php">
 <![CDATA[
 <?php
+
 // 200x100 の画像を作成します
 $im = imagecreatetruecolor(200, 100);
 $white = imagecolorallocate($im, 0xFF, 0xFF, 0xFF);
 $black = imagecolorallocate($im, 0x00, 0x00, 0x00);
 
 // 背景を白に設定します
-imagefilledrectangle($im, 0, 0, 299, 99, $white);
+imagefilledrectangle($im, 0, 0, 199, 99, $white);
 
 // 線幅を 5 に設定します
 imagesetthickness($im, 5);

--- a/reference/info/functions/gc-collect-cycles.xml
+++ b/reference/info/functions/gc-collect-cycles.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 3dee475a90f49a8b755b741e892723eb68e68993 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: eec7af8395621ed03c2f4ffe8e7d784da6641739 Maintainer: takagi Status: ready -->
 <refentry xml:id="function.gc-collect-cycles" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>gc_collect_cycles</refname>
@@ -39,29 +39,28 @@
  </refsect1>
  -->
 
- <!-- Use when a CHANGELOG exists
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>Enter the PHP version of change here</entry>
-       <entry>Description of change</entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       戻り値に、サイクルを通じて間接的に収集された文字列とリソースが
+       含まれなくなりました。
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
- -->
 
  <!-- Use when examples exist
  <refsect1 role="examples">

--- a/reference/intl/grapheme/grapheme-strlen.xml
+++ b/reference/intl/grapheme/grapheme-strlen.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: b548fc8e5592b577d29aabf9cf2e79d5385ae549 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: e7d502fecc2e84d4c57e6451b16f68bec1295ba8 Maintainer: takagi Status: ready -->
 <refentry xml:id="function.grapheme-strlen" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>grapheme_strlen</refname>
@@ -37,10 +37,10 @@
  
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    成功した場合に文字列の長さを返します。
-   &return.falseforfailure;
-  </para>
+   失敗した場合は &null; または &false; を返します。
+  </simpara>
  </refsect1>
  
  <refsect1 role="examples">

--- a/reference/intl/intlchar/digit.xml
+++ b/reference/intl/intlchar/digit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: fe67f9ad47e7f04f50c4ec1366bdbcbd8ab940f2 Maintainer: mumumu Status: ready -->
 <refentry xml:id="intlchar.digit" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>IntlChar::digit</refname>
@@ -19,7 +19,7 @@
   </para>
   <para>
    基数が
-   <literal>2&lt;=radix&lt;=36</literal>
+   <literal>2 &lt;= radix &lt;= 36</literal>
    の範囲外であったり、
    <parameter>codepoint</parameter>
    の値が指定された基数に対して有効な値でない場合、
@@ -30,22 +30,22 @@
     <member>
      指定された文字が、10進数の値である場合。
      これは、general category "Nd" (decimal digit numbers)、かつ
-     Numeric_Type of Decimal である場合です。
+     Numeric_Type of "Decimal" である場合です。
      この場合、値はその文字の10進の数値になります。
     </member>
     <member>
      指定された文字が、アルファベットの大文字
-     'A' から 'Z' までの範囲にある場合。
-     この場合、値は指定された文字を c とすると、c-'A'+10 になります。
+     <literal>'A'</literal> から <literal>'Z'</literal> までの範囲にある場合。
+     この場合、値は <literal>codepoint - 'A' + 10</literal> になります。
     </member>
     <member>
      指定された文字が、アルファベットの小文字
-     'a' から 'z' までの範囲にある場合。
-     この場合、値は指定された文字を c とすると、c-'a'+10 になります。
+     <literal>'a'</literal> から <literal>'z'</literal> までの範囲にある場合。
+     この場合、値は <literal>codepoint - 'a' + 10</literal> になります。
     </member>
     <member>
-     ASCII の範囲 (0061..007A, 0041..005A)
-     または全角の ASCII の範囲 (FF41..FF5A, FF21..FF3A) 
+     ASCII の範囲 (<literal>0061..007A</literal>, <literal>0041..005A</literal>)
+     または全角の ASCII の範囲 (<literal>FF41..FF5A</literal>, <literal>FF21..FF3A</literal>)
      にあると認識できるアルファベットの場合。
     </member>
    </simplelist>
@@ -90,10 +90,13 @@
    <programlisting role="php">
     <![CDATA[
 <?php
+
 var_dump(IntlChar::digit("0"));
 var_dump(IntlChar::digit("3"));
-var_dump(IntlChar::digit("A"));
+
 var_dump(IntlChar::digit("A", 16));
+var_dump(IntlChar::digit("A"));
+
 ?>
 ]]>
    </programlisting>
@@ -102,8 +105,8 @@ var_dump(IntlChar::digit("A", 16));
     <![CDATA[
 int(0)
 int(3)
-bool(false)
 int(10)
+bool(false)
 ]]>
    </screen>
   </example>

--- a/reference/intl/intldatepatterngenerator/getbestpattern.xml
+++ b/reference/intl/intldatepatterngenerator/getbestpattern.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 5b6663923676dd3f48bdc916a6a2de651fd959b2 Maintainer: mumumu Status: ready -->
 <refentry xml:id="intldatepatterngenerator.getbestpattern" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>IntlDatePatternGenerator::getBestPattern</refname>
@@ -35,12 +35,12 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    成功時に
-   <methodname>DateTimeInterface::format</methodname>
-   が受け入れるフォーマットを返します。
+   <classname>IntlDateFormatter</classname>
+   が受け入れる ICU の 日付/時刻 パターンを返します。
    &return.falseforfailure;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/intl/intltimezone/getianaid.xml
+++ b/reference/intl/intltimezone/getianaid.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 3f1722ae51abab1a1ee5fde3ada01fe5cbb87f36 Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="intltimezone.getianaid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>IntlTimeZone::getIanaID</refname>
+  <refname>intltz_get_iana_id</refname>
+  <refpurpose>タイムゾーン識別子を、対応する IANA 識別子に変換する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <simpara>&style.oop; (method):</simpara>
+  <methodsynopsis role="IntlTimeZone">
+   <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>string</type><type>false</type></type><methodname>IntlTimeZone::getIanaID</methodname>
+   <methodparam><type>string</type><parameter>timezoneId</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>&style.procedural;:</simpara>
+  <methodsynopsis>
+   <type class="union"><type>string</type><type>false</type></type><methodname>intltz_get_iana_id</methodname>
+   <methodparam><type>string</type><parameter>timezoneId</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   タイムゾーン識別子を、対応する IANA 識別子に変換します。たとえば、
+   <literal>"GMT"</literal> は <literal>"Etc/GMT"</literal> を返し、
+   <literal>"US/Eastern"</literal> は <literal>"America/New_York"</literal> を返します。
+  </simpara>
+  <note>
+   <simpara>
+    この関数を使うには、ICU version ≥ 74 が必要です。
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+ <variablelist>
+  <varlistentry>
+   <term><parameter>timezoneId</parameter></term>
+   <listitem>
+    <simpara>
+     変換するタイムゾーン識別子。
+    </simpara>
+   </listitem>
+  </varlistentry>
+ </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   IANA のタイムゾーン識別子を &string; で返します。失敗した場合は &false; を返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+ <simplelist>
+  <member><function>intltz_get_id_for_windows_id</function></member>
+  <member><function>intltz_get_windows_id</function></member>
+  <member><function>intltz_create_time_zone</function></member>
+ </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pdo/pdostatement/setfetchmode.xml
+++ b/reference/pdo/pdostatement/setfetchmode.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!-- $Revision$ -->
-<!-- EN-Revision: b4756524479423ee3118adec1effa89171a9ffda Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 8a910daad2efdfd29acf6766be8bca7c32c3dd2a Maintainer: takagi Status: ready -->
 <!-- CREDITS: shimooka,mumumu -->
 <refentry xml:id="pdostatement.setfetchmode" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,25 +13,25 @@
   &reftitle.description;
 
   <methodsynopsis role="PDOStatement">
-   <modifier>public</modifier> <type>bool</type><methodname>PDOStatement::setFetchMode</methodname>
+   <modifier>public</modifier> <type>true</type><methodname>PDOStatement::setFetchMode</methodname>
    <methodparam><type>int</type><parameter>mode</parameter></methodparam>
   </methodsynopsis>
 
   <methodsynopsis role="PDOStatement">
-   <modifier>public</modifier> <type>bool</type><methodname>PDOStatement::setFetchMode</methodname>
+   <modifier>public</modifier> <type>true</type><methodname>PDOStatement::setFetchMode</methodname>
    <methodparam><type>int</type><parameter>mode</parameter><initializer>PDO::FETCH_COLUMN</initializer></methodparam>
    <methodparam><type>int</type><parameter>colno</parameter></methodparam>
   </methodsynopsis>
 
   <methodsynopsis role="PDOStatement">
-   <modifier>public</modifier> <type>bool</type><methodname>PDOStatement::setFetchMode</methodname>
+   <modifier>public</modifier> <type>true</type><methodname>PDOStatement::setFetchMode</methodname>
    <methodparam><type>int</type><parameter>mode</parameter><initializer>PDO::FETCH_CLASS</initializer></methodparam>
    <methodparam><type>string</type><parameter>class</parameter></methodparam>
    <methodparam><type class="union"><type>array</type><type>null</type></type><parameter>constructorArgs</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
 
   <methodsynopsis role="PDOStatement">
-   <modifier>public</modifier> <type>bool</type><methodname>PDOStatement::setFetchMode</methodname>
+   <modifier>public</modifier> <type>true</type><methodname>PDOStatement::setFetchMode</methodname>
    <methodparam><type>int</type><parameter>mode</parameter><initializer>PDO::FETCH_INTO</initializer></methodparam>
    <methodparam><type>object</type><parameter>object</parameter></methodparam>
   </methodsynopsis>
@@ -87,9 +87,26 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   &return.success;
-  </para>
+  <simpara>
+   &return.true.always;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &return.type.true.84;
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/pdo_dblib/pdo-dblib.xml
+++ b/reference/pdo_dblib/pdo-dblib.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 3f82c54505bbf99a7dfdee2ae7f674b1e2719bd3 Maintainer: KentarouTakeda Status: ready -->
+<!-- EN-Revision: 608815b2f52cc7dae75eb02e27f457aad1e5e977 Maintainer: KentarouTakeda Status: ready -->
 <!-- CREDITS: KentarouTakeda -->
 <reference xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="class.pdo-dblib" role="class">
  <title>Pdo\Dblib クラス</title>
@@ -144,6 +144,13 @@
      <term><constant>Pdo\Dblib::ATTR_DATETIME_CONVERT</constant></term>
      <listitem>
       <simpara>
+       この接続属性は、datetime 型に対する文字列のフォーマットを制御します。
+       これが &false; の場合、PDO_DBLIB は datetime 型を、SQL Server が返すフォーマット
+       （つまり <literal>"2017-10-27 10:22:44"</literal>）の文字列として返します。
+       &true; の場合、PDO_DBLIB は datetime 型を、FreeTDS の
+       <filename>locales.conf</filename> ファイルで指定された、ユーザー定義の
+       フォーマットあるいはロケールのフォーマットを使って文字列に変換します。
+       デフォルトでは、この属性は &false; です。
       </simpara>
      </listitem>
     </varlistentry>

--- a/reference/phar/Phar/setStub.xml
+++ b/reference/phar/Phar/setStub.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9c828621cbce488cf6306b21c39e208f847eabd5 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 8a910daad2efdfd29acf6766be8bca7c32c3dd2a Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="phar.setstub">
  <refnamediv>
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="Phar">
-   <modifier>public</modifier> <type>bool</type><methodname>Phar::setStub</methodname>
+   <modifier>public</modifier> <type>true</type><methodname>Phar::setStub</methodname>
    <methodparam><type class="union"><type>resource</type><type>string</type></type><parameter>stub</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>length</parameter><initializer>-1</initializer></methodparam>
   </methodsynopsis>
@@ -74,9 +74,9 @@ include 'phar://myphar.phar/somefile.php';
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   &return.success;
-  </para>
+  <simpara>
+   &return.true.always;
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -101,6 +101,7 @@ include 'phar://myphar.phar/somefile.php';
      </row>
     </thead>
     <tbody>
+     &return.type.true.84;
      <row>
       <entry>8.3.0</entry>
       <entry>

--- a/reference/phar/PharData/setStub.xml
+++ b/reference/phar/PharData/setStub.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: f03806fcd8fe03a0501bd40b6e3939ff6589a1d2 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 8a910daad2efdfd29acf6766be8bca7c32c3dd2a Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="phardata.setstub">
  <refnamediv>
@@ -10,9 +10,9 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="PharData">
-   <modifier>public</modifier> <type>bool</type><methodname>PharData::setStub</methodname>
+   <modifier>public</modifier> <type>true</type><methodname>PharData::setStub</methodname>
    <methodparam><type>string</type><parameter>stub</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>len</parameter><initializer>-1</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>length</parameter><initializer>-1</initializer></methodparam>
   </methodsynopsis>
 
 
@@ -37,7 +37,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>len</parameter></term>
+     <term><parameter>length</parameter></term>
      <listitem>
       <para>
        
@@ -51,9 +51,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   &return.success;
-  </para>
+  <simpara>
+   &return.true.always;
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -61,6 +61,23 @@
   <para>
    このメソッドがコールされると必ず <classname>PharException</classname> をスローします。
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &return.type.true.84;
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/reflection/reflectionclass/getstaticpropertyvalue.xml
+++ b/reference/reflection/reflectionclass/getstaticpropertyvalue.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ec2fe9a592f794978114ef5021db9f1d00c2e05d Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 8a910daad2efdfd29acf6766be8bca7c32c3dd2a Maintainer: takagi Status: ready -->
 
 <refentry xml:id="reflectionclass.getstaticpropertyvalue" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,7 +13,7 @@
   <methodsynopsis role="ReflectionClass">
    <modifier>public</modifier> <type>mixed</type><methodname>ReflectionClass::getStaticPropertyValue</methodname>
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter role="reference">def_value</parameter></methodparam>
+   <methodparam choice="opt"><type>mixed</type><parameter role="reference">default</parameter></methodparam>
   </methodsynopsis>
   <para>
    このクラスのstaticプロパティの値を取得します。
@@ -34,7 +34,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>def_value</parameter></term>
+     <term><parameter>default</parameter></term>
      <listitem>
       <para>
        指定した名前のstaticプロパティがそのクラスに存在しない場合に返す、デフォルト値。

--- a/reference/uodbc/book.xml
+++ b/reference/uodbc/book.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 1634a886415d0ab4df195fe49d18a1c150b70758 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: d705f166224fded16bf34a674b3e3690a083b34c Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa -->
  
 <book xml:id="book.uodbc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -11,23 +11,23 @@
  <!-- {{{ preface -->
  <preface xml:id="intro.uodbc">
   &reftitle.intro;
-  <para>
+  <simpara>
    通常の ODBC サポートに加えて、PHP の Unified ODBC 関数では、各々の
    API を実装するために ODBC API のセマンティックスを借用する複数の
    データベースにアクセスすることが可能です。ほとんど同じ複数のデータベース
    ドライバを維持管理する代わりに、これらのドライバは単一の ODBC 関数セットに
    統合されています。
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    以下のデータベースが Unified ODBC でサポートされています。
    <link xlink:href="&url.adabas;">Adabas D</link>,
    <link xlink:href="&url.ibmdb2;">IBM DB2</link>,
    <link xlink:href="&url.iodbc;">iODBC</link>,
    <link xlink:href="&url.solid;">Solid</link>,
    <link xlink:href="&url.sybase;">Sybase SQL Anywhere</link>
-  </para>
+  </simpara>
   <note>
-   <para>
+   <simpara>
     iODBC を除き、上のデータベースと接続する際には ODBC は使用しません。
     内部ではネイティブに通信しており、単に
     ODBC 関数と同じ名前や構文を用いているだけです。
@@ -37,15 +37,17 @@
     <link xlink:href="&url.iodbc;">www.iodbc.org</link> にあります。
     またもうひとつの方法である unixODBC は
     <link xlink:href="&url.unixodbc;">www.unixodbc.org</link> にあります。
-   </para>
+   </simpara>
   </note>
  </preface>
  <!-- }}} -->
- 
+
  &reference.uodbc.setup;
  &reference.uodbc.constants;
  &reference.uodbc.reference;
 
+ &reference.uodbc.odbc.connection;
+ &reference.uodbc.odbc.result;
 </book>
 
 <!-- Keep this comment at the end of the file

--- a/reference/uodbc/odbc.connection.xml
+++ b/reference/uodbc/odbc.connection.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: d705f166224fded16bf34a674b3e3690a083b34c Maintainer: KentarouTakeda Status: ready -->
+<reference xmlns="http://docbook.org/ns/docbook" xml:id="class.odbc-connection" role="class">
+ <title>Odbc\Connection クラス</title>
+ <titleabbrev>Odbc\Connection</titleabbrev>
+
+ <partintro>
+
+  <!-- {{{ Odbc\Connection intro -->
+  <section xml:id="odbc-connection.intro">
+   &reftitle.intro;
+   <simpara>
+    PHP 8.4.0 以降、<literal>odbc_connection</literal> &resource; を置き換える完全不透明クラスです。
+   </simpara>
+  </section>
+  <!-- }}} -->
+
+  <section xml:id="odbc-connection.synopsis">
+   &reftitle.classsynopsis;
+
+   <!-- {{{ Synopsis -->
+   <packagesynopsis>
+    <package>Odbc</package>
+
+    <classsynopsis class="class">
+     <ooclass>
+      <classname>Connection</classname>
+     </ooclass>
+    </classsynopsis>
+   </packagesynopsis>
+   <!-- }}} -->
+
+  </section>
+
+ </partintro>
+
+</reference>
+<!-- Keep this comment at the end of the file
+ Local variables:
+ mode: sgml
+ sgml-omittag:t
+ sgml-shorttag:t
+ sgml-minimize-attributes:nil
+ sgml-always-quote-attributes:t
+ sgml-indent-step:1
+ sgml-indent-data:t
+ indent-tabs-mode:nil
+ sgml-parent-document:nil
+ sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+ sgml-exposed-tags:nil
+ sgml-local-catalogs:nil
+ sgml-local-ecat-files:nil
+ End:
+ vim600: syn=xml fen fdm=syntax fdl=2 si
+ vim: et tw=78 syn=sgml
+ vi: ts=1 sw=1
+ -->

--- a/reference/uodbc/odbc.result.xml
+++ b/reference/uodbc/odbc.result.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: d705f166224fded16bf34a674b3e3690a083b34c Maintainer: KentarouTakeda Status: ready -->
+<reference xmlns="http://docbook.org/ns/docbook" xml:id="class.odbc-result" role="class">
+ <title>Odbc\Result クラス</title>
+ <titleabbrev>Odbc\Result</titleabbrev>
+
+ <partintro>
+
+  <!-- {{{ Odbc\Result intro -->
+  <section xml:id="odbc-result.intro">
+   &reftitle.intro;
+   <simpara>
+    PHP 8.4.0 以降、<literal>odbc_result</literal> &resource; を置き換える完全不透明クラスです。
+   </simpara>
+  </section>
+  <!-- }}} -->
+
+  <section xml:id="odbc-result.synopsis">
+   &reftitle.classsynopsis;
+
+   <!-- {{{ Synopsis -->
+   <packagesynopsis>
+    <package>Odbc</package>
+
+    <classsynopsis class="class">
+     <ooclass>
+      <classname>Result</classname>
+     </ooclass>
+    </classsynopsis>
+   </packagesynopsis>
+   <!-- }}} -->
+
+  </section>
+
+ </partintro>
+
+</reference>
+<!-- Keep this comment at the end of the file
+ Local variables:
+ mode: sgml
+ sgml-omittag:t
+ sgml-shorttag:t
+ sgml-minimize-attributes:nil
+ sgml-always-quote-attributes:t
+ sgml-indent-step:1
+ sgml-indent-data:t
+ indent-tabs-mode:nil
+ sgml-parent-document:nil
+ sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+ sgml-exposed-tags:nil
+ sgml-local-catalogs:nil
+ sgml-local-ecat-files:nil
+ End:
+ vim600: syn=xml fen fdm=syntax fdl=2 si
+ vim: et tw=78 syn=sgml
+ vi: ts=1 sw=1
+ -->


### PR DESCRIPTION
## 新規翻訳（3件）

- reference/intl/intltimezone/getianaid.xml — IntlTimeZone::getIanaID（PHP 8.4）
  - php/doc-en@3f1722a
- reference/uodbc/odbc.connection.xml — Odbc\Connection クラス（PHP 8.4 resource→object 変換）
  - php/doc-en@d705f16
- reference/uodbc/odbc.result.xml — Odbc\Result クラス（PHP 8.4 resource→object 変換）
  - php/doc-en@d705f16

## 既訳の同期（15件）

### stub シグネチャ整合（php/doc-en@8a910da）

- reference/reflection/reflectionclass/getstaticpropertyvalue.xml — 第2引数を def_value→default にリネーム
- reference/phar/Phar/setStub.xml — 戻り値型 bool→true、PHP 8.4 changelog を追加
- reference/phar/PharData/setStub.xml — 戻り値型 bool→true、PHP 8.4 changelog を追加
- reference/pdo/pdostatement/setfetchmode.xml — 戻り値型 bool→true（4 シグネチャ）、PHP 8.4 changelog を追加

### reference/intl

- reference/intl/intlchar/digit.xml — example の出力を修正
  - php/doc-en@e166139, php/doc-en@fe67f9a
- reference/intl/grapheme/grapheme-strlen.xml — 失敗時の戻り値を null または false に更新
  - php/doc-en@e7d502f
- reference/intl/intldatepatterngenerator/getbestpattern.xml — 戻り値が IntlDateFormatter 用の ICU パターンである旨に修正
  - php/doc-en@5b66639

### reference/image/functions（php/doc-en@d56953f）

- imagedashedline.xml — 座標説明を「左上/右下」から「1つ目/2つ目の点」に修正
- imagerectangle.xml — 原点の説明文を description へ移動
- imagesetbrush.xml — サンプルコードの矩形サイズを修正
- imagesetthickness.xml — サンプルコードの矩形サイズを修正

### 独立ファイル

- reference/info/functions/gc-collect-cycles.xml — PHP 8.5 changelog エントリを追加
  - php/doc-en@eec7af8
- reference/errorfunc/functions/debug-backtrace.xml — options テーブルをビットマスク式に再構成、object/args の省略条件ヒントを追加
  - php/doc-en@86a4b30, php/doc-en@1e31c8f, php/doc-en@26f18ba, php/doc-en@a8dfc2c
- reference/uodbc/book.xml — Odbc\Connection / Odbc\Result ページ追加に伴うエンティティ参照を追加
  - php/doc-en@d705f16
- reference/pdo_dblib/pdo-dblib.xml — Pdo\Dblib::ATTR_DATETIME_CONVERT 定数の説明を追加
  - php/doc-en@608815b
