### PR TITLE
doc-en と同期し <parameter> の $ 記号除去ほかを反映（20ファイル）

### DIFF
--- a/appendices/migration83/deprecated.xml
+++ b/appendices/migration83/deprecated.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9c828621cbce488cf6306b21c39e208f847eabd5 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: mumumu Status: ready -->
 <sect1 xml:id="migration83.deprecated">
  <title>PHP 8.3.x で推奨されなくなる機能</title>
 
@@ -32,9 +32,9 @@
  <sect2 xml:id="migration83.deprecated.core.dba">
   <title>DBA</title>
 
-  <para>
-   <parameter>$dba</parameter> を第3引数に渡して <function>dba_fetch</function> をコールすることは、推奨されなくなりました。
-  </para>
+  <simpara>
+   <parameter>dba</parameter> を第3引数に渡して <function>dba_fetch</function> をコールすることは、推奨されなくなりました。
+  </simpara>
  </sect2>
 
  <sect2 xml:id="migration83.deprecated.ffi">
@@ -59,25 +59,25 @@
  <sect2 xml:id="migration83.deprecated.ldap">
   <title>LDAP</title>
 
-  <para>
-   <function>ldap_connect</function> に、<parameter>$hostname</parameter> と <parameter>$port</parameter> を別々に渡してコールすることは、推奨されなくなりました。
+  <simpara>
+   <function>ldap_connect</function> に、<parameter>hostname</parameter> と <parameter>port</parameter> を別々に渡してコールすることは、推奨されなくなりました。
    <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_3#deprecate_calling_ldap_connect_with_2_parameters -->
-  </para>
+  </simpara>
  </sect2>
 
  <sect2 xml:id="migration83.deprecated.mbstring">
   <title>マルチバイト文字列</title>
 
-  <para>
-   <function>mb_strimwidth</function> に負の <parameter>$width</parameter> を渡すことは、推奨されなくなりました。
-  </para>
+  <simpara>
+   <function>mb_strimwidth</function> に負の <parameter>width</parameter> を渡すことは、推奨されなくなりました。
+  </simpara>
  </sect2>
 
  <sect2 xml:id="migration83.deprecated.phar">
   <title>Phar</title>
 
   <para>
-   <type>resource</type> と <parameter>$length</parameter> を渡して <methodname>Phar::setStub</methodname> をコールすることは、推奨されなくなりました。<code>$phar->setStub(stream_get_contents($resource));</code> に置き換えるべきです。
+   <type>resource</type> と <parameter>length</parameter> を渡して <methodname>Phar::setStub</methodname> をコールすることは、推奨されなくなりました。<code>$phar->setStub(stream_get_contents($resource));</code> に置き換えるべきです。
   </para>
  </sect2>
 

--- a/appendices/migration83/incompatible.xml
+++ b/appendices/migration83/incompatible.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: a989e5f21db7902c0028ad51e9adc94024d13216 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: mumumu Status: ready -->
 <sect1 xml:id="migration83.incompatible" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>下位互換性のない変更点</title>
 
@@ -121,15 +121,15 @@
   <para>
    <function>range</function> 関数に対して、さまざまな変更が加えられました:
    <simplelist>
-    <member>オブジェクトやリソース、配列を境界の値として渡すと、<classname>TypeError</classname> がスローされるようになりました。</member>
-    <member><parameter>$step</parameter> に <literal>0</literal> を渡すと、よりわかりやすい <classname>ValueError</classname> がスローされるようになりました。</member>
-    <member>範囲が増加しているのに、<parameter>$step</parameter> に負の値を渡すと、<classname>ValueError</classname> がスローされるようになりました。</member>
-    <member><parameter>$step</parameter> が整数型として解釈できる float の場合、整数型として解釈するようになりました。</member>
-    <member>引数のいずれかが無限大または NAN の場合、<classname>ValueError</classname> がスローされるようになりました。</member>
-    <member><parameter>$start</parameter> や <parameter>$end</parameter> が空文字列の場合、<constant>E_WARNING</constant> が発生するようになりました。値そのものが <literal>0</literal> にキャストされる動作は変更されていません。</member>
-    <member><parameter>$start</parameter> や <parameter>$end</parameter> が1バイトより長い場合、<constant>E_WARNING</constant> が発生するようになりました。但し、それが数値形式の文字列でない場合に限ります。</member>
-    <member><parameter>$start</parameter> や <parameter>$end</parameter> が整数型にキャストした値の場合、<constant>E_WARNING</constant> が発生するようになりました。なぜなら、他の境界の入力値は数値だからです。(例: <code>range(5, 'z');</code>)</member>
-    <member><parameter>$step</parameter> が float の場合で、ある範囲の文字を生成しようとした場合、<constant>E_WARNING</constant> が発生するようになりました。但し、境界の値がともに数値形式の文字列の場合を除きます。(例: <code>range('5', '9', 0.5);</code>  のようなコードは、警告が発生しません)</member>
+    <member>オブジェクトやリソース、配列を境界の値として渡すと、<exceptionname>TypeError</exceptionname> がスローされるようになりました。</member>
+    <member><parameter>step</parameter> に <literal>0</literal> を渡すと、よりわかりやすい <exceptionname>ValueError</exceptionname> がスローされるようになりました。</member>
+    <member>範囲が増加しているのに、<parameter>step</parameter> に負の値を渡すと、<exceptionname>ValueError</exceptionname> がスローされるようになりました。</member>
+    <member><parameter>step</parameter> が整数型として解釈できる float の場合、整数型として解釈するようになりました。</member>
+    <member>引数のいずれかが無限大または NAN の場合、<exceptionname>ValueError</exceptionname> がスローされるようになりました。</member>
+    <member><parameter>start</parameter> や <parameter>end</parameter> が空文字列の場合、<constant>E_WARNING</constant> が発生するようになりました。値そのものが <literal>0</literal> にキャストされる動作は変更されていません。</member>
+    <member><parameter>start</parameter> や <parameter>end</parameter> が1バイトより長い場合、<constant>E_WARNING</constant> が発生するようになりました。但し、それが数値形式の文字列でない場合に限ります。</member>
+    <member><parameter>start</parameter> や <parameter>end</parameter> が整数型にキャストした値の場合、<constant>E_WARNING</constant> が発生するようになりました。なぜなら、他の境界の入力値は数値だからです。(例: <code>range(5, 'z');</code>)</member>
+    <member><parameter>step</parameter> が float の場合で、ある範囲の文字を生成しようとした場合、<constant>E_WARNING</constant> が発生するようになりました。但し、境界の値がともに数値形式の文字列の場合を除きます。(例: <code>range('5', '9', 0.5);</code>  のようなコードは、警告が発生しません)</member>
     <member><function>range</function> 関数は、境界の値の一方が数字の場合、もう片方の境界の値を整数にキャストせず、文字のリストを生成するようになりました。(例: <code>range('9', 'A');</code>).</member>
    </simplelist>
 
