### PR TITLE
datetime モジュールを完訳: PHP 8.4 の変更を同期し未訳5件を新規翻訳

### DIFF
--- a/reference/datetime/dateinterval/createfromdatestring.xml
+++ b/reference/datetime/dateinterval/createfromdatestring.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c0c9d7721b5a8564a4e27671389a456c1be13e6b Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 9eb962113cadccc164d196003062ff5d893de3a5 Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 
 <refentry xml:id="dateinterval.createfromdatestring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -85,6 +85,11 @@
     </thead>
     <tbody>
      <row>
+      <entry>8.4.0</entry>
+      <entry>
+       仮の戻り値の型が、<type>DateInterval</type> になりました。
+       これより前のバージョンでは、<type class="union"><type>DateInterval</type><type>false</type></type> でした。
+      </entry>
       <entry>8.3.0</entry>
       <entry>
        無効な文字列が渡された場合、

--- a/reference/datetime/dateperiod/construct.xml
+++ b/reference/datetime/dateperiod/construct.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 0cf48a5a4869bd8b42f84e7032076756cde6a474 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 9eb962113cadccc164d196003062ff5d893de3a5 Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 
 <refentry xml:id="dateperiod.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -35,9 +35,9 @@
     <methodparam choice="opt"><type>int</type><parameter>options</parameter><initializer>0</initializer></methodparam>
    </constructorsynopsis>
    <simpara>
-    代わりに、static なファクトリメソッド
-    <methodname>DatePeriod::createFromISO8601String</methodname>
-    を使いましょう。
+    このコンストラクタのバリエーションは、PHP 8.4.0 以降は非推奨です。
+    代わりに <methodname>DatePeriod::createFromISO8601String</methodname>
+    を使ってください。
    </simpara>
   </warning>
   <para>
@@ -167,6 +167,14 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        <parameter>isostr</parameter> を使うシグネチャは非推奨となりました。
+        代わりに <methodname>DatePeriod::createFromISO8601String</methodname>
+        を使ってください。
+       </entry>
+      </row>
       <row>
        <entry>8.3.0</entry>
        <entry>

--- a/reference/datetime/datetime/createfromtimestamp.xml
+++ b/reference/datetime/datetime/createfromtimestamp.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 726154e3c846bc0e16c60542377ea806df32e55d Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="datetime.createfromtimestamp" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>DateTime::createFromTimestamp</refname>
+  <refpurpose>Unix タイムスタンプからインスタンスを生成する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="DateTime">
+   <modifier>public</modifier> <modifier>static</modifier> <type>static</type><methodname>DateTime::createFromTimestamp</methodname>
+   <methodparam><type class="union"><type>int</type><type>float</type></type><parameter>timestamp</parameter></methodparam>
+  </methodsynopsis>
+
+  <simpara>
+   Unix タイムスタンプからインスタンスを生成します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+
+  <variablelist>
+   <varlistentry>
+    <term><parameter>timestamp</parameter></term>
+    <listitem>
+     <simpara>
+      日付を表す Unix タイムスタンプ。
+      &float; の値も受け付けるため、マイクロ秒の精度を指定できます。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   新しい <classname>DateTime</classname> インスタンスを返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   <parameter>timestamp</parameter> が [<constant>PHP_INT_MIN</constant>, <constant>PHP_INT_MAX</constant>]
+   の範囲外の場合、<exceptionname>DateRangeError</exceptionname> がスローされます。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="datetime.createfromtimestamp.example.basic">
+   <title><methodname>DateTime::createFromTimestamp</methodname> の例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$date = DateTime::createFromTimestamp(123.456789);
+echo $date->format('Y-m-d H:i:s.u');
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+1970-01-01 00:02:03.456789
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/datetime/datetime/modify.xml
+++ b/reference/datetime/datetime/modify.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 9eb962113cadccc164d196003062ff5d893de3a5 Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 
 <refentry xml:id="datetime.modify" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -71,6 +71,14 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       仮の戻り値の型が、<type>DateTime</type> になりました。
+       これより前のバージョンでは、
+       <type class="union"><type>DateTime</type><type>false</type></type> でした。
+      </entry>
+     </row>
      <row>
       <entry>8.3.0</entry>
       <entry>

