### PR TITLE
doc-en と同期しコード例の誤り修正ほかを反映（17ファイル）

### DIFF
--- a/appendices/migration74/new-features.xml
+++ b/appendices/migration74/new-features.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e150cc645a17588282e5e6b5e43e600a2f345549 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 8e2cfbdce0cd028a6521c6e073f148e0f7efac7c Maintainer: mumumu Status: ready -->
 
 <sect1 xml:id="migration74.new-features" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>新機能</title>
@@ -90,8 +90,8 @@ class A
 class B extends A
 {
     // Fatal error: Could not check compatibility between B::method():C and
-    // A::method(): A, because class С is not available
-    public function method(): С {}
+    // A::method(): A, because class C is not available
+    public function method(): C {}
 }
 
 class C extends B {}

--- a/appendices/migration84/new-features.xml
+++ b/appendices/migration84/new-features.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: KentarouTakeda Status: ready -->
+<!-- EN-Revision: d7efc67559999c1dda0f65c90617b60c6872a61b Maintainer: KentarouTakeda Status: ready -->
 <!-- Credits: KentarouTakeda -->
 <sect1 xml:id="migration84.new-features">
  <title>新機能</title>
@@ -27,7 +27,7 @@
 <?php
 class Person
 {
-    // 「仮想」プロパティ。明示的に設定されることはありません。
+    // 「仮想」プロパティ。明示的に設定することはできません。
     public string $fullName {
         get => $this->firstName . ' ' . $this->lastName;
     }
@@ -56,6 +56,8 @@ $p->firstName = 'peter';
 print $p->firstName; // Prints "Peter"
 $p->lastName = 'Peterson';
 print $p->fullName; // Prints "Peter Peterson"
+
+$p->fullName = "Peter 'Pete' Peterson"; // Throws Error: "Property Person::$fullName is read-only"
 ]]>
     </programlisting>
    </informalexample>

--- a/language/types/boolean.xml
+++ b/language/types/boolean.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4657c1173e6b3852cdc8db4fc64f380d10ebae0c Maintainer: takagi Status: ready -->
+<!-- EN-Revision: ee66d210fb1dd5799fbca9881c6ac2560a19579d Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa,shimooka,mumumu -->
 <sect1 xml:id="language.types.boolean">
  <title>論理型 (boolean) </title>
@@ -22,7 +22,10 @@
    <programlisting role="php">
 <![CDATA[
 <?php
+
 $foo = True; // 値TRUEを$fooに代入する
+
+var_dump($foo); // bool(true)
 ?>
 ]]>
    </programlisting>
