### PR TITLE
doc-en と同期し PHP 8.5 の言語リファレンスほかを反映（12ファイル）

### DIFF
--- a/appendices/aliases.xml
+++ b/appendices/aliases.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 6d46a5549bcb66444ce7a3b34301420ba7552bc8 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: e2274fb291cb76151378a209e8c92612d1ba5340 Maintainer: hirokawa Status: ready -->
 <!-- Credits: mumumu -->
  <appendix xml:id="aliases" xmlns="http://docbook.org/ns/docbook">
   <title>関数エイリアスのリスト</title>
@@ -137,16 +137,6 @@
      <row>
       <entry>imap_fetchtext</entry>
       <entry><function>imap_body</function></entry>
-      <entry><link linkend="ref.imap">IMAP</link></entry>
-     </row>
-     <row>
-      <entry>imap_getmailboxes</entry>
-      <entry><function>imap_list_full</function></entry>
-      <entry><link linkend="ref.imap">IMAP</link></entry>
-     </row>
-     <row>
-      <entry>imap_getsubscribed</entry>
-      <entry><function>imap_lsub_full</function></entry>
       <entry><link linkend="ref.imap">IMAP</link></entry>
      </row>
      <row>
@@ -597,6 +587,11 @@
      <row>
       <entry>pg_setclientencoding</entry>
       <entry><function>pg_set_client_encoding</function></entry>
+      <entry><link linkend="ref.pgsql">PostgreSQL</link></entry>
+     </row>
+     <row>
+      <entry>pg_exec</entry>
+      <entry><function>pg_query</function></entry>
       <entry><link linkend="ref.pgsql">PostgreSQL</link></entry>
      </row>
      <row>

--- a/language/predefined/attributes.xml
+++ b/language/predefined/attributes.xml
@@ -1,17 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 02bee41067ab2822cbffcb4b3b2387f79488dffd Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: efda0bb311990257715bd3a41ab2b04769ce2e4e Maintainer: mumumu Status: ready -->
 <part xml:id="reserved.attributes" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>定義済みのアトリビュート</title>
 
  <partintro>
-  <para>
+  <simpara>
    PHP には、定義済みのアトリビュートがいくつか用意されています。
-  </para>
+  </simpara>
  </partintro>
 
  &language.predefined.attributes.attribute;
  &language.predefined.attributes.allowdynamicproperties;
+ &language.predefined.attributes.delayedtargetvalidation;
  &language.predefined.attributes.deprecated;
  &language.predefined.attributes.nodiscard;
  &language.predefined.attributes.override;

