### PR TITLE
既訳の誤りを修正（誤訳・訳抜け・未訳注記・用語統一）

### DIFF
--- a/appendices/migration74/new-features.xml
+++ b/appendices/migration74/new-features.xml
@@ -174,7 +174,7 @@ $fruits = ['banana', 'orange', ...$parts, 'watermelon'];
 
    <para>
     <link linkend="object.tostring">__toString()</link>
-    から例外をスローできるようになりました。以前は、この場合には致命的なエラーが発生していました。この関数内に既に存在する、回復可能な致命的なエラーは
+    から例外をスローできるようになりました。以前は、この場合には致命的なエラーが発生していました。文字列への変換時に発生する既存の回復可能な致命的なエラーは
     <classname>Error</classname> 例外クラスに変換されます。
    </para>
   </sect3>
@@ -261,7 +261,7 @@ $fruits = ['banana', 'orange', ...$parts, 'watermelon'];
    ユーザー名とパスワードが、PDO DSN の一部として指定できるようになりました。対象となるのは、mysql, mssql, sybase, dblib, firebird, oci ドライバです。以前は、この機能は pgsql ドライバでのみサポートされていました。ユーザー名/パスワードがコンストラクタとDSNの両方で指定された場合は、コンストラクタの指定が優先します。
   </para>
   <para>
-      SQLクエリのクエスチョンマークが、パラメータのプレースホルダーとして解釈されるのを防ぐためにエスケープできるようになりました。<literal>??</literal> を書くことで、単一のクエスチョンマークをデータベースに送信できるようになります。PostgreSQL のJSONのキーが存在するかを確認する演算子 (<literal>?</literal>) として使って下さい。
+      SQLクエリのクエスチョンマークが、パラメータのプレースホルダーとして解釈されるのを防ぐためにエスケープできるようになりました。<literal>??</literal> を書くことで、単一のクエスチョンマークをデータベースに送信し、例えば PostgreSQL の JSON キー存在 (<literal>?</literal>) 演算子を使えるようになります。
   </para>
  </sect2>
 
@@ -338,10 +338,9 @@ public function __unserialize(array $data): void
 ]]>
      </programlisting>
     </informalexample>
-    新しいシリアル化の機構は、 <interfacename>Serializable</interfacename>
-    インターフェイス を置き換えるものです。
+    新しいシリアル化の機構は、将来非推奨になる
     <interfacename>Serializable</interfacename>
-    インターフェイスは将来非推奨になるでしょう。
+    インターフェイスを置き換えるものです。
    </para>
   </sect3>
 

--- a/appendices/migration84/new-features.xml
+++ b/appendices/migration84/new-features.xml
@@ -112,9 +112,9 @@ class Example
 }
 
 $initializer = static function (Example $ghost): void {
-    // Fetch data or dependencies
+    // データや依存関係を取得します
     $data = getData();
-    // Initialize
+    // 初期化します
     $ghost->__construct($data);
 };
 
@@ -172,8 +172,8 @@ $object = $reflector->newLazyGhost($initializer);
    <!-- TODO: expand and examples? -->
    <simpara>
     <classname>WeakReference</classname> のデバッグ情報を取得すると、
-    参照しているオブジェクト、または参照が無効になっている場合は
-    &null; が出力されるようになりました。
+    参照しているオブジェクト(参照が無効になっている場合は
+    &null;)もあわせて出力されるようになりました。
    </simpara>
   </sect3>
 
@@ -276,7 +276,7 @@ $object = $reflector->newLazyGhost($initializer);
    新たなクラスが追加されました(例: <classname>Dom\Node</classname> は
    <classname>DOMNode</classname> に対応する新しいクラスです)。
    これらのクラスは HTML 5 に対応しており、WHATWG の仕様に準拠しています。
-   これは DOM 拡張の長年のバグを解決します。
+   これは DOM 拡張モジュールの長年のバグを解決します。
    従来の DOM クラスも後方互換性のために引き続き利用可能です。
   </simpara>
 
@@ -299,7 +299,7 @@ $object = $reflector->newLazyGhost($initializer);
    に任意の callable を渡すことが可能になりました。
 
    さらに、<methodname>DOMXPath::registerPhpFunctionNs</methodname> により、
-   <code>php:function('name')</code> ではなく、ネイティブな関数呼び出し構文で
+   <code>php:function('name')</code> ではなく、ネイティブな関数呼び出し構文を使う
    コールバックを登録できるようになりました。
   </simpara>
  </sect2>
