### PR TITLE
PHP 8.4/8.5 関連の原文更新を同期し、HashContext::__debugInfo を新規翻訳

### DIFF
--- a/appendices/migration85/other-changes.xml
+++ b/appendices/migration85/other-changes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 6b48f364497107ae46f926bfc99a4e3d9d546316 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: c7b445ec851969e669026cfa483b104ea2de5d95 Maintainer: mumumu Status: ready -->
 <sect1 xml:id="migration85.other-changes">
  <title>その他の変更</title>
 
@@ -440,7 +440,8 @@
 
    <simpara>
     致命的なエラーにバックトレースを含めるかどうかを制御するために、
-    fatal_error_backtraces INI ディレクティブが追加されました。
+    <link linkend="ini.fatal-error-backtraces">fatal_error_backtraces</link>
+    INI ディレクティブが追加されました。
     <!-- RFC: https://wiki.php.net/rfc/error_backtraces_v2 -->
    </simpara>
 

--- a/language/enumerations.xml
+++ b/language/enumerations.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 1eb67bea30f61f7d9cdfd371146911a0ba07bbd2 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 8af3521cb43f54c652baaf8dbbcb786b79a5d04e Maintainer: mumumu Status: ready -->
  <chapter xml:id="language.enumerations" xmlns="http://docbook.org/ns/docbook" annotations="interactive">
   <title>列挙型(Enum)</title>
   <sect1 xml:id="language.enumerations.overview">
@@ -46,6 +46,7 @@
    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