--- a/language/predefined/attributes/delayedtargetvalidation.xml
+++ b/language/predefined/attributes/delayedtargetvalidation.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: efda0bb311990257715bd3a41ab2b04769ce2e4e Maintainer: KentarouTakeda Status: ready -->
+<reference xml:id="class.delayedtargetvalidation" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>DelayedTargetValidation アトリビュート</title>
+ <titleabbrev>DelayedTargetValidation</titleabbrev>
+
+ <partintro>
+
+  <section xml:id="delayedtargetvalidation.intro">
+   &reftitle.intro;
+   <simpara>
+    このアトリビュートは、内部アトリビュートに対する適用対象の検証エラーを、
+    コンパイル時から、Reflection API を通じてアトリビュートがインスタンス化される時点へと遅延させます。
+   </simpara>
+   <simpara>
+    宣言に適用すると、同じ適用対象における内部アトリビュートの不正な使用は、
+    コンパイル時のエラーを引き起こしません。代わりに検証は先送りされ、
+    <link linkend="reflectionattribute.newinstance">ReflectionAttribute::newInstance()</link>
+    を通じてアトリビュートがインスタンス化される時点で実行されます。
+   </simpara>
+   <simpara>
+    これは主に前方互換性を意図したものであり、
+    将来の PHP バージョンで有効な適用対象が追加されうるアトリビュートを使うコードを、
+    古いバージョンで壊さずに済むようにします。
+   </simpara>
+  </section>
+
+  <section xml:id="delayedtargetvalidation.synopsis">
+   &reftitle.classsynopsis;
+
+   <classsynopsis class="class">
+    <ooclass>
+     <modifier role="attribute">#[\Attribute]</modifier>
+     <modifier>final</modifier>
+     <classname>DelayedTargetValidation</classname>
+    </ooclass>
+   </classsynopsis>
+
+  </section>
+
+  <section xml:id="delayedtargetvalidation.examples">
+   &reftitle.examples;
+
+   <example>
+    <title>不正な適用対象の検証を遅延させる</title>
+    <programlisting role="php"><![CDATA[
+<?php
+
+class Base {
+    protected function foo(): void {}
+}
+
+class Child extends Base {
+
+    #[\DelayedTargetValidation]
+    #[\Override]
+    public const NAME = 'child';
+
+    #[\Override]
+    protected function foo(): void {}
+}
+]]></programlisting>
+
+    <simpara>
+     <classname>Override</classname> がクラス定数に対して使えない PHP バージョンであっても、
+     これはコンパイル時のエラーを発生させません。
+    </simpara>
+   </example>
+
+   <example>
+    <title>検証はリフレクション時に行われる</title>
+    <programlisting role="php"><![CDATA[
+<?php
+
+$reflection = new ReflectionClassConstant(Child::class, 'NAME');
+
+foreach ($reflection->getAttributes() as $attribute) {
+    $attribute->newInstance(); // 不正な場合はスローされる可能性がある
+}
+]]></programlisting>
+
+    <simpara>
+     同じ適用対象に適用されたアトリビュート（DelayedTargetValidation 自身を除く）が、
+     <link linkend="reflectionattribute.newinstance">ReflectionAttribute::newInstance()</link>
+     を使ってリフレクション経由でインスタンス化されると、
+     適用対象の検証が実行され、サポートされていない適用対象でアトリビュートが使われていれば
+     例外がスローされる可能性があります。
+    </simpara>
+   </example>
+
+  </section>
+
+  <section xml:id="delayedtargetvalidation.notes">
+   &reftitle.notes;
+   <simpara>
+    このアトリビュートは、内部アトリビュートの適用対象の検証にのみ影響します。
+   </simpara>
+   <simpara>
+    これらのアトリビュートが実行する機能的な検証を抑制するわけではありません。
+    たとえば <classname>Override</classname> は、
+    メソッドが実際には親のメソッドをオーバーライドしていない場合に、引き続きエラーを発生させます。
+   </simpara>
+  </section>
+
+  <section xml:id="delayedtargetvalidation.seealso">
+   &reftitle.seealso;
+   <simplelist>
+    <member><link linkend="language.attributes">アトリビュートの概要</link></member>
+    <member><link linkend="class.override">Override</link></member>
+   </simplelist>
+  </section>
+
+ </partintro>
+
+</reference>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/language/predefined/fiber/throw.xml
+++ b/language/predefined/fiber/throw.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 8fee3ae9715ffa15922469eb7d98f4878917a6ee Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: b3a0b9924ba577a3abf246c1bd1a6cf5c4bf14dc Maintainer: mumumu Status: ready -->
 <refentry xml:id="fiber.throw" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Fiber::throw</refname>
@@ -49,6 +49,40 @@
    停止する前にファイバーが例外をスローする場合、
    このメソッドの呼び出しからスローされます。
   </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <informalexample>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+$fiber = new Fiber(function () {
+   try {
+       // 中断ポイントを宣言してファイバーの実行を停止する
+       Fiber::suspend();
+   } catch (Throwable $e) {
+       echo $e->getMessage();
+   }
+});
+
+$fiber->start();
+
+// 中断ポイントでスローする例外を渡して
+// ファイバーの実行を再開する
+$fiber->throw(new Exception('Message of an exception thrown at the current interrupt point'));
+
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+Message of an exception thrown at the current interrupt point
+]]>
+   </screen>
+  </informalexample>
  </refsect1>
 
 </refentry>

--- a/language/types/array.xml
+++ b/language/types/array.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 3061900171d4ae84d532571bfd6eda823726dad4 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: bfdd82f3f6cde571a61de3fcea28a03145374dda Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa,shimooka,mumumu -->
 <sect1 xml:id="language.types.array">
  <title>配列</title>
@@ -553,12 +553,12 @@ var_dump($arr);
    </example>
 
    <note>
-    <para>
-     上記のように、キーを省略して新規要素を追加する場合、
-     追加される数値添字は、使用されている添字の最大値 +1 (ただし、少なくとも 0 以上) になります。
-     まだ数値添字が存在しない場合は、添字は <literal>0</literal>
-     (ゼロ) となります。
-    </para>
+    <simpara>
+     キーを省略した場合、キーは使用されている整数添字の最大値 +
+     <literal>1</literal> になります。配列に正の整数添字が存在しない場合は、
+     キーは <literal>0</literal> となります。
+     PHP 8.3.0 以降では、負の整数になることもあります。
+    </simpara>
 
     <warning>
      <simpara>