@@ -319,11 +319,12 @@ $object = $reflector->newLazyGhost($initializer);
 
   <simpara>
    Curve25519 および Curve448 ベースのキーのサポートが追加されました。
-   具体的には、x25519、ed25519、x448、ed448 フィールドが
+   具体的には、
    <function>openssl_pkey_new</function>、
    <function>openssl_pkey_get_details</function>、
    <function>openssl_sign</function>、および
-   <function>openssl_verify</function> を、サポートするよう拡張されました。
+   <function>openssl_verify</function> が、x25519、ed25519、x448、ed448 フィールドを
+   サポートするよう拡張されました。
   </simpara>
 
   <simpara>
@@ -396,10 +397,11 @@ $object = $reflector->newLazyGhost($initializer);
      エスケープ
     </member>
     <member>
-     バッククオートで囲まれたリテラルでのクオートの二重化によるエスケープ
+     バッククオートで囲まれた識別子リテラルでのクオートの二重化によるエスケープ
     </member>
     <member>
-     2 つのハイフンによるコメント、C 言語形式のコメント、
+     少なくとも1つの空白が後に続く 2 つのハイフンによるコメント、
+     ネストされていない C 言語形式のコメント、
      # によるコメント
     </member>
    </simplelist>

--- a/appendices/migration85/other-changes.xml
+++ b/appendices/migration85/other-changes.xml
@@ -8,7 +8,7 @@
   <title>PHP コア</title>
 
   <sect3 xml:id="migration85.other-changes.core.core">
-   <title>Core</title>
+   <title>PHP コア</title>
 
    <simpara>
     macOS における高精度なタイマー(<function>hrtime</function>)
@@ -83,7 +83,7 @@
    </simpara>
 
    <simpara>
-    FPM のログの長さの上限は、
+    FPM のアクセスログの長さの上限は、
     <link linkend="log-limit">log_limit</link> の値を尊重するようになりました。
    </simpara>
 
@@ -171,7 +171,7 @@
 
    <simpara>
     <function>openssl_cms_encrypt</function> の <parameter>$cipher_algo</parameter>
-    パラメーターに、暗号名を示す文字列を指定できるようになりました。
+    パラメータに、暗号名を示す文字列を指定できるようになりました。
     これによって、認証付きのエンベロープデータ向けに、
     AES GCM 暗号アルゴリズムを含むより多くのアルゴリズムを使えるようになります。
    </simpara>
@@ -205,9 +205,9 @@
    <simpara>
     <methodname>Pdo\Pgsql::setAttribute</methodname> と
     <methodname>Pdo\Pgsql::prepare</methodname> は、
-    lazy フェッチモードに入ることを示すために、
     <constant>PDO::ATTR_PREFETCH</constant> に 0 を設定できるようになりました。
-    このモードの場合、Statement は並列に実行できません。
+    0 を設定すると、lazy フェッチモードに入ります。
+    このモードの場合、ステートメントは並列に実行できません。
    </simpara>
 
   </sect3>
@@ -327,7 +327,7 @@
    <simpara>
     <function>curl_setopt</function> に指定する
     <constant>CURLOPT_FOLLOWLOCATION</constant> オプションの値が、
-    boolean ではなく数値として扱われるようになりました。
+    boolean ではなく整数として扱われるようになりました。
     これは <constant>CURLFOLLOW_OBEYCODE</constant> と
     <constant>CURLFOLLOW_FIRSTONLY</constant> を処理するためです。
    </simpara>
@@ -338,7 +338,7 @@
    <title>Fileinfo</title>
 
    <simpara>
-    file の magic データベースが、5.45 から 5.46 に更新されました。
+    file が、5.45 から 5.46 に更新されました。
    </simpara>
 
    <simpara>
@@ -415,7 +415,7 @@
     <function>readline_clear_history</function>,
     <function>readline_callback_handler_install</function>
     の戻り値の型が、
-    <type>bool</type> から <type>true</type> に変更されました。
+    <type>bool</type> ではなく、<type>true</type> に変更されました。
    </simpara>
 
   </sect3>
@@ -448,8 +448,8 @@
    <simpara>
     起動時にのみ有効な、max_memory_limit INI ディレクティブが追加されました。
     これは、起動時または実行時に設定可能な memory_limit の最大値を制御するためのものです。