@@ -147,10 +147,10 @@ range('9', 'A');  // PHP 8.3.0 より前は、[9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
 
   <para>
     <function>number_format</function> は、負の
-    <parameter>$decimals</parameter> の値を小数点以下
-    <parameter>$num</parameter> 桁から <code>abs($decimals)</code>
+    <parameter>decimals</parameter> の値を小数点以下
+    <parameter>num</parameter> 桁から <code>abs($decimals)</code>
     桁に丸めるようになりました。
-    これより前のバージョンでは、負の <parameter>$decimals</parameter>
+    これより前のバージョンでは、負の <parameter>decimals</parameter>
     は黙って無視されていました。
   </para>
 

--- a/appendices/migration83/new-features.xml
+++ b/appendices/migration83/new-features.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: mumumu Status: ready -->
 <sect1 xml:id="migration83.new-features" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>新機能</title>
 
@@ -141,9 +141,9 @@ echo $user_ini['listen']; // localhost:9000
  <sect2 xml:id="migration83.new-features.posix">
   <title>POSIX</title>
 
-  <para>
-   <function>posix_getrlimit</function> で、リソースの制限値をひとつ取得できる、オプションの <parameter>$resource</parameter> パラメータが使えるようになりました。
-  </para>
+  <simpara>
+   <function>posix_getrlimit</function> で、リソースの制限値をひとつ取得できる、オプションの <parameter>resource</parameter> パラメータが使えるようになりました。
+  </simpara>
 
   <para>
    <function>posix_isatty</function> は、通常のパラメータ解釈のセマンティクス(ZPP) に従い、整数値に対して警告を発生させるようになりました。

--- a/appendices/migration83/other-changes.xml
+++ b/appendices/migration83/other-changes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: b1116af46680f7baf89c46610430a3b63ce9a1f0 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: mumumu Status: ready -->
 <sect1 xml:id="migration83.other-changes" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>その他の変更</title>
 
@@ -131,9 +131,9 @@
   <sect3 xml:id="migration83.other-changes.functions.gd">
    <title>Gd</title>
 
-   <para>
-    <function>imagerotate</function> 関数のシグネチャが変更され、<parameter>$ignore_transparent</parameter> パラメータが削除されました。このパラメータは PHP 5.5.0 以降、無視されていたためです。
-   </para>
+   <simpara>
+    <function>imagerotate</function> 関数のシグネチャが変更され、<parameter>ignore_transparent</parameter> パラメータが削除されました。このパラメータは PHP 5.5.0 以降、無視されていたためです。
+   </simpara>
   </sect3>
 
   <sect3 xml:id="migration83.other-changes.functions.intl">
@@ -183,13 +183,13 @@
   <sect3 xml:id="migration83.other-changes.functions.mysqli">
    <title>mysqli</title>
 
-   <para>
-    <function>mysqli_fetch_object</function> は、<parameter>$constructor_args</parameter> が空でないのに、クラスにコンストラクタが存在しない場合、 <classname>Exception</classname> ではなく <classname>ValueError</classname> を発生させるようになりました。
-   </para>
+   <simpara>
+    <function>mysqli_fetch_object</function> は、<parameter>constructor_args</parameter> が空でないのに、クラスにコンストラクタが存在しない場合、 <classname>Exception</classname> ではなく <classname>ValueError</classname> を発生させるようになりました。
+   </simpara>
 
-   <para>
-    <function>mysqli_poll</function> は、<parameter>$read</parameter> と <parameter>$error</parameter> が両方渡されない場合、<classname>ValueError</classname> を発生させるようになりました。
-   </para>
+   <simpara>
+    <function>mysqli_poll</function> は、<parameter>read</parameter> と <parameter>error</parameter> が両方渡されない場合、<classname>ValueError</classname> を発生させるようになりました。
+   </simpara>
 
    <para>
     <function>mysqli_field_seek</function> と <methodname>mysqli_result::field_seek</methodname> の戻り値の型が、<type>bool</type> ではなく <type>true</type> に変更されました。