--- a/language/types/boolean.xml
+++ b/language/types/boolean.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: fee54c7c435a1664a7a8b0e7b7de7cec4a084c45 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4657c1173e6b3852cdc8db4fc64f380d10ebae0c Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa,shimooka,mumumu -->
 <sect1 xml:id="language.types.boolean">
  <title>論理型 (boolean) </title>
@@ -118,8 +118,7 @@ if ($show_separators) {
    <listitem>
     <simpara>
      bool 型へキャストするように動作がオーバーロードされた内部オブジェクト。
-     例: 属性がない空要素から作成された <link linkend="ref.simplexml">SimpleXML</link>
-     オブジェクトや、値 <literal>0</literal> を表す
+     例: 値 <literal>0</literal> を表す
      <classname>GMP</classname> オブジェクト。
     </simpara>
    </listitem>

--- a/language/types/type-juggling.xml
+++ b/language/types/type-juggling.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 78a11d3ca004ee937549d932e77a79c51b9777cd Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 50f76f26914c5a9e61aa26f2e36c4acb362a48fd Maintainer: mumumu Status: ready -->
 <sect1 xml:id="language.types.type-juggling">
  <title>型の相互変換</title>
 
@@ -327,6 +327,13 @@ var_dump($bar);
    <member><literal>(unset)</literal> - <type>NULL</type> へのキャスト</member>
   </simplelist>
 
+  <simpara>
+   PHP 8.5.0 以降では
+   <link linkend="language.types.void.casting"><literal>(void)</literal></link>
+   キャストも使用できますが、これは値の変換ではありません。
+   式の結果を明示的に破棄する文として使用します。
+  </simpara>
+
   <warning>
    <para>
     <literal>(integer)</literal> は、<literal>(int)</literal> のエイリアスです。
@@ -429,6 +436,7 @@ if ($fst === $str) {
     <member><link linkend="language.types.object.casting">オブジェクトへの変換</link></member>
     <member><link linkend="language.types.resource.casting">リソース型への変換</link></member>
     <member><link linkend="language.types.null.casting">NULL への変換</link></member>
+    <member><link linkend="language.types.void.casting"><literal>(void)</literal> による値の破棄</link></member>
     <member><link linkend="types.comparisons">型の比較表</link></member>
    </simplelist>
   </para>

--- a/language/types/void.xml
+++ b/language/types/void.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 161dde4fe721309398dd324edbf02aec409f127b Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 50f76f26914c5a9e61aa26f2e36c4acb362a48fd Maintainer: mumumu Status: ready -->
 <sect1 xml:id="language.types.void">
  <title>Void</title>
 
@@ -17,6 +17,37 @@
   </simpara>
  </note>
 
+ <sect2 xml:id="language.types.void.casting">
+  <title><literal>(void)</literal> による値の破棄</title>
+
+  <simpara>
+   <literal>(void)</literal> 構文を使うと、式の結果を明示的に破棄できます。
+   これは、戻り値を無視するのが意図的であることを示すのに便利です。
+   特に、<classname>NoDiscard</classname>
+   アトリビュートが指定された関数やメソッドを呼び出す場合に役立ちます。
+  </simpara>
+
+  <simpara>
+   他のキャストとは異なり、<literal>(void)</literal> は値を別の型に変換せず、
+   値を生成しません。これは文であり、式の一部として使うことはできません。
+  </simpara>
+
+  <example>
+   <title>戻り値を破棄する</title>
+   <programlisting role="php" annotations="non-interactive">
+    <![CDATA[
+<?php
+#[\NoDiscard]
+function process(): bool {
+    return true;
+}
+
+(void) process(); // 戻り値を明示的に破棄する
+?>
+]]>
+   </programlisting>
+  </example>
+ </sect2>
 </sect1>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/language/wrappers/expect.xml
+++ b/language/wrappers/expect.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: f94d903985119d3ac00f4528551df947f57b667f Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa -->
 
 <refentry xml:id="wrappers.expect" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="verify_info:false" role="stream_wrapper">
@@ -11,11 +11,11 @@
 
  <refsect1 role="description"><!-- {{{ -->
   &reftitle.description;
-  <para>
+  <simpara>
    <filename>expect://</filename> ラッパーでオープンしたストリームを使用すると、
    プロセスの標準入力・標準出力・標準エラー出力への PTY 経由でのアクセスが
    可能となります。
-  </para>
+  </simpara>
   <note>
    <title>このラッパーはデフォルトでは有効となっていません。</title>
    <simpara>

--- a/reference/eio/constants.xml
+++ b/reference/eio/constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4e53894013ec0d223e2723ece46447ba00d5baf5 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 2132501990f8e139a75021165634830f1f6a90e1 Maintainer: takagi Status: ready -->
 <appendix xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="eio.constants">
  &reftitle.constants;
  &extension.constants;
@@ -139,7 +139,6 @@
     </term>
     <listitem>
      <simpara>
-
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/eio/functions/eio-chown.xml
+++ b/reference/eio/functions/eio-chown.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4e53894013ec0d223e2723ece46447ba00d5baf5 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.eio-chown">
  <refnamediv>
@@ -19,7 +19,9 @@
    <methodparam choice="opt"><type>mixed</type><parameter>data</parameter><initializer>NULL</initializer></methodparam>
   </methodsynopsis>
   <simpara>
-  ファイルやディレクトリのオーナーを変更します。
+  <function>eio_chown</function> は、ファイルやディレクトリのオーナーを変更します。
+  新しいオーナーは <parameter>uid</parameter> で、グループは
+  <parameter>gid</parameter> で指定します。
   </simpara>
  </refsect1>
 

--- a/reference/uopz/functions/uopz-extend.xml
+++ b/reference/uopz/functions/uopz-extend.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 5c724a01a192e135bf165399d9b25caf6099482a Maintainer: satoruyoshida Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: satoruyoshida Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="function.uopz-extend" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -56,7 +56,7 @@
    <link linkend="book.opcache">OPcache</link> が有効になっており、
    かつ <parameter>class</parameter> または <parameter>parent</parameter>
    が変更不能な場合(トレイトの場合も)、
-   <function>uopz_extends</function> 関数は
+   <function>uopz_extend</function> 関数は
    <classname>RuntimeException</classname> をスローするようになりました。
   </simpara>
  </refsect1>


### PR DESCRIPTION
## 翻訳内容

### language/types（4件）

- language/types/void.xml — (void) キャストの PHP 8.5 構文を追加
  1. php/doc-en@50f76f2691
- language/types/type-juggling.xml — (void) キャストへの言及（説明・関連項目）を追加
  1. php/doc-en@50f76f2691
- language/types/boolean.xml — false とみなされる例から SimpleXML を削除
  1. php/doc-en@4657c1173e
- language/types/array.xml — example 10 のノートを更新（PHP 8.3.0 で負の整数添字になりうる旨）
  1. php/doc-en@bfdd82f3f6

### language/predefined（3件）

- language/predefined/fiber/throw.xml — 使用例を追加
  1. php/doc-en@b3a0b9924b
- language/predefined/attributes.xml — DelayedTargetValidation のエントリ参照を追加（para→simpara 同期含む）
  1. php/doc-en@efda0bb311
- language/predefined/attributes/delayedtargetvalidation.xml — DelayedTargetValidation アトリビュートの新規翻訳（PHP 8.5）
  1. php/doc-en@efda0bb311

### reference/eio（2件・モジュール完訳）

- reference/eio/constants.xml — 英語版のマークアップ同期（文末ピリオド等は意味不変のため訳文据え置き）
  1. php/doc-en@940ea8c1b2
  2. php/doc-en@2132501990
- reference/eio/functions/eio-chown.xml — description をコピペ誤り修正後の正しい説明に更新
  1. php/doc-en@184764a63e

### 独立ファイル

- language/wrappers/expect.xml — description の para→simpara マークアップ同期
  1. php/doc-en@8bc832a464
  2. php/doc-en@330a38c4d4
- appendices/aliases.xml — エイリアス一覧を更新（imap 2件削除・pg_exec→pg_query 追加）
  1. php/doc-en@e2274fb291
- reference/uopz/functions/uopz-extend.xml — errors の関数名の誤りを修正（uopz_extends→uopz_extend）
  1. php/doc-en@c9490d424e
  2. php/doc-en@330a38c4d4