--- a/reference/datetime/datetime/setmicrosecond.xml
+++ b/reference/datetime/datetime/setmicrosecond.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 726154e3c846bc0e16c60542377ea806df32e55d Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="datetime.setmicrosecond" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>DateTime::setMicrosecond</refname>
+  <refpurpose>時刻のマイクロ秒部分を設定する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="DateTime">
+   <modifier>public</modifier> <type>static</type><methodname>DateTime::setMicrosecond</methodname>
+   <methodparam><type>int</type><parameter>microsecond</parameter></methodparam>
+  </methodsynopsis>
+
+  <simpara>
+   時刻のマイクロ秒部分を設定します。
+  </simpara>
+  <simpara>
+   <methodname>DateTimeImmutable::setMicrosecond</methodname> に似ていますが、
+   <classname>DateTime</classname> を使って動作します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+
+  <variablelist>
+   <varlistentry>
+    <term><parameter>microsecond</parameter></term>
+    <listitem>
+     <simpara>
+      設定するマイクロ秒の値 (<literal>0</literal> から <literal>999999</literal>)。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &date.datetime.return.modifiedobject;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   <parameter>microsecond</parameter> が
+   [<literal>0</literal>, <literal>999999</literal>] の範囲外の場合、
+   <exceptionname>DateRangeError</exceptionname> がスローされます。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="datetime.setmicrosecond.example.basic">
+   <title><methodname>DateTime::setMicrosecond</methodname> の例</title>
+
+   <programlisting role="php">
+<![CDATA[
+<?php
+$date = DateTime::createFromTimestamp(123.456789);
+echo $date->format('Y-m-d H:i:s.u') . PHP_EOL;
+$date->setMicrosecond(987654);
+echo $date->format('Y-m-d H:i:s.u') . PHP_EOL;
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+1970-01-01 00:02:03.456789
+1970-01-01 00:02:03.987654
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>DateTimeInterface::getMicrosecond</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/datetime/datetime/settimestamp.xml
+++ b/reference/datetime/datetime/settimestamp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 02ff7fef5b34cf8f5395180d9d39fb64d9398d00 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 726154e3c846bc0e16c60542377ea806df32e55d Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 
 <refentry xml:id="datetime.settimestamp" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -65,6 +65,7 @@
   &reftitle.seealso;
   <simplelist>
    <member><function>DateTimeImmutable::setTimestamp</function></member>
+   <member><function>DateTime::setMicrosecond</function></member>
   </simplelist>
  </refsect1>
 </refentry>

--- a/reference/datetime/datetimeimmutable/add.xml
+++ b/reference/datetime/datetimeimmutable/add.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 42d5fb01e01e9ab1fdb47612833dd13d9003df6a Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 726154e3c846bc0e16c60542377ea806df32e55d Maintainer: takagi Status: ready -->
 
 <refentry xml:id="datetimeimmutable.add" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,7 +13,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="DateTimeImmutable">
-   <modifier role="attribute">#[\NoDiscard]</modifier>
+   <modifier role="attribute">#[\NoDiscard(message: "as DateTimeImmutable::add() does not modify the object itself")]</modifier>
    <modifier>public</modifier> <type>DateTimeImmutable</type><methodname>DateTimeImmutable::add</methodname>
    <methodparam><type>DateInterval</type><parameter>interval</parameter></methodparam>
   </methodsynopsis>

--- a/reference/datetime/datetimeimmutable/createfromtimestamp.xml
+++ b/reference/datetime/datetimeimmutable/createfromtimestamp.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 726154e3c846bc0e16c60542377ea806df32e55d Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="datetimeimmutable.createfromtimestamp" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>DateTimeImmutable::createFromTimestamp</refname>
+  <refpurpose>Unix タイムスタンプからインスタンスを生成する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="DateTimeImmutable">
+   <modifier>public</modifier> <modifier>static</modifier> <type>static</type><methodname>DateTimeImmutable::createFromTimestamp</methodname>
+   <methodparam><type class="union"><type>int</type><type>float</type></type><parameter>timestamp</parameter></methodparam>
+  </methodsynopsis>
+
+  <simpara>
+   Unix タイムスタンプからインスタンスを生成します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+
+  <variablelist>
+   <varlistentry>
+    <term><parameter>timestamp</parameter></term>
+    <listitem>
+     <simpara>
+      日付を表す Unix タイムスタンプ。
+      &float; の値も受け付けるため、マイクロ秒の精度を指定できます。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   新しい <classname>DateTimeImmutable</classname> インスタンスを返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   <parameter>timestamp</parameter> が [<constant>PHP_INT_MIN</constant>, <constant>PHP_INT_MAX</constant>] の範囲外の場合、
+   <exceptionname>DateRangeError</exceptionname> がスローされます。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="datetimeimmutable.createfromtimestamp.example.basic">
+   <title><methodname>DateTimeImmutable::createFromTimestamp</methodname> の例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$date = DateTimeImmutable::createFromTimestamp(123.456789);
+echo $date->format('Y-m-d H:i:s.u');
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+1970-01-01 00:02:03.456789
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/datetime/datetimeimmutable/modify.xml
+++ b/reference/datetime/datetimeimmutable/modify.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 726154e3c846bc0e16c60542377ea806df32e55d Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 
 <refentry xml:id="datetimeimmutable.modify" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -12,7 +12,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="DateTimeImmutable">
-   <modifier role="attribute">#[\NoDiscard]</modifier>
+   <modifier role="attribute">#[\NoDiscard(message: "as DateTimeImmutable::modify() does not modify the object itself")]</modifier>
    <modifier>public</modifier> <type>DateTimeImmutable</type><methodname>DateTimeImmutable::modify</methodname>
    <methodparam><type>string</type><parameter>modifier</parameter></methodparam>
   </methodsynopsis>
@@ -62,6 +62,14 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       仮の戻り値の型が、<type>DateTimeImmutable</type> になりました。
+       これより前のバージョンでは、
+       <type class="union"><type>DateTimeImmutable</type><type>false</type></type> でした。
+      </entry>
+     </row>
      <row>
       <entry>8.3.0</entry>
       <entry>

--- a/reference/datetime/datetimeimmutable/setdate.xml
+++ b/reference/datetime/datetimeimmutable/setdate.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 726154e3c846bc0e16c60542377ea806df32e55d Maintainer: takagi Status: ready -->
 
 <refentry xml:id="datetimeimmutable.setdate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -11,7 +11,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="DateTimeImmutable">
-   <modifier role="attribute">#[\NoDiscard]</modifier>
+   <modifier role="attribute">#[\NoDiscard(message: "as DateTimeImmutable::setDate() does not modify the object itself")]</modifier>
    <modifier>public</modifier> <type>DateTimeImmutable</type><methodname>DateTimeImmutable::setDate</methodname>
    <methodparam><type>int</type><parameter>year</parameter></methodparam>
    <methodparam><type>int</type><parameter>month</parameter></methodparam>

--- a/reference/datetime/datetimeimmutable/setisodate.xml
+++ b/reference/datetime/datetimeimmutable/setisodate.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 726154e3c846bc0e16c60542377ea806df32e55d Maintainer: takagi Status: ready -->
 
 <refentry xml:id="datetimeimmutable.setisodate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -11,7 +11,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="DateTimeImmutable">
-   <modifier role="attribute">#[\NoDiscard]</modifier>
+   <modifier role="attribute">#[\NoDiscard(message: "as DateTimeImmutable::setISODate() does not modify the object itself")]</modifier>
    <modifier>public</modifier> <type>DateTimeImmutable</type><methodname>DateTimeImmutable::setISODate</methodname>
    <methodparam><type>int</type><parameter>year</parameter></methodparam>
    <methodparam><type>int</type><parameter>week</parameter></methodparam>

--- a/reference/datetime/datetimeimmutable/setmicrosecond.xml
+++ b/reference/datetime/datetimeimmutable/setmicrosecond.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 726154e3c846bc0e16c60542377ea806df32e55d Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="datetimeimmutable.setmicrosecond" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>DateTimeImmutable::setMicrosecond</refname>
+  <refpurpose>時刻のマイクロ秒部分を設定する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="DateTimeImmutable">
+   <modifier role="attribute">#[\NoDiscard(message: "as DateTimeImmutable::setMicrosecond() does not modify the object itself")]</modifier>
+   <modifier>public</modifier> <type>static</type><methodname>DateTimeImmutable::setMicrosecond</methodname>
+   <methodparam><type>int</type><parameter>microsecond</parameter></methodparam>
+  </methodsynopsis>
+
+  <simpara>
+   元のオブジェクトを基にマイクロ秒部分を変更した、
+   新しい <type>DateTimeImmutable</type> オブジェクトを返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+
+  <variablelist>
+   <varlistentry>
+    <term><parameter>microsecond</parameter></term>
+    <listitem>
+     <simpara>
+      設定するマイクロ秒の値 (<literal>0</literal> から <literal>999999</literal>)。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &date.datetimeimmutable.return.modifiedobject;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   <parameter>microsecond</parameter> が [<literal>0</literal>, <literal>999999</literal>]
+   の範囲外の場合、<exceptionname>DateRangeError</exceptionname> がスローされます。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="datetimeimmutable.setmicrosecond.example.basic">
+   <title><methodname>DateTimeImmutable::setMicrosecond</methodname> の例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$date = DateTimeImmutable::createFromTimestamp(123.456789);
+echo $date->format('Y-m-d H:i:s.u') . PHP_EOL;
+$date = $date->setMicrosecond(987654);
+echo $date->format('Y-m-d H:i:s.u') . PHP_EOL;
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+1970-01-01 00:02:03.456789
+1970-01-01 00:02:03.987654
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>DateTimeInterface::getMicrosecond</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/datetime/datetimeimmutable/settime.xml
+++ b/reference/datetime/datetimeimmutable/settime.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 726154e3c846bc0e16c60542377ea806df32e55d Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 
 <refentry xml:id="datetimeimmutable.settime" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -12,7 +12,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="DateTimeImmutable">
-   <modifier role="attribute">#[\NoDiscard]</modifier>
+   <modifier role="attribute">#[\NoDiscard(message: "as DateTimeImmutable::setTime() does not modify the object itself")]</modifier>
    <modifier>public</modifier> <type>DateTimeImmutable</type><methodname>DateTimeImmutable::setTime</methodname>
    <methodparam><type>int</type><parameter>hour</parameter></methodparam>
    <methodparam><type>int</type><parameter>minute</parameter></methodparam>

--- a/reference/datetime/datetimeimmutable/settimestamp.xml
+++ b/reference/datetime/datetimeimmutable/settimestamp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 726154e3c846bc0e16c60542377ea806df32e55d Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 
 <refentry xml:id="datetimeimmutable.settimestamp" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -12,7 +12,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="DateTimeImmutable">
-   <modifier role="attribute">#[\NoDiscard]</modifier>
+   <modifier role="attribute">#[\NoDiscard(message: "as DateTimeImmutable::setTimestamp() does not modify the object itself")]</modifier>
    <modifier>public</modifier> <type>DateTimeImmutable</type><methodname>DateTimeImmutable::setTimestamp</methodname>
    <methodparam><type>int</type><parameter>timestamp</parameter></methodparam>
   </methodsynopsis>
@@ -75,6 +75,7 @@ echo $newDate->format('U = Y-m-d H:i:s') . "\n";
   &reftitle.seealso;
   <simplelist>
    <member><function>DateTimeImmutable::getTimestamp</function></member>
+   <member><function>DateTimeImmutable::setMicrosecond</function></member>
   </simplelist>
  </refsect1>
 

--- a/reference/datetime/datetimeimmutable/settimezone.xml
+++ b/reference/datetime/datetimeimmutable/settimezone.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 726154e3c846bc0e16c60542377ea806df32e55d Maintainer: takagi Status: ready -->
 
 <refentry xml:id="datetimeimmutable.settimezone" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -11,7 +11,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="DateTimeImmutable">
-   <modifier role="attribute">#[\NoDiscard]</modifier>
+   <modifier role="attribute">#[\NoDiscard(message: "as DateTimeImmutable::setTimezone() does not modify the object itself")]</modifier>
    <modifier>public</modifier> <type>DateTimeImmutable</type><methodname>DateTimeImmutable::setTimezone</methodname>
    <methodparam><type>DateTimeZone</type><parameter>timezone</parameter></methodparam>
   </methodsynopsis>

--- a/reference/datetime/datetimeimmutable/sub.xml
+++ b/reference/datetime/datetimeimmutable/sub.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 726154e3c846bc0e16c60542377ea806df32e55d Maintainer: takagi Status: ready -->
 
 <refentry xml:id="datetimeimmutable.sub" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,7 +13,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="DateTimeImmutable">
-   <modifier role="attribute">#[\NoDiscard]</modifier>
+   <modifier role="attribute">#[\NoDiscard(message: "as DateTimeImmutable::sub() does not modify the object itself")]</modifier>
    <modifier>public</modifier> <type>DateTimeImmutable</type><methodname>DateTimeImmutable::sub</methodname>
    <methodparam><type>DateInterval</type><parameter>interval</parameter></methodparam>
   </methodsynopsis>

--- a/reference/datetime/datetimeinterface/getmicrosecond.xml
+++ b/reference/datetime/datetimeinterface/getmicrosecond.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 726154e3c846bc0e16c60542377ea806df32e55d Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="datetimeinterface.getmicrosecond" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>DateTimeInterface::getMicrosecond</refname>
+  <refname>DateTimeImmutable::getMicrosecond</refname>
+  <refname>DateTime::getMicrosecond</refname>
+  <refpurpose>Unix タイムスタンプのマイクロ秒部分を取得する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="DateTimeInterface">
+   <modifier>public</modifier> <type>int</type><methodname>DateTimeInterface::getMicrosecond</methodname>
+   <void/>
+  </methodsynopsis>
+  <methodsynopsis role="DateTimeImmutable">
+   <modifier>public</modifier> <type>int</type><methodname>DateTimeImmutable::getMicrosecond</methodname>
+   <void/>
+  </methodsynopsis>
+  <methodsynopsis role="DateTime">
+   <modifier>public</modifier> <type>int</type><methodname>DateTime::getMicrosecond</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Unix タイムスタンプのマイクロ秒部分を取得します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   その日付をあらわす Unix タイムスタンプのマイクロ秒部分を返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="datetimeinterface.getmicrosecond.example.basic">
+   <title><methodname>DateTimeInterface::getMicrosecond</methodname> の例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$date = new DateTimeImmutable('2024-01-01 12:34:56.789123');
+var_dump($date->format('u'));
+var_dump($date->getMicrosecond());
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+string(6) "789123"
+int(789123)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>DateTimeInterface::getTimestamp</methodname></member>
+   <member><methodname>DateTimeInterface::format</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/datetime/datetimeinterface/gettimestamp.xml
+++ b/reference/datetime/datetimeinterface/gettimestamp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 726154e3c846bc0e16c60542377ea806df32e55d Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 
 <refentry xml:id="datetime.gettimestamp" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -157,6 +157,7 @@ echo $milli, "\n", $micro, "\n";
    <member><function>DateTime::setTimestamp</function></member>
    <member><function>DateTimeImmutable::setTimestamp</function></member>
    <member><function>DateTimeInterface::format</function></member>
+   <member><function>DateTimeInterface::getMicrosecond</function></member>
   </simplelist>
  </refsect1>
 


### PR DESCRIPTION
## 翻訳内容

PHP 8.4 の date/time 拡張の変更を同期し、datetime モジュールを完訳化します（既訳更新 13件 + 新規翻訳 5件）。

### 新規翻訳: PHP 8.4 で追加されたメソッド（5件） — php/doc-en@726154e3c8

- reference/datetime/datetime/createfromtimestamp.xml
- reference/datetime/datetime/setmicrosecond.xml
- reference/datetime/datetimeimmutable/createfromtimestamp.xml
- reference/datetime/datetimeimmutable/setmicrosecond.xml
- reference/datetime/datetimeinterface/getmicrosecond.xml

### NoDiscard 属性の message 引数を同期（6件） — php/doc-en@726154e3c8

- reference/datetime/datetimeimmutable/ 配下の add.xml, setdate.xml, setisodate.xml, settime.xml, settimezone.xml, sub.xml

### PHP 8.4.0 の仮の戻り値の型変更の changelog を追加（3件） — php/doc-en@9eb962113c

- reference/datetime/datetime/modify.xml
- reference/datetime/dateinterval/createfromdatestring.xml
- reference/datetime/datetimeimmutable/modify.xml（php/doc-en@726154e3c8 の NoDiscard 同期を含む）

### isostr 非推奨化・seealso 追加（4件） — php/doc-en@9eb962113c, php/doc-en@726154e3c8

- reference/datetime/dateperiod/construct.xml — isostr シグネチャの PHP 8.4.0 非推奨化（warning 改稿 + changelog 追加）
- reference/datetime/datetimeimmutable/settimestamp.xml — NoDiscard 同期 + seealso に DateTimeImmutable::setMicrosecond を追加
- reference/datetime/datetime/settimestamp.xml — seealso に DateTime::setMicrosecond を追加
- reference/datetime/datetimeinterface/gettimestamp.xml — seealso に DateTimeInterface::getMicrosecond を追加

### 備考

reference/datetime/dateinterval/createfromdatestring.xml の changelog は、8.4.0 と 8.3.0 のエントリが同一 `<row>` 内にある原文 php/doc-en@9eb962113c のマークアップの誤りをそのまま反映しています（原文側に修正 PR は未提出）。原文の修正後に追従します。
