### PR TITLE
language/operators: 単項演算子と instanceof の優先順位、前置演算子内の代入の結合に関する注記を同期

### DIFF
--- a/language/operators/precedence.xml
+++ b/language/operators/precedence.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: a7428462fea1c0387cf5e8473b4c48c3c8ac8c2c Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 80dfa568e602649eb13585bf59a7b6239eddaac3 Maintainer: mumumu Status: ready -->
 <sect1 xml:id="language.operators.precedence">
  <title>演算子の優先順位</title>
  <titleabbrev>演算子の優先順位</titleabbrev>
@@ -305,6 +305,19 @@
    </tgroup>
   </table>
  </para>
+ <note>
+  <simpara>
+   キャスト演算子と同じ行にある単項演算子
+   (<literal>~</literal>、<literal>@</literal>、および単項演算の
+   <literal>+</literal>/<literal>-</literal>) は
+   <literal>instanceof</literal> よりも強く結合しますが、
+   <literal>!</literal> は <literal>instanceof</literal> よりも弱く結合します。
+   そのため <literal>(int) $x instanceof Foo</literal> は
+   <literal>((int) $x) instanceof Foo</literal> とグループ分けされ、
+   <literal>!$x instanceof Foo</literal> は
+   <literal>!($x instanceof Foo)</literal> とグループ分けされます。
+  </simpara>
+ </note>
  <para>
   <example>
    <title>結合時の評価</title>
@@ -421,6 +434,16 @@ x minus one equals 3, or so I hope
    のような式も許します。この場合は <literal>foo()</literal> の戻り値が
    <varname>$a</varname> に代入されます。
   </para>
+  <simpara>
+   これが可能なのは、代入の左辺は変数でなければならず、
+   そのため代入は、周囲にある優先順位の高い前置演算子ではなく、その変数とグループ分けされるからです。
+   同じことが、式をオペランドに取る他の前置演算子、
+   たとえば <literal>clone</literal>、キャスト演算子、<literal>@</literal>、
+   <literal>~</literal> にも当てはまります。
+   たとえば <literal>clone $a = $b</literal> は
+   <literal>(clone $a) = $b</literal> ではなく
+   <literal>clone ($a = $b)</literal> とグループ分けされます。
+  </simpara>
  </note>
  <sect2 role="changelog">
   &reftitle.changelog;


### PR DESCRIPTION
## 概要

php/doc-en@80dfa568 (doc: clarify unary-vs-instanceof precedence and assignment
binding inside prefix operators) に追従し、演算子の優先順位に関する注記を2つ追加しました。

## 翻訳内容

- language/operators/precedence.xml — 単項演算子と instanceof の優先順位、前置演算子内での代入の結合を明確化
  1. php/doc-en@80dfa568

追加した注記:

- 演算子表の直後 — キャスト演算子と同じ行にある単項演算子 (`~`、`@`、単項の `+`/`-`) は
  `instanceof` よりも強く結合するが、`!` は弱く結合する。したがって
  `(int) $x instanceof Foo` は `((int) $x) instanceof Foo` に、
  `!$x instanceof Foo` は `!($x instanceof Foo)` にグループ分けされる
- `if (!$a = foo())` の注記内 — 代入の左辺は変数でなければならないため、代入は周囲にある
  優先順位の高い前置演算子ではなくその変数とグループ分けされる。`clone`、キャスト演算子、
  `@`、`~` も同様で、`clone $a = $b` は `clone ($a = $b)` にグループ分けされる

原文の差分は追加のみのため、既存の訳文は変更していません。