-    この値を超えると、-1 を設定しない限り警告が発生します。
-    代わりに、memory_limit の値が、現在の max_memory_limit の値に設定されます。
+    この値を超えると、-1 を設定しない限り警告が発生し、
+    memory_limit の値が、超過した値の代わりに現在の max_memory_limit の値に設定されます。
     <!-- ML discussion: https://externals.io/message/127108 -->
    </simpara>
 
@@ -517,8 +517,8 @@
    <title>PHP コア</title>
 
    <simpara>
-    <code>match(true)</code> パターン向けに、
-    boolean 値との同一性の比較に関する OPcode が削除されました。
+    boolean 値との同一性の比較に関する OPcode が、
+    特に <code>match(true)</code> パターンで削除されました。
    </simpara>
 
    <simpara>
@@ -528,7 +528,7 @@
    </simpara>
 
    <simpara>
-    例外オブジェクトを生成する速度が向上しました。
+    例外オブジェクトを生成する速度が大幅に向上しました。
    </simpara>
 
    <simpara>
@@ -600,7 +600,7 @@
 
    <simpara>
     <classname>SplFixedArray</classname> の、
-    多次元のアクセス処理と、メソッドのパフォーマンスが向上しました。
+    添字アクセス(次元アクセサ)と、メソッドのパフォーマンスが向上しました。
    </simpara>
 
   </sect3>

--- a/install/windows/apache2.xml
+++ b/install/windows/apache2.xml
@@ -41,6 +41,12 @@
 
  <sect2 xml:id="install.windows.apache2.module">
   <title>Apache ハンドラとしてインストール</title>
+  <note>
+   <simpara>
+    apache2handler SAPI を使う場合は、Thread Safe (TS) 版の
+    PHP を使わなければいけません。
+   </simpara>
+  </note>
   <para>
    Apache 2.x 用の PHP モジュールを読み込むには、
    以下の行を Apache 設定ファイル &httpd.conf; に追加しなければいけません:


### PR DESCRIPTION
英語版の内容に変更はなく、既存翻訳の改善のため EN-Revision は更新していない。

### appendices/migration84/new-features.xml
- OpenSSL の Curve25519/Curve448 サポート説明の主述転倒を修正（関数がフィールドをサポートする、が逆になっていた）
- DOMXPath::registerPhpFunctionNs 説明の「ネイティブな関数呼び出し構文」の係り先を修正
- WeakReference のデバッグ情報説明の "also"（参照先オブジェクトも出力される）の訳抜けを補完
- PDO_MYSQL のコメント構文説明の訳抜けを補完（"at least 1 whitespace" / "non-nested" / "identifiers"）
- 「DOM 拡張」を用語集に従い「DOM 拡張モジュール」に修正
- レイジーオブジェクトのコード例の英語コメントを翻訳

### appendices/migration74/new-features.xml
- "in string conversions"（文字列への変換時）を「この関数内に既に存在する」と訳していた誤りを修正
- PDO のクエスチョンマークのエスケープ説明を、例示・可能の原文から命令文に訳していた誤りを修正（"e.g." の訳抜けも補完）
- 新しいシリアル化機構の説明を、原文の1文・interfacename 1個に合わせて修正（2文・2個に分割されていた）

### appendices/migration85/other-changes.xml
- FPM のアクセスログ上限説明の "access" の訳抜けを補完
- max_memory_limit 説明の "instead" の係り先の誤りを修正（警告と設定が対立して読めていた）
- match(true) の OPcode 削除説明を、boolean 同一性比較全般から match(true) 限定に誤読していた点を修正
- SplFixedArray の "dimension accessors"（添字アクセス）を「多次元のアクセス処理」と訳していた誤りを修正
- Pdo\Pgsql の lazy フェッチモードの因果説明を修正
- CURLOPT_FOLLOWLOCATION の "integer" を「数値」から「整数」に修正
- readline の戻り値型 "true, rather than bool" を「bool から true に」から「bool ではなく true に」に修正（finfo_close の訳と統一）
- Fileinfo で原文にない「magic データベース」の限定を除去
- 例外オブジェクト生成の "much faster" の "much"（大幅に）の訳抜けを補完
- sect3 title "Core" を同ファイル内の他見出しに合わせ「PHP コア」に統一
- openssl_cms_encrypt の「パラメーター」を同ファイル内表記に合わせ「パラメータ」に統一

### install/windows/apache2.xml
- 「Apache ハンドラとしてインストール」節の未訳注記（apache2handler SAPI 利用時は Thread Safe 版 PHP が必須）を追加