@@ -199,17 +199,17 @@
   <sect3 xml:id="migration83.other-changes.functions.odbc">
    <title>ODBC</title>
 
-   <para>
-    <function>odbc_autocommit</function >は、<parameter>$enable</parameter> パラメータで &null; を受け入れるようになりました。&null; を渡すと、パラメータをひとつ渡した場合と同じ振る舞いをします。つまり、自動コミットが有効かどうかだけを示す動きをします。
-   </para>
+   <simpara>
+    <function>odbc_autocommit</function >は、<parameter>enable</parameter> パラメータで &null; を受け入れるようになりました。&null; を渡すと、パラメータをひとつ渡した場合と同じ振る舞いをします。つまり、自動コミットが有効かどうかだけを示す動きをします。
+   </simpara>
   </sect3>
 
   <sect3 xml:id="migration83.other-changes.functions.pgsql">
    <title>PostgreSQL</title>
 
-   <para>
-    <function>pg_fetch_object</function> は、<parameter>$constructor_args</parameter> が空でないのに、クラスにコンストラクタが存在しない場合、<classname>Exception</classname> ではなく <classname>ValueError</classname> を発生させるようになりました。
-   </para>
+   <simpara>
+    <function>pg_fetch_object</function> は、<parameter>constructor_args</parameter> が空でないのに、クラスにコンストラクタが存在しない場合、<classname>Exception</classname> ではなく <classname>ValueError</classname> を発生させるようになりました。
+   </simpara>
 
    <para>
     <function>pg_insert</function> は、指定されたテーブルが無効な場合に、<constant>E_WARNING</constant> ではなく <classname>ValueError</classname> を発生させるようになりました。
@@ -219,9 +219,9 @@
     <function>pg_insert</function> と <function>pg_convert</function> は、フィールドの値/タイプ が PostgreSQL の型と一致しない場合に、<constant>E_WARNING</constant> ではなく <classname>ValueError</classname> または <classname>TypeError</classname> を発生させるようになりました。
    </para>
 
-   <para>
-    <function>pg_fetch_result</function>, <function>pg_field_prtlen</function>, <function>pg_field_is_null</function> のパラメータ <parameter>$row</parameter> は、nullable になりました。
-   </para>
+   <simpara>
+    <function>pg_fetch_result</function>, <function>pg_field_prtlen</function>, <function>pg_field_is_null</function> のパラメータ <parameter>row</parameter> は、nullable になりました。
+   </simpara>
   </sect3>
 
   <sect3 xml:id="migration83.other-changes.functions.random">
@@ -262,30 +262,30 @@
     <function>strtok</function> は、トークンの分割を開始した際にトークンが与えられていない場合、<constant>E_WARNING</constant> を発生させるようになりました。
    </para>
 
-   <para>
-    <function>password_hash</function> は、ソルトの生成が失敗した場合に、<classname>ValueError</classname> の <parameter>$previous</parameter> (直前にスローされた例外) として、既に存在する <classname>Random\RandomException</classname> をチェインさせるようになりました。
-   </para>
+   <simpara>
+    <function>password_hash</function> は、ソルトの生成が失敗した場合に、<exceptionname>ValueError</exceptionname> の <parameter>previous</parameter> (直前にスローされた例外) として、既に存在する <exceptionname>Random\RandomException</exceptionname> をチェインさせるようになりました。
+   </simpara>
 
-   <para>
-    <function>proc_open</function> の <parameter>$command</parameter> に配列を指定する場合、空でない要素を少なくともひとつ含んでいることが必須になりました。そうでない場合、<classname>ValueError</classname> がスローされます。
-   </para>
+   <simpara>
+    <function>proc_open</function> の <parameter>command</parameter> に配列を指定する場合、空でない要素を少なくともひとつ含んでいることが必須になりました。そうでない場合、<classname>ValueError</classname> がスローされます。
+   </simpara>
 
-   <para>
-    <function>proc_open</function> の <parameter>$command</parameter> に配列を指定する場合、かつそれが不正なコマンドの場合に、後に警告が発生するリソースではなく &false; を返すようになりました。Windows では既にそのように動作していましたが、posix_spawn を使っている場合(ほとんどのプラットフォーム Linux, BSD, MacOS) でも同様の振る舞いをするようになりました。ただ、posix_spawn をサポートしていないために、以前の振る舞いが変更されていない古いプラットフォームもまだ残っています。
-   </para>
+   <simpara>
+    <function>proc_open</function> の <parameter>command</parameter> に配列を指定する場合、かつそれが不正なコマンドの場合に、後に警告が発生するリソースではなく &false; を返すようになりました。Windows では既にそのように動作していましたが、posix_spawn を使っている場合(ほとんどのプラットフォーム Linux, BSD, MacOS) でも同様の振る舞いをするようになりました。ただ、posix_spawn をサポートしていないために、以前の振る舞いが変更されていない古いプラットフォームもまだ残っています。
+   </simpara>
 
    <para>
     <function>array_sum</function> と <function>array_product</function> は、配列に含まれる値が int/float に変換できない場合、警告を発生させるようになりました。これより前のバージョンでは、配列とオブジェクトは無視され、それら以外の値は int にキャストされていました。さらに、数値へのキャストを定義しているオブジェクト (例: <link linkend="book.gmp">GMP</link>) は、無視されるのではなく、数値に変換されるようになっています。
     <!-- RFC: https://wiki.php.net/rfc/saner-array-sum-product -->
    </para>
 
