### PR TITLE
PHP 8.4 で追加された関数の新規翻訳 (pcntl, intl, pgsql)

### DIFF
--- a/reference/intl/dateformatter/parsetocalendar.xml
+++ b/reference/intl/dateformatter/parsetocalendar.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 20687bf9c58232244e41272d118b98ef4af16a69 Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="intldateformatter.parsetocalendar" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>IntlDateFormatter::parseToCalendar</refname>
+  <refpurpose>文字列をパースしてタイムスタンプにし、使用中のカレンダーを更新する</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="IntlDateFormatter">
+   <modifier>public</modifier> <type class="union"><type>int</type><type>float</type><type>false</type></type><methodname>IntlDateFormatter::parseToCalendar</methodname>
+   <methodparam><type>string</type><parameter>string</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter role="reference">offset</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   <parameter>string</parameter> を時間に変換します。<parameter>offset</parameter>
+   からパースを開始し、入力値を可能な限り使用します。
+  </simpara>
+  <simpara>
+   このメソッドは <methodname>IntlDateFormatter::parse</methodname>
+   と同様に動作しますが、パースした <parameter>string</parameter>
+   に含まれるタイムゾーン情報に応じて、フォーマッターのタイムゾーンが更新される点が異なります。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>string</parameter></term>
+    <listitem>
+     <simpara>
+      時間に変換する文字列。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>offset</parameter></term>
+    <listitem>
+     <simpara>
+      <parameter>string</parameter> のパースを開始する位置 (ゼロから数えます)。
+      <parameter>string</parameter> をすべて消費するまでにエラーが発生しなかった場合、
+      <parameter>offset</parameter> は -1 となります。それ以外の場合は、
+      パースが終了した (そしてエラーが発生した) 位置となります。
+      パースが失敗した場合、この変数にはその終了位置が格納されます。
+      <parameter>offset</parameter> &gt; <code>strlen($string)</code> の場合、パースは即時に失敗します。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   タイムスタンプとしてパースされた値を返します。
+   パースできなかった場合は &false; を返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><methodname>IntlDateFormatter::parseToCalendar</methodname> の例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$fmt = new IntlDateFormatter(
+    'en_US',
+    IntlDateFormatter::FULL,
+    IntlDateFormatter::FULL,
+    'America/Los_Angeles',
+    IntlDateFormatter::GREGORIAN
+);
+echo $fmt->parseToCalendar('Wednesday, December 20, 1989 at 4:00:00 PM Pacific Standard Time');
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+630201600
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>IntlDateFormatter::parse</methodname></member>
+   <member><methodname>IntlDateFormatter::format</methodname></member>
+   <member><methodname>IntlDateFormatter::getErrorCode</methodname></member>
+   <member><methodname>IntlDateFormatter::getErrorMessage</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/spoofchecker/setallowedchars.xml
+++ b/reference/intl/spoofchecker/setallowedchars.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 20687bf9c58232244e41272d118b98ef4af16a69 Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="spoofchecker.setallowedchars" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Spoofchecker::setAllowedChars</refname>
+  <refpurpose>チェック時に許可する文字集合を設定する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Spoofchecker">
+   <modifier>public</modifier> <type>void</type><methodname>Spoofchecker::setAllowedChars</methodname>
+   <methodparam><type>string</type><parameter>pattern</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>patternOptions</parameter><initializer>0</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   これ以降のチェックで許容される文字を、
+   <parameter>pattern</parameter> で記述された集合に制限します。
+   この集合に含まれない文字が存在すると、
+   <methodname>Spoofchecker::isSuspicious</methodname> はそれを疑わしいものとして報告します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>pattern</parameter></term>
+    <listitem>
+     <simpara>
+      <literal>UnicodeSet</literal> パターン、
+      すなわち正規表現スタイルの文字クラスとして記述された文字集合。
+      <literal>[</literal> で始まり <literal>]</literal> で終わる必要があります。
+      たとえば <literal>[a-z0-9]</literal> のようにします。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>patternOptions</parameter></term>
+    <listitem>
+     <simpara>
+      <parameter>pattern</parameter> をどのように解釈するかを制御するビットマスク。
+      <literal>0</literal> にするか、
+      <constant>Spoofchecker::IGNORE_SPACE</constant> を単独で指定するか、
+      あるいはそれと <constant>Spoofchecker::CASE_INSENSITIVE</constant>、
+      <constant>Spoofchecker::ADD_CASE_MAPPINGS</constant>、
+      <constant>Spoofchecker::SIMPLE_CASE_INSENSITIVE</constant>
+      のいずれかひとつだけを組み合わせて指定しなければなりません。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   値を返しません。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   <parameter>pattern</parameter> が有効な文字集合のパターンでない場合や、
+   <parameter>patternOptions</parameter> がオプションの有効な組み合わせでない場合に、
+   <exceptionname>ValueError</exceptionname> をスローします。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><methodname>Spoofchecker::setAllowedChars</methodname> の例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$checker = new Spoofchecker();
+$checker->setAllowedChars('[a-z0-9]');
+
+var_dump($checker->isSuspicious('hello'));
+var_dump($checker->isSuspicious('héllo'));
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+bool(false)
+bool(true)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Spoofchecker::setAllowedLocales</methodname></member>
+   <member><methodname>Spoofchecker::isSuspicious</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pcntl/functions/pcntl-forkx.xml
+++ b/reference/pcntl/functions/pcntl-forkx.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: acb474ea92ab6226eaf419a85de05f68c6715a9f Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="function.pcntl-forkx" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pcntl_forkx</refname>
+  <refpurpose>forkx(2) を使って子プロセスを生成する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>int</type><methodname>pcntl_forkx</methodname>
+   <methodparam><type>int</type><parameter>flags</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   <function>pcntl_forkx</function> 関数は、
+   illumos および Solaris システムで利用可能な
+   <literal>forkx(2)</literal> システムコールを使って子プロセスを生成します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>flags</parameter></term>
+    <listitem>
+     <simpara>
+      <parameter>flags</parameter> パラメータは、フォークの動作を制御します。
+      デフォルトの動作にする場合は <literal>0</literal> を、
+      子プロセスの終了時に親プロセスへ <constant>SIGCHLD</constant>
+      シグナルが送信されるのを防ぐ場合は
+      <constant>FORK_NOSIGCHLD</constant> を渡します。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   成功時に、子プロセスの PID が親プロセスの実行スレッドに返され、
+   子プロセスの実行スレッドには <literal>0</literal> が返されます。
+   失敗した場合、親プロセスのコンテキストに <literal>-1</literal> が返され、
+   子プロセスは生成されずに、PHP のエラーが発生します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>pcntl_fork</function></member>
+   <member><function>pcntl_rfork</function></member>
+   <member><function>pcntl_waitpid</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pcntl/functions/pcntl-getcpu.xml
+++ b/reference/pcntl/functions/pcntl-getcpu.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: acb474ea92ab6226eaf419a85de05f68c6715a9f Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="function.pcntl-getcpu" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pcntl_getcpu</refname>
+  <refpurpose>呼び出し元のプロセスが最後に実行された CPU の番号を取得する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>int</type><methodname>pcntl_getcpu</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   <function>pcntl_getcpu</function> は、
+   呼び出し元のプロセスが最後に実行された CPU の番号を返します。
+   この関数は、Linux で利用可能な
+   <literal>sched_getcpu(3)</literal> システムコールを使います。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   CPU の番号を &integer; として返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>pcntl_getcpuaffinity</function></member>
+   <member><function>pcntl_setcpuaffinity</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pcntl/functions/pcntl-setns.xml
+++ b/reference/pcntl/functions/pcntl-setns.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: acb474ea92ab6226eaf419a85de05f68c6715a9f Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="function.pcntl-setns" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pcntl_setns</refname>
+  <refpurpose>呼び出し元のプロセスを、別のプロセスの名前空間に関連付け直す</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>pcntl_setns</methodname>
+   <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>process_id</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>nstype</parameter><initializer><constant>CLONE_NEWNET</constant></initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   呼び出し元のプロセスを、<parameter>process_id</parameter>
+   で指定したプロセスの Linux 名前空間に、
+   <literal>pidfd_open(2)</literal> で取得した pidfd と
+   <literal>setns(2)</literal> を使って関連付け直します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>process_id</parameter></term>
+    <listitem>
+     <simpara>
+      参加する名前空間を持つ、対象プロセスのプロセスID。
+      &null; の場合、呼び出し元のプロセス自身の PID を使います。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>nstype</parameter></term>
+    <listitem>
+     <simpara>
+      関連付け直す名前空間の種類。デフォルトは
+      <constant>CLONE_NEWNET</constant> (ネットワーク名前空間) です。
+      指定できる値には <constant>CLONE_NEWNET</constant>、
+      <constant>CLONE_NEWIPC</constant>、
+      <constant>CLONE_NEWUTS</constant> などがあります。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.success;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>pcntl_unshare</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pcntl/functions/pcntl-wifcontinued.xml
+++ b/reference/pcntl/functions/pcntl-wifcontinued.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: acb474ea92ab6226eaf419a85de05f68c6715a9f Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="function.pcntl-wifcontinued" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pcntl_wifcontinued</refname>
+  <refpurpose>子プロセスがジョブ制御による停止から再開したかどうかを調べる</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>pcntl_wifcontinued</methodname>
+   <methodparam><type>int</type><parameter>status</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   <function>pcntl_waitpid</function> のリターンを生じた子プロセスが、
+   ジョブ制御による停止から再開したかどうかを調べます。
+   この関数が役に立つのは、<function>pcntl_waitpid</function> のコールが
+   オプション <constant>WCONTINUED</constant> を用いて行われた場合のみです。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>status</parameter></term>
+    <listitem>
+     &pcntl.parameter.status;
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   <function>pcntl_waitpid</function> のリターンを生じた子プロセスが
+   ジョブ制御による停止から再開した場合に &true;、
+   それ以外の場合に &false; を返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>pcntl_waitpid</function></member>
+   <member><function>pcntl_wifstopped</function></member>
+   <member><function>pcntl_wifexited</function></member>
+   <member><function>pcntl_wifsignaled</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pgsql/functions/pg-change-password.xml
+++ b/reference/pgsql/functions/pg-change-password.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 491bd06bf430a9b0d9117a7b7c2c2b02a46ef84b Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="function.pg-change-password" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pg_change_password</refname>
+  <refpurpose>PostgreSQL ユーザーのパスワードを変更する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>pg_change_password</methodname>
+   <methodparam><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
+   <methodparam><type>string</type><parameter>user</parameter></methodparam>
+   <methodparam><type>string</type><parameter>password</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   <function>pg_change_password</function> は、
+   PostgreSQL ユーザーのパスワードを変更します。
+   この関数は libpq の <literal>PQchangePassword</literal> 関数を使用しており、
+   パスワードの暗号化はサーバーの設定に基づいて自動的に処理されます。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>connection</parameter></term>
+    <listitem>
+     &pgsql.parameter.connection;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>user</parameter></term>
+    <listitem>
+     <simpara>
+      パスワードを変更する PostgreSQL ユーザーの名前。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>password</parameter></term>
+    <listitem>
+     <simpara>
+      新しいパスワード。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.success;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>pg_connect</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pgsql/functions/pg-jit.xml
+++ b/reference/pgsql/functions/pg-jit.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 491bd06bf430a9b0d9117a7b7c2c2b02a46ef84b Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="function.pg-jit" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pg_jit</refname>
+  <refpurpose>サーバーの JIT 情報を返す</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>array</type><methodname>pg_jit</methodname>
+   <methodparam choice="opt"><type class="union"><type>PgSql\Connection</type><type>null</type></type><parameter>connection</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   <function>pg_jit</function> は、PostgreSQL サーバーの
+   JIT (ジャストインタイムコンパイル) 情報を含む配列を返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>connection</parameter></term>
+    <listitem>
+     &pgsql.parameter.connection-with-nullable-default;
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   サーバーの JIT 情報を含む &array; を返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>pg_version</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pgsql/functions/pg-put-copy-data.xml
+++ b/reference/pgsql/functions/pg-put-copy-data.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 491bd06bf430a9b0d9117a7b7c2c2b02a46ef84b Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="function.pg-put-copy-data" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pg_put_copy_data</refname>
+  <refpurpose>COPY 操作中にサーバーへデータを送信する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>int</type><methodname>pg_put_copy_data</methodname>
+   <methodparam><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
+   <methodparam><type>string</type><parameter>cmd</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   <literal>COPY FROM STDIN</literal> 操作中に、サーバーへデータを送信します。
+   この関数を呼び出す前に、<literal>COPY</literal> コマンドを
+   <function>pg_query</function> で発行しておく必要があります。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>connection</parameter></term>
+    <listitem>
+     &pgsql.parameter.connection;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>cmd</parameter></term>
+    <listitem>
+     <simpara>
+      サーバーに送信するデータ。末尾に改行がない場合は、自動的に改行が付加されます。
+      データは、<literal>COPY</literal> コマンドのフォーマットに従って
+      整形されていなければなりません。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   成功した場合に <literal>1</literal> を、
+   データをキューに入れられなかった場合（ノンブロッキングモードのみ）に
+   <literal>0</literal> を、エラーの場合に <literal>-1</literal> を返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>pg_put_copy_end</function></member>
+   <member><function>pg_query</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pgsql/functions/pg-put-copy-end.xml
+++ b/reference/pgsql/functions/pg-put-copy-end.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 491bd06bf430a9b0d9117a7b7c2c2b02a46ef84b Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="function.pg-put-copy-end" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pg_put_copy_end</refname>
+  <refpurpose>COPY 操作の完了をサーバーに通知する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>int</type><methodname>pg_put_copy_end</methodname>
+   <methodparam><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>error</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   <literal>COPY FROM STDIN</literal> 操作中に、
+   データの終端を示す通知をサーバーに送信します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>connection</parameter></term>
+    <listitem>
+     &pgsql.parameter.connection;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>error</parameter></term>
+    <listitem>
+     <simpara>
+      &null; でない場合、<literal>COPY</literal> 操作は、
+      指定したエラーメッセージとともに強制的に失敗します。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   成功した場合に <literal>1</literal> を、
+   データをキューに入れられなかった場合（ノンブロッキングモードのみ）に
+   <literal>0</literal> を、エラーの場合に <literal>-1</literal> を返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>pg_put_copy_data</function></member>
+   <member><function>pg_query</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pgsql/functions/pg-socket-poll.xml
+++ b/reference/pgsql/functions/pg-socket-poll.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 491bd06bf430a9b0d9117a7b7c2c2b02a46ef84b Maintainer: KentarouTakeda Status: ready -->
+
+<refentry xml:id="function.pg-socket-poll" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pg_socket_poll</refname>
+  <refpurpose>PostgreSQL 接続のソケットが読み取り/書き込み可能かどうかをポーリングする</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>int</type><methodname>pg_socket_poll</methodname>
+   <methodparam><type>resource</type><parameter>socket</parameter></methodparam>
+   <methodparam><type>int</type><parameter>read</parameter></methodparam>
+   <methodparam><type>int</type><parameter>write</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>timeout</parameter><initializer>-1</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   PostgreSQL 接続のソケットが読み取りおよび/または書き込み可能かどうかをポーリングします。
+   ソケットは <function>pg_socket</function> を使って取得できます。
+   この関数は、ノンブロッキングな非同期クエリのワークフローを実装する際に役立ちます。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>socket</parameter></term>
+    <listitem>
+     <simpara>
+      <function>pg_socket</function> から取得したソケットリソース。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>read</parameter></term>
+    <listitem>
+     <simpara>
+      読み取り可能かをチェックするかどうか。
+      チェックする場合は <literal>1</literal> を、
+      スキップする場合は <literal>0</literal> を渡します。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>write</parameter></term>
+    <listitem>
+     <simpara>
+      書き込み可能かをチェックするかどうか。
+      チェックする場合は <literal>1</literal> を、
+      スキップする場合は <literal>0</literal> を渡します。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>timeout</parameter></term>
+    <listitem>
+     <simpara>
+      待機する最大のミリ秒数。
+      無期限に待機する場合は <literal>-1</literal> を、
+      まったく待機しない場合は <literal>0</literal> を渡します。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   ソケットの準備ができている場合は正の値を、
+   タイムアウトに達した場合は <literal>0</literal> を、
+   エラー時は <literal>-1</literal> を返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>pg_socket</function></member>
+   <member><function>pg_consume_input</function></member>
+   <member><function>pg_send_query</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
## 翻訳内容