@@ -38,6 +41,7 @@ $foo = True; // 値TRUEを$fooに代入する
    <programlisting role="php">
 <![CDATA[
 <?php
+
 $action = "show_version";
 $show_separators = true;
 

--- a/reference/exec/functions/proc-close.xml
+++ b/reference/exec/functions/proc-close.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ef623ccf442df416da4e5bc254b4c5d4f6df9475 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 970d3aa7fdf5c714b584cbe67ebf9e32a1e8b0d3 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: shimooka,mumumu -->
 <!-- splitted from ./en/functions/exec.xml, last change in rev 1.28 -->
 <refentry xml:id='function.proc-close' xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>proc_close</refname>
-  <refpurpose><function>proc_open</function> で開かれたプロセスを閉じ、
-  そのプロセスの終了コードを返す</refpurpose>
+  <refpurpose><function>proc_open</function> で開かれたプロセスへのパイプを閉じ、
+  プロセスの終了を待ち、その終了コードを返す</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -45,10 +45,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    実行していたプロセスの終了状態を返します。
    エラーが発生した場合は <literal>-1</literal> を返します。
-  </para>
+  </simpara>
   &note.sigchild;
  </refsect1>
  <refsect1 role="changelog">

--- a/reference/exec/functions/proc-open.xml
+++ b/reference/exec/functions/proc-open.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 6667724b8a42ba501172bc874dd1644a6744be0f Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: f50098447455250c9f92eed119248aaa30920100 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi,mumumu -->
 <refentry xml:id="function.proc-open" xmlns="http://docbook.org/ns/docbook">
    <refnamediv>
@@ -96,11 +96,12 @@
        <simplelist>
         <member>
          プロセスに渡すパイプをあらわす配列。
-         最初の要素はディスクリプタの型で、2 番目の要素がその型に対応するオプションとなります。
+         最初の要素はディスクリプタの型で、2 番目以降の要素がその型に対応するオプションとなります。
          使用できる型は <literal>pipe</literal> (2 番目の要素は、
          プロセスにパイプの読み込み側を渡すのなら <literal>r</literal>、
          書き込み側を渡すのなら <literal>w</literal>)
-         および <literal>file</literal> (2 番目の要素はファイル名)
+         および <literal>file</literal> (2 番目の要素はファイル名、
+         3 番目の要素は <function>fopen</function> と同じファイルモード)
          です。
          <literal>w</literal> 以外に何を指定しても、
          <literal>r</literal> のように扱われるので注意して下さい。

--- a/reference/imagick/imagick/mergeimagelayers.xml
+++ b/reference/imagick/imagick/mergeimagelayers.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 976425d4f6eec32448be3cc22ec063015921b753 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 8e2cfbdce0cd028a6521c6e073f148e0f7efac7c Maintainer: takagi Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagick.mergeimagelayers">
  <refnamediv>
   <refname>Imagick::mergeImageLayers</refname>
@@ -60,7 +60,7 @@
 <?php
 function mergeImageLayers($layerMethodType, $imagePath1, $imagePath2) {
 
-    $imagick = new \Imagick(realpath($imagePath));
+    $imagick = new \Imagick(realpath($imagePath1));
 
     $imagick2 = new \Imagick(realpath($imagePath2));
     $imagick->addImage($imagick2);

--- a/reference/rar/rarentry/getunpackedsize.xml
+++ b/reference/rar/rarentry/getunpackedsize.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ee741f54f831af19f135d1d9894a41477ab896c3 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 8e2cfbdce0cd028a6521c6e073f148e0f7efac7c Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="rarentry.getunpackedsize">
  <refnamediv>

--- a/reference/reflection/reflectionfunction/construct.xml
+++ b/reference/reflection/reflectionfunction/construct.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 629dfc9ec496d66c49b626dfc72a4981e74d6250 Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 
 <refentry xml:id="reflectionfunction.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -90,12 +90,12 @@ function dumpReflectionFunction($func)
     );
 
     // ドキュメントコメントを表示します
-    printf("---> Documentation:\n %s\n", var_export($func->getDocComment(), 1));
+    printf("---> Documentation:\n %s\n", var_export($func->getDocComment(), true));
 
     // static変数が存在すれば表示します
     if ($statics = $func->getStaticVariables())
     {
-        printf("---> Static variables: %s\n", var_export($statics, 1));
+        printf("---> Static variables: %s\n", var_export($statics, true));
     }
 }
 

--- a/reference/spl/splfileinfo/getgroup.xml
+++ b/reference/spl/splfileinfo/getgroup.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 84d643420e0a5b43f34238aff8bde6dce168825b Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 8e2cfbdce0cd028a6521c6e073f148e0f7efac7c Maintainer: takagi Status: ready -->
 <refentry xml:id="splfileinfo.getgroup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SplFileInfo::getGroup</refname>
@@ -47,7 +47,7 @@
 <![CDATA[
 <?php
 $info = new SplFileInfo('example.jpg');
-echo info->getFilename() . ' belongs to group id ' . $info->getGroup() . "\n";
+echo $info->getFilename() . ' belongs to group id ' . $info->getGroup() . "\n";
 print_r(posix_getgrgid($info->getGroup()));
 ?>
 ]]>

--- a/reference/spl/splfileinfo/getowner.xml
+++ b/reference/spl/splfileinfo/getowner.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 84d643420e0a5b43f34238aff8bde6dce168825b Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 8e2cfbdce0cd028a6521c6e073f148e0f7efac7c Maintainer: takagi Status: ready -->
 <refentry xml:id="splfileinfo.getowner" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SplFileInfo::getOwner</refname>
@@ -47,7 +47,7 @@
 <![CDATA[
 <?php
 $info = new SplFileInfo('example.jpg');
-echo info->getFilename() . ' belongs to owner id ' . $info->getOwner() . "\n";
+echo $info->getFilename() . ' belongs to owner id ' . $info->getOwner() . "\n";
 print_r(posix_getpwuid($info->getOwner()));
 ?>
 ]]>

--- a/reference/spl/splfileinfo/getsize.xml
+++ b/reference/spl/splfileinfo/getsize.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 84d643420e0a5b43f34238aff8bde6dce168825b Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 8e2cfbdce0cd028a6521c6e073f148e0f7efac7c Maintainer: takagi Status: ready -->
 <refentry xml:id="splfileinfo.getsize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SplFileInfo::getSize</refname>
@@ -47,7 +47,7 @@
 <![CDATA[
 <?php
 $info = new SplFileInfo('example.jpg');
-echo $fileinfo->getFilename() . " " . $fileinfo->getSize();
+echo $info->getFilename() . " " . $info->getSize();
 ?>
 ]]>
     </programlisting>

--- a/reference/stream/book.xml
+++ b/reference/stream/book.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 98d4a70aac9e7e3663282507f2f9ce014227e39d Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 564bdc2db8f4c01ba36f64e24356756442b74bc5 Maintainer: takagi Status: ready -->
 <!-- CREDITS: shimooka,hirokawa -->
 
 <book xml:id="book.stream" xmlns="http://docbook.org/ns/docbook">
@@ -76,6 +76,7 @@
  &reference.stream.examples;
  &reference.stream.php-user-filter;
  &reference.stream.streamwrapper;
+ &reference.stream.streambucket;
  &reference.stream.reference;
  
 </book>

--- a/reference/stream/streambucket.xml
+++ b/reference/stream/streambucket.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: a7be7e9abb82bfd0c69ea341d74fb9456e93f6f6 Maintainer: KentarouTakeda Status: ready -->
+<!-- EN-Revision: 564bdc2db8f4c01ba36f64e24356756442b74bc5 Maintainer: KentarouTakeda Status: ready -->
 <reference xml:id="class.streambucket" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>StreamBucket クラス</title>
@@ -76,7 +76,7 @@
       </simpara>
      </listitem>
     </varlistentry>
-    <varlistentry xml:id="streambucket.props.dataLength">
+    <varlistentry xml:id="streambucket.props.datalength">
      <term>int <varname>dataLength</varname></term>
      <listitem>
       <simpara>バケット内の文字列の長さ。</simpara>
@@ -96,8 +96,6 @@
   </section>
 
  </partintro>
-
- &reference.stream.entities.streambucket;
 
 </reference>
 <!-- Keep this comment at the end of the file

--- a/reference/uri/uri/rfc3986/uri/parse.xml
+++ b/reference/uri/uri/rfc3986/uri/parse.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+<!-- EN-Revision: 8e2cfbdce0cd028a6521c6e073f148e0f7efac7c Maintainer: KentarouTakeda Status: ready -->
 <refentry xml:id="uri-rfc3986-uri.parse" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Uri\Rfc3986\Uri::parse</refname>
@@ -63,7 +63,7 @@ $uri = \Uri\Rfc3986\Uri::parse("https://example.com");
 if ($uri !== null) {
     echo "Valid URI: " . $uri->toString();
 } else {
-    echo "Invalid URI"
+    echo "Invalid URI";
 }
 ?>
 ]]>