-   <para>
-    <function>number_format</function> の <parameter>$decimals</parameter> パラメータは、負の整数値の四捨五入も扱うようになりました。つまり、<parameter>$decimals</parameter> が負の値の場合、<parameter>$num</parameter> は 小数点前の有効桁数 <parameter>$decimals</parameter> 桁に丸められます。これより前のバージョンでは、負の <parameter>$decimals</parameter> を指定しても、黙って無視され、数値は小数点以下が0桁になるように丸められていました。
-   </para>
+   <simpara>
+    <function>number_format</function> の <parameter>decimals</parameter> パラメータは、負の整数値の四捨五入も扱うようになりました。つまり、<parameter>decimals</parameter> が負の値の場合、<parameter>num</parameter> は 小数点前の有効桁数 <parameter>decimals</parameter> 桁に丸められます。これより前のバージョンでは、負の <parameter>decimals</parameter> を指定しても、黙って無視され、数値は小数点以下が0桁になるように丸められていました。
+   </simpara>
 
-   <para>
-    <function>strrchr</function> に <parameter>$before_needle</parameter> が追加されました。これは <function>strstr</function> や <function>stristr</function> の対応するパラメータと、似た振る舞いをします。
-   </para>
+   <simpara>
+    <function>strrchr</function> に <parameter>before_needle</parameter> が追加されました。これは <function>strstr</function> や <function>stristr</function> の対応するパラメータと、似た振る舞いをします。
+   </simpara>
 
    <para>
     <function>str_getcsv</function> と <function>fgetcsv</function> は、最後のフィールドに終端されていないクォートだけが含まれている場合、null バイトの文字列をひとつ返すのではなく、空文字列を返すようになりました。

--- a/appendices/migration85/deprecated.xml
+++ b/appendices/migration85/deprecated.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 2def8c3cfec11fcc74f153b337301bbc06c16bc9 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 7385bb692296b40e9ac697ebc2f301de316768a0 Maintainer: mumumu Status: ready -->
 <sect1 xml:id="migration85.deprecated">
  <title>PHP 8.5.x で推奨されなくなる機能</title>
 
@@ -223,7 +223,7 @@
   </simpara>
 
   <simpara>
-   <function>finfo_buffer</function> 関数の <parameter>$context</parameter>
+   <function>finfo_buffer</function> 関数の <parameter>context</parameter>
    パラメータは、推奨されなくなりました。
    このパラメータは無視されているためです。
    <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_context_parameter_for_finfo_buffer -->
@@ -311,7 +311,7 @@
   <title>OpenSSL</title>
 
   <simpara>
-   <function>openssl_pkey_derive</function> の <parameter>$key_length</parameter>
+   <function>openssl_pkey_derive</function> の <parameter>key_length</parameter>
    パラメータは、推奨されなくなりました。
    このパラメータは無視されているか、キーを切り捨てるかしており、
    それらの挙動がセキュリティ上の脆弱性になりうるためです。
@@ -370,7 +370,7 @@
     <member><constant>PDO::ODBC_SQL_USE_ODBC</constant> => <constant>Pdo\Odbc::SQL_USE_ODBC</constant></member>
     <member><constant>PDO::PGSQL_ATTR_DISABLE_PREPARES</constant> => <constant>Pdo\Pgsql::ATTR_DISABLE_PREPARES</constant></member>
     <member><constant>PDO::SQLITE_ATTR_EXTENDED_RESULT_CODES</constant> => <constant>Pdo\Sqlite::ATTR_EXTENDED_RESULT_CODES</constant></member>
-    <member><constant>PDO::SQLITE_ATTR_OPEN_FLAGS</constant> => <constant>Pdo\Sqlite::OPEN_FLAGS</constant></member>
+    <member><constant>PDO::SQLITE_ATTR_OPEN_FLAGS</constant> => <constant>Pdo\Sqlite::ATTR_OPEN_FLAGS</constant></member>
     <member><constant>PDO::SQLITE_ATTR_READONLY_STATEMENT</constant> => <constant>Pdo\Sqlite::ATTR_READONLY_STATEMENT</constant></member>
     <member><constant>PDO::SQLITE_DETERMINISTIC</constant> => <constant>Pdo\Sqlite::DETERMINISTIC</constant></member>
     <member><constant>PDO::SQLITE_OPEN_READONLY</constant> => <constant>Pdo\Sqlite::OPEN_READONLY</constant></member>

--- a/appendices/migration85/incompatible.xml
+++ b/appendices/migration85/incompatible.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: f81bbcf9d36c28bf067b5514cffdbc7663357cf3 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 570cdc0ceb6db0452b080c97bb5990b2a11dfbc3 Maintainer: mumumu Status: ready -->
 <sect1 xml:id="migration85.incompatible" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>下位互換性のない変更点</title>
 
@@ -175,13 +175,13 @@
   <title>Bzip2</title>
 
   <simpara>
-   <parameter>$block_size</parameter> に 1 から 9 の間以外の値を指定した場合、
+   <parameter>block_size</parameter> に 1 から 9 の間以外の値を指定した場合、
    <function>bzcompress</function> は <classname>ValueError</classname>
    をスローするようになりました。
   </simpara>
 
   <simpara>
-   <parameter>$work_factor</parameter> に 0 から 250 の間以外の値を指定した場合、
+   <parameter>work_factor</parameter> に 0 から 250 の間以外の値を指定した場合、
    <function>bzcompress</function> は <classname>ValueError</classname>
    をスローするようになりました。
   </simpara>
@@ -209,7 +209,7 @@
   <title>FileInfo</title>
 
   <simpara>