PHP 8.4 で追加された関数ドキュメントの新規翻訳（11件）

### reference/pcntl/functions（4件）

- reference/pcntl/functions/pcntl-forkx.xml — pcntl_forkx（forkx(2) による子プロセス生成）
  1. php/doc-en@acb474e
- reference/pcntl/functions/pcntl-getcpu.xml — pcntl_getcpu（実行中 CPU 番号の取得）
  1. php/doc-en@acb474e
- reference/pcntl/functions/pcntl-setns.xml — pcntl_setns（名前空間への再関連付け）
  1. php/doc-en@acb474e
- reference/pcntl/functions/pcntl-wifcontinued.xml — pcntl_wifcontinued（ジョブ制御停止からの再開判定）
  1. php/doc-en@acb474e

### reference/intl（2件）

- reference/intl/dateformatter/parsetocalendar.xml — IntlDateFormatter::parseToCalendar
  1. php/doc-en@20687bf
- reference/intl/spoofchecker/setallowedchars.xml — Spoofchecker::setAllowedChars
  1. php/doc-en@20687bf

### reference/pgsql/functions（5件）

- reference/pgsql/functions/pg-change-password.xml — pg_change_password
  1. php/doc-en@491bd06
- reference/pgsql/functions/pg-jit.xml — pg_jit
  1. php/doc-en@491bd06
- reference/pgsql/functions/pg-put-copy-data.xml — pg_put_copy_data
  1. php/doc-en@491bd06
- reference/pgsql/functions/pg-put-copy-end.xml — pg_put_copy_end
  1. php/doc-en@491bd06
- reference/pgsql/functions/pg-socket-poll.xml — pg_socket_poll
  1. php/doc-en@491bd06