--- a/reference/uri/uri/whatwg/url/parse.xml
+++ b/reference/uri/uri/whatwg/url/parse.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: KentarouTakeda Status: ready -->
+<!-- EN-Revision: 8e2cfbdce0cd028a6521c6e073f148e0f7efac7c Maintainer: KentarouTakeda Status: ready -->
 <refentry xml:id="uri-whatwg-url.parse" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Uri\WhatWg\Url::parse</refname>
@@ -73,7 +73,7 @@ $url = \Uri\WhatWg\Url::parse("https://example.com");
 if ($url !== null) {
     echo "Valid URL: " . $url->toAsciiString();
 } else {
-    echo "Invalid URL"
+    echo "Invalid URL";
 }
 ?>
 ]]>

--- a/reference/xattr/functions/xattr-list.xml
+++ b/reference/xattr/functions/xattr-list.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14af302c9c0e561fa6f9cdd956268758ba9a89c5 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 8e2cfbdce0cd028a6521c6e073f148e0f7efac7c Maintainer: takagi Status: ready -->
 <refentry xml:id="function.xattr-list" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>xattr_list</refname>
@@ -81,7 +81,7 @@ foreach ($root_attributes as $attr_name) {
 }
 
 echo "\n User 属性: \n";
-foreach ($attributes as $attr_name) {
+foreach ($user_attributes as $attr_name) {
     printf("%s\n", $attr_name);
 }
 

--- a/reference/yaf/yaf_route_rewrite/assemble.xml
+++ b/reference/yaf/yaf_route_rewrite/assemble.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c9389e4a0e96801fd14d91336ff3f12e45929a73 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 8e2cfbdce0cd028a6521c6e073f148e0f7efac7c Maintainer: mumumu Status: ready -->
 
 <refentry xml:id="yaf-route-rewrite.assemble" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -55,7 +55,7 @@
    <title><function>Yaf_Route_Rewrite::assemble</function> の例</title>
    <programlisting role="php">
 <![CDATA[
-router = new Yaf_Router();
+$router = new Yaf_Router();
 
 $route  = new Yaf_Route_Rewrite(
                 "/product/:name/:id/*",


### PR DESCRIPTION
## 翻訳内容

### コード例の修正同期（10件）

原文の一括修正コミット（実行不能なコード例の修正: 未定義変数・構文エラー等）を反映。

- appendices/migration74/new-features.xml — 型変位の例のキリル文字 С をラテン文字 C に修正
  1. php/doc-en@8e2cfbdce0
- reference/spl/splfileinfo/getgroup.xml — 例の変数の `$` 欠落の誤りを修正
  1. php/doc-en@8e2cfbdce0
- reference/spl/splfileinfo/getowner.xml — 例の変数の `$` 欠落の誤りを修正
  1. php/doc-en@8e2cfbdce0
- reference/spl/splfileinfo/getsize.xml — 例の未定義変数の誤りを修正（`$fileinfo` → `$info`）
  1. php/doc-en@8e2cfbdce0
- reference/uri/uri/rfc3986/uri/parse.xml — 例のセミコロン欠落の誤りを修正
  1. php/doc-en@8e2cfbdce0
- reference/uri/uri/whatwg/url/parse.xml — 例のセミコロン欠落の誤りを修正
  1. php/doc-en@8e2cfbdce0
- reference/imagick/imagick/mergeimagelayers.xml — 例の未定義変数の誤りを修正（`$imagePath` → `$imagePath1`）
  1. php/doc-en@8e2cfbdce0
- reference/rar/rarentry/getunpackedsize.xml — EN-Revision 更新のみ（原文のメソッド名修正は日本語版で対応済みだった）
  1. php/doc-en@8e2cfbdce0
- reference/xattr/functions/xattr-list.xml — 例の未定義変数の誤りを修正（`$attributes` → `$user_attributes`）
  1. php/doc-en@8e2cfbdce0
- reference/yaf/yaf_route_rewrite/assemble.xml — 例の変数の `$` 欠落の誤りを修正
  1. php/doc-en@8e2cfbdce0

### reference/stream（2件）

- reference/stream/book.xml — StreamBucket クラスへの参照を追加
  1. php/doc-en@564bdc2db8
- reference/stream/streambucket.xml — xml:id の小文字化と不要なエンティティ参照の削除
  1. php/doc-en@564bdc2db8

### 独立ファイル

- appendices/migration84/new-features.xml — プロパティフックの仮想プロパティ例を明確化（cannot への変更とエラー例の追加）
  1. php/doc-en@d7efc67559
- language/types/boolean.xml — 例を実行可能に（`var_dump()` の追加）
  1. php/doc-en@ee66d210fb
- reference/exec/functions/proc-close.xml — 「プロセスを閉じる」から「パイプを閉じて終了を待つ」へ説明を正確化
  1. php/doc-en@970d3aa7fd
- reference/exec/functions/proc-open.xml — descriptor_spec の file 型に第 3 要素（ファイルモード）の説明を追加
  1. php/doc-en@f500984474
- reference/reflection/reflectionfunction/construct.xml — 例の `var_export()` 第 2 引数の誤りを修正（`1` → `true`）
  1. php/doc-en@629dfc9ec4