-   <parameter>$filename</parameter> に nul バイトが含まれている場合、
+   <parameter>filename</parameter> に nul バイトが含まれている場合、
    <function>finfo_file</function> と
    <methodname>finfo::file</methodname> は、
    <exceptionname>TypeError</exceptionname> ではなく
@@ -332,14 +332,14 @@
 
   <simpara>
    <function>pcntl_exec</function> の
-   <parameter>$args</parameter> パラメータのエントリに、
+   <parameter>args</parameter> パラメータのエントリに、
    null バイトが含まれていた場合、
    <exceptionname>ValueError</exceptionname> がスローされるようになりました。
   </simpara>
 
   <simpara>
    <function>pcntl_exec</function> の
-   <parameter>$env_vars</parameter> パラメータのエントリまたはキーに、
+   <parameter>env_vars</parameter> パラメータのエントリまたはキーに、
    null バイトが含まれていた場合、
    <exceptionname>ValueError</exceptionname> がスローされるようになりました。
   </simpara>
@@ -500,13 +500,6 @@
    <exceptionname>TypeError</exceptionname> がスローされるようになりました。
   </simpara>
 
-  <simpara>
-   <function>setlocale</function> の
-   <parameter>locales</parameter> 引数に整数 <literal>0</literal>
-   を渡すことはサポートされなくなり、
-   <exceptionname>TypeError</exceptionname> がスローされるようになりました。
-  </simpara>
-
  </sect2>
 
  <sect2 xml:id="migration85.incompatible.simplexml">
@@ -547,7 +540,7 @@
 
   <simpara>
    <methodname>SoapClient::__doRequest</methodname> に、
-   オプションの <parameter>$uriParserClass</parameter>
+   オプションの <parameter>uriParserClass</parameter>
    パラメータが新しく追加されました。
    これは、文字列と &null; を受け入れます。
    &null; を渡すと、オリジナルの <function>parse_url</function>
@@ -608,7 +601,7 @@
 
   <simpara>
    <methodname>SplFileObject::fwrite</methodname> の
-   <parameter>$length</parameter> パラメータは、nullable になりました。
+   <parameter>length</parameter> パラメータは、nullable になりました。
    デフォルト値が <literal>0</literal> から &null; に変更されています。
   </simpara>
 
@@ -621,6 +614,13 @@
    printf ファミリの関数に精度を指定しないフォーマットを使った場合、
    精度を 0 として扱うようになりました。
    これより前のバージョンでは、誤って精度をリセットしていました。
+  </simpara>
+
+  <simpara>
+   <function>setlocale</function> の
+   <parameter>locales</parameter> 引数に整数 <literal>0</literal>
+   を渡すことはサポートされなくなり、
+   <exceptionname>TypeError</exceptionname> がスローされるようになりました。
   </simpara>
 
  </sect2>

--- a/appendices/migration85/new-features.xml
+++ b/appendices/migration85/new-features.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ce397343296708654c8cdac774e23a9ee47ab27d Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: mumumu Status: ready -->
 <sect1 xml:id="migration85.new-features" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>新機能</title>
 
@@ -439,7 +439,7 @@ print T1 . PHP_EOL;   // Prints "0"
    上記のサポートによって、
    <methodname>SoapFault::__construct</methodname> と
    <methodname>SoapServer::fault</methodname> のシグネチャに、
-   オプションの <parameter>$lang</parameter> パラメータが追加されました。
+   オプションの <parameter>lang</parameter> パラメータが追加されました。
    これによって、.NET SOAP クライアントとの互換性問題が解決します。
   </simpara>
 
@@ -504,9 +504,9 @@ print T1 . PHP_EOL;   // Prints "0"
    <methodname>XSLTProcessor::getParameter</methodname>,
    <methodname>XSLTProcessor::setParameter</methodname>,
    <methodname>XSLTProcessor::removeParameter</methodname> の
-   <parameter>$namespace</parameter> 引数は、
+   <parameter>namespace</parameter> 引数は、
    空でなくても動作するようになりました。
-   動作するのは、<parameter>$name</parameter> 引数が Clark 記法でなく、かつ
+   動作するのは、<parameter>name</parameter> 引数が Clark 記法でなく、かつ
    QName 形式でもない場合です。
    これらの場合は、名前空間が href または prefix からそれぞれ取得されるためです。
   </simpara>

--- a/appendices/migration85/other-changes.xml
+++ b/appendices/migration85/other-changes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c7b445ec851969e669026cfa483b104ea2de5d95 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 750153283926d760d97dfe59a19d7c13c602625a Maintainer: mumumu Status: ready -->
 <sect1 xml:id="migration85.other-changes">
  <title>その他の変更</title>
 
@@ -99,7 +99,7 @@
 
    <simpara>
     <function>grapheme_extract</function> は、
-    無効な開始バイトをスキップする際に <parameter>$next</parameter>
+    無効な開始バイトをスキップする際に <parameter>next</parameter>
     の値を適切に割り当てるようになりました。
     これより前のバージョンでは、grapheme 境界の終端ではなく、
     先頭を指すケースがありました。
@@ -115,7 +115,7 @@
    </simpara>
 
    <simpara>
-    以下の関数は、<parameter>$locale</parameter> 引数をサポートしました:
+    以下の関数は、<parameter>locale</parameter> 引数をサポートしました:
     <function>grapheme_strpos</function>,
     <function>grapheme_stripos</function>,
     <function>grapheme_strrpos</function>,