+
 enum Suit
 {
     case Hearts;
@@ -70,6 +71,7 @@ enum Suit
     <programlisting role="php">
 <![CDATA[
 <?php
+
 enum Suit
 {
     case Hearts;
@@ -121,6 +123,7 @@ pick_a_card('Spades');
     <programlisting role="php">
 <![CDATA[
 <?php
+
 enum Suit
 {
     case Hearts;
@@ -176,6 +179,7 @@ if ($a !== 'Spades') {
     <programlisting role="php">
 <![CDATA[
 <?php
+
 enum Suit
 {
     case Hearts;
@@ -222,6 +226,7 @@ print Suit::Spades->name;
   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
+
 enum Suit: string
 {
     case Hearts = 'H';
@@ -276,6 +281,7 @@ enum Suit: string
    <programlisting role="php">
 <![CDATA[
 <?php
+
 enum Suit: string
 {
     case Hearts = 'H';
@@ -300,6 +306,7 @@ print Suit::Clubs->value;
    <programlisting role="php">
 <![CDATA[
 <?php
+
 enum Suit: string
 {
     case Hearts = 'H';
@@ -357,6 +364,7 @@ $ref = &$suit->value;
    <programlisting role="php">
 <![CDATA[
 <?php
+
 enum Suit: string
 {
     case Hearts = 'H';
@@ -409,6 +417,7 @@ print $suit->value . "\n";
    <programlisting role="php">
 <![CDATA[
 <?php
+
 interface Colorful
 {
     public function color(): string;
@@ -424,7 +433,7 @@ enum Suit implements Colorful
     // インターフェイスの規約を満たすための実装
     public function color(): string
     {
-        return match($this) {
+        return match ($this) {
             Suit::Hearts, Suit::Diamonds => 'Red',
             Suit::Clubs, Suit::Spades => 'Black',
         };
@@ -465,6 +474,7 @@ print Suit::Diamonds->shape(); // "Rectangle" と表示
   <programlisting role="php" annotations="non-interactive">
    <![CDATA[
 <?php
+
 interface Colorful
 {
     public function color(): string;
@@ -480,7 +490,7 @@ enum Suit: string implements Colorful
     // インターフェイスの規約を満たすための実装
     public function color(): string
     {
-        return match($this) {
+        return match ($this) {
             Suit::Hearts, Suit::Diamonds => 'Red',
             Suit::Clubs, Suit::Spades => 'Black',
         };
@@ -518,6 +528,7 @@ enum Suit: string implements Colorful
   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
+
 interface Colorful
 {
     public function color(): string;
@@ -534,7 +545,7 @@ final class Suit implements UnitEnum, Colorful
 
     public function color(): string
     {
-        return match($this) {
+        return match ($this) {
             Suit::Hearts, Suit::Diamonds => 'Red',
             Suit::Clubs, Suit::Spades => 'Black',
         };
@@ -575,6 +586,7 @@ final class Suit implements UnitEnum, Colorful
    <programlisting role="php">
 <![CDATA[
 <?php
+
 enum Size
 {
     case Small;
@@ -583,7 +595,7 @@ enum Size
 
     public static function fromLength(int $cm): self
     {
-        return match(true) {
+        return match (true) {
             $cm < 50 => self::Small,
             $cm < 100 => self::Medium,
             default => self::Large,
@@ -622,6 +634,7 @@ var_dump(Size::fromLength(50));
    <programlisting role="php">
 <![CDATA[
 <?php
+
 enum Size
 {
     case Small;
@@ -654,6 +667,7 @@ var_dump(Size::Huge);
    <programlisting role="php">
 <![CDATA[
 <?php
+
 interface Colorful
 {
     public function color(): string;
@@ -661,7 +675,8 @@ interface Colorful
 
 trait Rectangle
 {
-    public function shape(): string {
+    public function shape(): string
+    {
         return "Rectangle";
     }
 }
@@ -677,7 +692,7 @@ enum Suit implements Colorful
 
     public function color(): string
     {
-        return match($this) {
+        return match ($this) {
             Suit::Hearts, Suit::Diamonds => 'Red',
             Suit::Clubs, Suit::Spades => 'Black',
         };
@@ -718,6 +733,7 @@ var_dump($suit->shape());
   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
+
 // これは、完全に正しい列挙型の定義です
 enum Direction implements ArrayAccess
 {
@@ -833,6 +849,7 @@ $foo = new Foo();
   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
+
 $clovers = new Suit();
 // Error: Cannot instantiate enum Suit
 
@@ -859,6 +876,7 @@ $horseshoes = (new ReflectionClass(Suit::class))->newInstanceWithoutConstructor(
    <programlisting role="php">
 <![CDATA[
 <?php
+
 enum Suit
 {
     case Hearts;
@@ -904,6 +922,7 @@ var_dump(SuitBacked::cases());
    <programlisting role="php">
 <![CDATA[
 <?php
+
 enum Suit: string
 {
     case Hearts = 'H';
@@ -926,6 +945,12 @@ print serialize(Suit::Hearts);
    警告が発生し、&false; が返されます。
   </para>
 
+  <simpara>
+   <function>unserialize</function> の
+   <literal>allowed_classes</literal> オプションは、
+   <link linkend="language.enumerations">列挙型(Enum)</link> には影響しません。
+  </simpara>
+
   <para>
    Pure Enum を JSON にシリアライズしようとすると、
    Error がスローされます。
@@ -946,11 +971,14 @@ print serialize(Suit::Hearts);
    <programlisting role="php">
 <![CDATA[
 <?php
-enum Foo {
+
+enum Foo
+{
     case Bar;
 }
 
-enum Baz: int {
+enum Baz: int
+{
     case Beep = 5;
 }
 
@@ -983,12 +1011,14 @@ Baz Enum:int {
   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
+
 class A {}
 class B extends A {}
 
 function foo(A $a) {}
 
-function bar(B $b) {
+function bar(B $b)
+{
     foo($b);
 }
 ]]>
@@ -1007,7 +1037,9 @@ function bar(B $b) {
   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
-enum ErrorCode {
+
+enum ErrorCode
+{
     case SOMETHING_BROKE;
 }
 
@@ -1034,13 +1066,16 @@ function quux(ErrorCode $errorCode)
   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
+
 // 列挙型が final でなかったと仮定した、思考実験のコード
 // このコードは実際には動作しないので注意
-enum MoreErrorCode extends ErrorCode {
+enum MoreErrorCode extends ErrorCode
+{
     case PEBKAC;
 }
 
-function fot(MoreErrorCode $errorCode) {
+function fot(MoreErrorCode $errorCode)
+{
     quux($errorCode);
 }
 
@@ -1073,6 +1108,7 @@ fot(MoreErrorCode::PEBKAC);
     <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
+
 enum SortOrder
 {
     case Asc;
@@ -1106,6 +1142,7 @@ function query($fields, $filter, SortOrder $order = SortOrder::Asc)
     <programlisting role="php">
 <![CDATA[
 <?php
+
 enum UserStatus: string
 {
     case Pending = 'P';
@@ -1115,7 +1152,7 @@ enum UserStatus: string
 
     public function label(): string
     {
-        return match($this) {
+        return match ($this) {
             self::Pending => 'Pending',
             self::Active => 'Active',
             self::Suspended => 'Suspended',
@@ -1152,6 +1189,7 @@ var_dump($status->label());
     <programlisting role="php">
 <![CDATA[
 <?php
+
 enum UserStatus: string
 {
     case Pending = 'P';

--- a/reference/datetime/dateinterval/createfromdatestring.xml
+++ b/reference/datetime/dateinterval/createfromdatestring.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9eb962113cadccc164d196003062ff5d893de3a5 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 82f00c8d4d4f09fa5a363bc0c6f48e0c80eea72d Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 
 <refentry xml:id="dateinterval.createfromdatestring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -90,6 +90,8 @@
        仮の戻り値の型が、<type>DateInterval</type> になりました。
        これより前のバージョンでは、<type class="union"><type>DateInterval</type><type>false</type></type> でした。
       </entry>
+     </row>
+     <row>
       <entry>8.3.0</entry>
       <entry>
        無効な文字列が渡された場合、

--- a/reference/errorfunc/ini.xml
+++ b/reference/errorfunc/ini.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e5ff446c832aded712d45c885609ffdd277e6a49 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: c7b445ec851969e669026cfa483b104ea2de5d95 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi,mumumu -->
 <section xml:id="errorfunc.configuration" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.runtime;
@@ -23,6 +23,14 @@
      <entry>NULL</entry>
      <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
+    </row>
+    <row>
+     <entry><link linkend="ini.fatal-error-backtraces">fatal_error_backtraces</link></entry>
+     <entry>"1"</entry>
+     <entry><constant>INI_ALL</constant></entry>
+     <entry>
+      PHP 8.5.0 以降で有効です。
+     </entry>
     </row>
     <row>
      <entry><link linkend="ini.display-errors">display_errors</link></entry>
@@ -201,6 +209,24 @@
      </note>
     </listitem>
    </varlistentry>
+
+   <varlistentry xml:id="ini.fatal-error-backtraces">
+    <term>
+     <parameter>fatal_error_backtraces</parameter>
+     <type>bool</type>
+    </term>
+    <listitem>
+     <simpara>
+      致命的なエラーにバックトレースを含めるかどうかを制御します。
+      致命的なエラーとは、<constant>E_ERROR</constant>、
+      <constant>E_CORE_ERROR</constant>、<constant>E_COMPILE_ERROR</constant>、
+      <constant>E_USER_ERROR</constant>、
+      <constant>E_RECOVERABLE_ERROR</constant>、および
+      <constant>E_PARSE</constant> のことです。
+     </simpara>
+    </listitem>
+   </varlistentry>
+
    <varlistentry xml:id="ini.display-errors">
     <term>
      <parameter>display_errors</parameter>

--- a/reference/filesystem/functions/tempnam.xml
+++ b/reference/filesystem/functions/tempnam.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d1cacac75c04a115ee9b464015ce8e7782bd1517 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 17ebcd2ea14b405b781bd93aea6fa7219b6e29ae Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: shimooka,mumumu -->
 <refentry xml:id="function.tempnam" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -72,6 +72,14 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       <function>tempnam</function> が作成するファイルの名前は、
+       以前より13バイト長くなりました。
+       総合的な長さは引き続きプラットフォーム依存です。
+      </entry>
+     </row>
      <row>
       <entry>7.1.0</entry>
       <entry>

--- a/reference/hash/hashcontext/debuginfo.xml
+++ b/reference/hash/hashcontext/debuginfo.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: ed4d79beef8c9abd379088eefc8901a6fece7a3b Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="hashcontext.debuginfo" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>HashContext::__debugInfo</refname>
+  <refpurpose>ハッシュコンテキストに関するデバッグ情報を返す</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="HashContext">
+   <modifier>public</modifier> <type>array</type><methodname>HashContext::__debugInfo</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   このメソッドは、直接コールするためのものではありません。
+   <classname>HashContext</classname> のインスタンスを調べる際に、
+   <function>var_dump</function> や関連する関数からコールされます。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   デバッグ情報の連想配列を返します。
+   この配列には <literal>algo</literal> キーが含まれており、
+   そのコンテキストが使用しているハッシュアルゴリズムの名前を保持しています。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><methodname>HashContext::__debugInfo</methodname> の例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$ctx = hash_init('sha256');
+var_dump($ctx);
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+object(HashContext)#1 (1) {
+  ["algo"]=>
+  string(6) "sha256"
+}
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>hash_init</function></member>
+   <member><function>var_dump</function></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/spl/splfixedarray.xml
+++ b/reference/spl/splfixedarray.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 17ebcd2ea14b405b781bd93aea6fa7219b6e29ae Maintainer: takagi Status: ready -->
 <reference xml:id="class.splfixedarray" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>SplFixedArray クラス</title>
  <titleabbrev>SplFixedArray</titleabbrev>
@@ -68,6 +68,18 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        <classname>SplFixedArray</classname> での範囲外アクセスは、
+        <exceptionname>RuntimeException</exceptionname> ではなく
+        <exceptionname>OutOfBoundsException</exceptionname>
+        型の例外をスローするようになりました。
+        <exceptionname>OutOfBoundsException</exceptionname> は
+        <exceptionname>RuntimeException</exceptionname> の子クラスであるため、
+        これらの例外をキャッチしようとする際の動作に変更はありません。
+       </entry>
+      </row>
       <row>
        <entry>8.2.0</entry>
        <entry>

--- a/reference/var/functions/debug-zval-dump.xml
+++ b/reference/var/functions/debug-zval-dump.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 2a5223230bf6177c225003ca30c63f48ef266cc0 Maintainer: shimooka Status: ready -->
+<!-- EN-Revision: 17ebcd2ea14b405b781bd93aea6fa7219b6e29ae Maintainer: shimooka Status: ready -->
 <refentry xml:id="function.debug-zval-dump" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>debug_zval_dump</refname>
@@ -47,6 +47,29 @@
    &return.void;
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       <function>debug_zval_dump</function> は、配列がパックされているかどうかを示すようになりました。
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/var/functions/unserialize.xml
+++ b/reference/var/functions/unserialize.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: a9e47cecca7d5834de43b7641baf5d86828bb153 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 8af3521cb43f54c652baaf8dbbcb786b79a5d04e Maintainer: hirokawa Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="function.unserialize" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -104,6 +104,9 @@
             このオプションを省略すると、&true; を指定したのと同じ意味になります。
             つまり、PHP はあらゆるクラスのオブジェクトをインスタンス化しようとします。
            </simpara>
+           <simpara>
+            このオプションは、<link linkend="language.enumerations">列挙型(Enum)</link> には影響しません。
+           </simpara>
           </entry>
          </row>
          <row>
@@ -176,6 +179,14 @@
         クラス名の <type>array</type> でない場合、
         <exceptionname>TypeError</exceptionname> と <exceptionname>ValueError</exceptionname> を
         スローするようになりました。
+       </entry>
+      </row>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        大文字の <literal>"S"</literal> タグを使って文字列をアンシリアライズすることは、
+        推奨されなくなりました。
+        代わりに、小文字の <literal>"s"</literal> タグを使ってください。
        </entry>
       </row>
       <row>


### PR DESCRIPTION
## 翻訳内容

### fatal_error_backtraces INI ディレクティブの文書化（2件）

- reference/errorfunc/ini.xml — fatal_error_backtraces ディレクティブの説明とクイックリファレンス表の行を追加
  1. php/doc-en@c7b445ec85
- appendices/migration85/other-changes.xml — 既訳の fatal_error_backtraces の記述に、新設された説明へのリンクを反映
  1. php/doc-en@c7b445ec85

### unserialize の allowed_classes オプションと列挙型（2件）

- reference/var/functions/unserialize.xml — allowed_classes が列挙型に影響しない旨の注記と、大文字 "S" タグが非推奨になった旨の 8.4.0 changelog を追加
  1. php/doc-en@17ebcd2ea1
  2. php/doc-en@8af3521cb4
- language/enumerations.xml — 同じ注記をシリアライズの節に追加。コード例を原文のコーディングスタイル変更に合わせて更新（訳文への影響なし）
  1. php/doc-en@4c158f4a34
  2. php/doc-en@8af3521cb4

### PHP 8.4.0 の changelog 追加（3件）

- reference/spl/splfixedarray.xml — 範囲外アクセスの例外が OutOfBoundsException になった旨を追加
  1. php/doc-en@4d17b7b494 （マークアップ変換は反映済みのため本 PR に差分なし）
  2. php/doc-en@17ebcd2ea1
- reference/filesystem/functions/tempnam.xml — 作成されるファイル名が 13 バイト長くなった旨を追加
  1. php/doc-en@17ebcd2ea1
- reference/var/functions/debug-zval-dump.xml — changelog セクションを新設し、配列がパックされているかどうかを示すようになった旨を追加
  1. php/doc-en@17ebcd2ea1

### 独立ファイル

- reference/datetime/dateinterval/createfromdatestring.xml — changelog の row マークアップの誤りを原文の修正に合わせて修正（8.2.0 と 8.3.0 のエントリを別々の row に分離）
  1. php/doc-en@82f00c8d4d
- reference/hash/hashcontext/debuginfo.xml — HashContext::__debugInfo（PHP 8.4 で追加）の新規翻訳
  1. php/doc-en@ed4d79beef
