### PR TITLE
ci: add per-PR EN-Revision hash check

### DIFF
--- a/.github/workflows/check-en-revision.yml
+++ b/.github/workflows/check-en-revision.yml
@@ -1,0 +1,47 @@
+# https://docs.github.com/en/actions
+# Checks that the EN-Revision comment of the .xml files changed in a PR points to
+# the latest doc-en commit for that file. Emits a ::error annotation and fails if
+# the hash is missing, wrong, from another file, or outdated.
+
+name: "Structure"
+
+on:
+  pull_request:
+    branches: ["master"]
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  revision:
+    name: "Check EN-Revision"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout translation"
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: "Checkout php/doc-en"
+        uses: actions/checkout@v4
+        with:
+          path: en
+          repository: php/doc-en
+          fetch-depth: 0
+
+      - name: "Check EN-Revision"
+        run: |
+          BASE="${{ github.event.pull_request.base.sha }}"
+          git fetch --no-tags --depth=1 origin "$BASE"
+          fail=0
+          while IFS= read -r f; do
+            [ -f "$f" ] && [ -f "en/$f" ] || continue
+            declared=$(grep -oiP 'EN-Revision:\s*\K[0-9a-f]+' "$f" | head -1 || true)
+            latest=$(git -C en log -1 --format=%H -- "$f")
+            if [ "$declared" != "$latest" ]; then
+              echo "::error file=$f::EN-Revision ${declared:-missing} != latest doc-en commit $latest"
+              fail=1
+            fi
+          done < <(git diff --name-only "$BASE"...HEAD -- '*.xml')
+          exit $fail


### PR DESCRIPTION
Adds a GitHub Actions workflow that runs on every pull request and verifies that the `EN-Revision` header in modified XML files points to the latest `doc-en` commit for that file.

## How it works

- Triggered on `pull_request` events targeting `master`
- Collects the list of `.xml` files changed in the PR
- For each file that also exists in `doc-en`, reads the declared `EN-Revision` hash
- Compares it against `git log -1` on the matching `doc-en` file
- Emits a `::error` annotation and fails if the hash is missing or outdated

This ensures that translation updates always reference the exact upstream commit they are based on, making future sync work easier to track.

## Prior art

This check is already in use in `doc-fr`, `doc-ru`, and `doc-es`. There is also an ongoing initiative in `doc-base` to provide reusable workflows that all `doc-*` repos can share.