@@ -157,7 +157,7 @@
     <function>openssl_public_encrypt</function> と
     <function>openssl_private_decrypt</function> は、
     OAEP パディング向けのハッシュダイジェストアルゴリズムを指定するために、
-    新しく <parameter>$digest_algo</parameter>
+    新しく <parameter>digest_algo</parameter>
     パラメータを設定できるようになりました。
    </simpara>
 
@@ -165,12 +165,12 @@
     <function>openssl_sign</function> と
     <function>openssl_verify</function> は、
     よりセキュアな RSA PSS パディングを使えるようにするために、
-    新しく <parameter>$padding</parameter>
+    新しく <parameter>padding</parameter>
     パラメータを設定できるようになりました。
    </simpara>
 
    <simpara>
-    <function>openssl_cms_encrypt</function> の <parameter>$cipher_algo</parameter>
+    <function>openssl_cms_encrypt</function> の <parameter>cipher_algo</parameter>
     パラメータに、暗号名を示す文字列を指定できるようになりました。
     これによって、認証付きのエンベロープデータ向けに、
     AES GCM 暗号アルゴリズムを含むより多くのアルゴリズムを使えるようになります。
@@ -303,7 +303,7 @@
    <simpara>
     <function>gzfile</function>, <function>gzopen</function>,
     <function>readgzfile</function> 関数の
-    <parameter>$use_include_path</parameter> 引数の型が、
+    <parameter>use_include_path</parameter> 引数の型が、
     <type>int</type> から <type>bool</type> に変更されました。
    </simpara>
 
@@ -371,19 +371,6 @@
     <link linkend="book.dom">ext/dom</link>
     から分離された lexbor ライブラリが含まれています。
     この新しい拡張モジュールは、ユーザーランドに直接公開されません。
-   </simpara>
-
-  </sect3>
-
-  <sect3 xml:id="migration85.other-changes.extensions.opcache">
-   <title>Opcache</title>
-
-   <simpara>
-    <link linkend="book.opcache">Opcache 拡張モジュール</link> は、
-    常に PHP バイナリに組み込まれ、ロードされるようになりました。
-    <link linkend="ini.opcache.enable">opcache.enable</link> と
-    <link linkend="ini.opcache.enable-cli">opcache.enable_cli</link>
-    の設定はまだ有効です。
    </simpara>
 
   </sect3>

--- a/appendices/migration85/windows-support.xml
+++ b/appendices/migration85/windows-support.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ec45af749649dc0d6a23eaedeed1b601f7460813 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: mumumu Status: ready -->
 <sect1 xml:id="migration85.windows-support">
  <title>Windows のサポート</title>
 
@@ -69,9 +69,9 @@
   <title>Streams</title>
 
   <simpara>
-   パイプストリームが <parameter>$read</parameter>
-   配列のみに存在し、かつ <parameter>$write</parameter> と
-   <parameter>$except</parameter> 配列が空の場合、
+   パイプストリームが <parameter>read</parameter>
+   配列のみに存在し、かつ <parameter>write</parameter> と
+   <parameter>except</parameter> 配列が空の場合、
    <function>stream_select</function> は、
    POSIX システムと似た振る舞いをするようになりました。
    つまり、少なくとも1つのパイプが読み取り可能になった場合、

--- a/reference/com/functions/variant-cat.xml
+++ b/reference/com/functions/variant-cat.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 31ab1b9a07ee6fdfd09cafaf22efa1cf78b49798 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="function.variant-cat" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -18,11 +18,11 @@
    <parameter>left</parameter> と
    <parameter>right</parameter> を連結し、その結果を返します。
   </para>
-  <para>
+  <simpara>
    この関数は、理論上は
-   <parameter>$left</parameter> <literal>.</literal> <parameter>$right</parameter>
+   <parameter>left</parameter> <literal>.</literal> <parameter>right</parameter>
    と等価です。
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;

--- a/reference/datetime/datetime/construct.xml
+++ b/reference/datetime/datetime/construct.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 8b4c3d8dc5e190fbd5d84eede38a4da13537043d Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 
 <refentry xml:id="datetime.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -33,31 +33,31 @@
     <term><parameter>datetime</parameter></term>
     <listitem>
      <para>&date.formats.parameter;</para>
-     <para>
+     <simpara>
       ここに <literal>"now"</literal> を指定して
-      <parameter>$timezone</parameter> パラメータを使うと、現在時刻を取得できます。
-     </para>
+      <parameter>timezone</parameter> パラメータを使うと、現在時刻を取得できます。
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>timezone</parameter></term>
     <listitem>
-     <para>
-      <parameter>$datetime</parameter> のタイムゾーンを表す
+     <simpara>
+      <parameter>datetime</parameter> のタイムゾーンを表す
       <classname>DateTimeZone</classname> オブジェクト。
-     </para>
-     <para>
-      <parameter>$timezone</parameter> を省略した場合、または &null; の場合、
+     </simpara>
+     <simpara>
+      <parameter>timezone</parameter> を省略した場合、または &null; の場合、
       現在のタイムゾーンを使います。
-     </para>
+     </simpara>
      <note>
-      <para>
-       <parameter>$datetime</parameter> パラメータが UNIX タイムスタンプ
+      <simpara>
+       <parameter>datetime</parameter> パラメータが UNIX タイムスタンプ
        (<literal>@946684800</literal> など)
        であったりタイムゾーンつきで指定した場合
        (<literal>2010-01-28T15:00:00+02:00</literal> など) は、
-       <parameter>$timezone</parameter> パラメータや現在のタイムゾーンは無視されます。
-      </para>
+       <parameter>timezone</parameter> パラメータや現在のタイムゾーンは無視されます。
+      </simpara>
      </note>
     </listitem>
    </varlistentry>

--- a/reference/datetime/datetimeimmutable/construct.xml
+++ b/reference/datetime/datetimeimmutable/construct.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 
 <refentry xml:id="datetimeimmutable.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -36,33 +36,33 @@
     <term><parameter>datetime</parameter></term>
     <listitem>
      <para>&date.formats.parameter;</para>
-     <para>
+     <simpara>
       ここに <literal>"now"</literal> を指定して
-      <parameter>$timezone</parameter> パラメータを使うと、現在時刻を取得できます。
-     </para>
+      <parameter>timezone</parameter> パラメータを使うと、現在時刻を取得できます。
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>timezone</parameter></term>
     <listitem>
-     <para>
-      <parameter>$datetime</parameter> のタイムゾーンを表す
+     <simpara>
+      <parameter>datetime</parameter> のタイムゾーンを表す
       <classname>DateTimeZone</classname> オブジェクト。
-     </para>
-     <para>
-      <parameter>$timezone</parameter> を省略した場合、
+     </simpara>
+     <simpara>
+      <parameter>timezone</parameter> を省略した場合、
       または &null; の場合、
       現在のタイムゾーンを使います。
-     </para>
+     </simpara>
      <note>
-      <para>
-       <parameter>$datetime</parameter> パラメータが UNIX タイムスタンプ
+      <simpara>
+       <parameter>datetime</parameter> パラメータが UNIX タイムスタンプ
        (<literal>@946684800</literal> など)
        であったりタイムゾーン付きで指定した場合
        (<literal>2010-01-28T15:00:00+02:00</literal> や
        <literal>2010-07-05T06:00:00Z</literal> など) は、
-       <parameter>$timezone</parameter> パラメータや現在のタイムゾーンは無視されます。
-      </para>
+       <parameter>timezone</parameter> パラメータや現在のタイムゾーンは無視されます。
+      </simpara>
      </note>
     </listitem>
    </varlistentry>

--- a/reference/pcre/functions/preg-match-all.xml
+++ b/reference/pcre/functions/preg-match-all.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: b731f708be0b9f5c656b81eb6491d04b0d5b19d8 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: hirokawa Status: ready -->
 <!-- Credits: haruki,mumumu -->
 <refentry xml:id="function.preg-match-all" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -310,7 +310,7 @@ Array
       <row>
        <entry>7.2.0</entry>
        <entry>
-        <parameter>$flags</parameter> パラメータが
+        <parameter>flags</parameter> パラメータが
         <constant>PREG_UNMATCHED_AS_NULL</constant> をサポートしました。
        </entry>
       </row>

--- a/reference/pcre/functions/preg-match.xml
+++ b/reference/pcre/functions/preg-match.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d6f54016d62904cfd8200604aadd5e3f0d9bad97 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: hirokawa Status: ready -->
 <!-- Credits: haruki,mumumu -->
 <refentry xml:id="function.preg-match" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -277,7 +277,7 @@ Array
       <row>
        <entry>7.2.0</entry>
        <entry>
-        <parameter>$flags</parameter> パラメータが
+        <parameter>flags</parameter> パラメータが
         <constant>PREG_UNMATCHED_AS_NULL</constant> をサポートしました。
        </entry>
       </row>

--- a/reference/session/examples.xml
+++ b/reference/session/examples.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 184f3f7bd45643cb80f828d0bb001991ec3a5fad Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: takagi Status: ready -->
 <!-- CREDITS: shimooka,hirokawa -->
 
 <appendix xml:id="session.examples" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -245,12 +245,12 @@ if (empty($_SESSION['count'])) {
    セッションが明確に破棄されたときには、PHP は
    <parameter>destroy</parameter> ハンドラをセッション ID つきでコールします。
   </para>
- <para>
+ <simpara>
    PHP はときどき <parameter>gc</parameter> コールバックを実行し、
    設定されているセッション有効期限にもとづいて期限切れのセッションレコードを無効化します。
-   この処理では、最後にアクセスされてからの時間が <parameter>$lifetime</parameter>
+   この処理では、最後にアクセスされてからの時間が <parameter>lifetime</parameter>
    を超えているすべてのレコードを永続ストレージから削除しなければなりません。
- </para>
+ </simpara>
  </section>
 </appendix>
 

--- a/reference/session/functions/session-decode.xml
+++ b/reference/session/functions/session-decode.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 584c3e8805b728ec0cfde0318bb34e00ebc36324 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: hirokawa Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.session-decode">
  <refnamediv>
   <refname>session_decode</refname>
@@ -13,11 +13,11 @@
    <type>bool</type><methodname>session_decode</methodname>
    <methodparam><type>string</type><parameter>data</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    <function>session_decode</function> は、
-   <parameter>$data</parameter> のセッションデータをデコードし、
+   <parameter>data</parameter> のセッションデータをデコードし、
    スーパーグローバル $_SESSION にその結果を格納します。
-  </para>
+  </simpara>
   <para>
    デフォルトのアンシリアライズの方法は PHP が内部的に実装しているものであり、
    <function>unserialize</function> とは違います。

--- a/reference/session/sessionhandler/destroy.xml
+++ b/reference/session/sessionhandler/destroy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 601f6f4ce5827d441a7e110184708f0abe9fd447 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 
 <refentry xml:id="sessionhandler.destroy" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -15,11 +15,11 @@
    <modifier>public</modifier> <type>bool</type><methodname>SessionHandler::destroy</methodname>
    <methodparam><type>string</type><parameter>id</parameter></methodparam>
   </methodsynopsis>
-  <para>
-   セッションを破棄します。<function>session_regenerate_id</function> (<parameter>$destory</parameter> を &true; にしたとき) や
+  <simpara>
+   セッションを破棄します。<function>session_regenerate_id</function> (<parameter>destroy</parameter> を &true; にしたとき) や
    <function>session_destroy</function> からコールされ、<function>session_decode</function>
    が失敗したときにもコールされます。
-  </para>
+  </simpara>
   <para>
    このメソッドは、このハンドラが <function>session_set_save_handler</function>
    で設定される前に ini 設定

--- a/reference/session/sessionhandler/read.xml
+++ b/reference/session/sessionhandler/read.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 601f6f4ce5827d441a7e110184708f0abe9fd447 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 
 <refentry xml:id="sessionhandler.read" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -26,13 +26,13 @@
    <link linkend="ini.session.save-handler">session.save_handler</link>
    で定義されていた PHP の保存ハンドラをラップします。
   </para>
-  <para>
+  <simpara>
    このクラスを継承して拡張する場合は、親の <parameter>read</parameter>
    メソッドをコールすればこのメソッドのラッパーを実行でき、それに付随する内部コールバックも実行されます。
    こうすれば、メソッドをオーバーライドしたり処理を横取りしてフィルタを追加したり
-   (親の <parameter>read</parameter> メソッドが返す <parameter>$data</parameter> を復号したりなど)
+   (親の <parameter>read</parameter> メソッドが返す <parameter>data</parameter> を復号したりなど)
    できます。
-  </para>
+  </simpara>
   <para>
    このメソッドに関する詳細は、
    <function>SessionHandlerInterface::read</function>

--- a/reference/session/sessionhandler/write.xml
+++ b/reference/session/sessionhandler/write.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 601f6f4ce5827d441a7e110184708f0abe9fd447 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 
 <refentry xml:id="sessionhandler.write" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -28,13 +28,13 @@
    <link linkend="ini.session.save-handler">session.save_handler</link>
    で定義されていた PHP の保存ハンドラをラップします。
   </para>
-  <para>
+  <simpara>
    このクラスを継承して拡張する場合は、親の <parameter>write</parameter>
    メソッドをコールすればこのメソッドのラッパーを実行でき、それに付随する内部コールバックも実行されます。
    こうすれば、メソッドをオーバーライドしたり処理を横取りしてフィルタを追加したり
-   (親の <parameter>write</parameter> メソッドに送る前に <parameter>$data</parameter> を暗号化したりなど)
+   (親の <parameter>write</parameter> メソッドに送る前に <parameter>data</parameter> を暗号化したりなど)
    できます。
-  </para>
+  </simpara>
   <para>
    このメソッドに関する詳細は、
    <function>SessionHandlerInterface::write</function>

--- a/reference/stream/constants.xml
+++ b/reference/stream/constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 561e36d646b8e48dc53a910234ee9f30cba147d0 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi,mumumu -->
 
 <appendix xml:id="stream.constants" xmlns="http://docbook.org/ns/docbook">
@@ -1212,7 +1212,7 @@
     <listitem>
      <simpara>
       ユーザー空間のフィルタが
-      バケットを <parameter>$out</parameter> に返したことを
+      バケットを <parameter>out</parameter> に返したことを
       示します。
      </simpara>
     </listitem>
@@ -1225,7 +1225,7 @@
     <listitem>
      <simpara>
       ユーザー空間のフィルタが
-      <parameter>$out</parameter> にバケットを返さなかったことを
+      <parameter>out</parameter> にバケットを返さなかったことを
       示します。(つまり、変換されたデータを返す用意ができていないという
       ことです。)
      </simpara>


### PR DESCRIPTION
## 翻訳内容

doc-en のマークアップ規約変更「Remove $ sigil from &lt;parameter&gt; names」への追従を中心とした同期です。いずれも訳文の散文には変更がありません。

### `<parameter>` の $ 記号除去・para→simpara 等のマークアップミラー（20件） — php/doc-en@4de6272a1f

- appendices/migration83/* (4): other-changes, incompatible, deprecated, new-features
- appendices/migration85/* (5): incompatible, new-features, windows-support, other-changes, deprecated
- reference/datetime/* (2): datetime/construct, datetimeimmutable/construct
- reference/pcre/* (2): preg-match, preg-match-all
- reference/session/* (5): examples, functions/session-decode, sessionhandler/{destroy,read,write}
- reference/stream/constants.xml, reference/com/functions/variant-cat.xml

$this とコード例内の変数は原文どおり保持しています。reference/session/sessionhandler/destroy.xml では、旧訳のパラメータ名タイポ（destory）も原文の表記（destroy）に合わせて解消しています。

### migration85 の実コンテンツ追従（3件）

- appendices/migration85/incompatible.xml — setlocale の項目を Session から Standard セクションへ移動 — php/doc-en@570cdc0ceb
- appendices/migration85/other-changes.xml — Opcache の重複セクションを削除（incompatible.xml への集約） — php/doc-en@7501532839
- appendices/migration85/deprecated.xml — 定数名の誤りを修正（Pdo\Sqlite::OPEN_FLAGS → Pdo\Sqlite::ATTR_OPEN_FLAGS） — php/doc-en@7385bb6922
