### PR TITLE
doc-en と同期し 10 モジュールを完訳（既訳更新 31 件・新規翻訳 5 件）

### DIFF
--- a/appendices/migration84/constants.xml
+++ b/appendices/migration84/constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 8a6397d39aefd23c61d64aa4e9af919772541e2a Maintainer: KentarouTakeda Status: ready -->
+<!-- EN-Revision: d0ac0a55fc0606f0c0c2f0b277d7d38699cc025a Maintainer: KentarouTakeda Status: ready -->
 <!-- Credits: KentarouTakeda -->
 <sect1 xml:id="migration84.constants">
  <title>新しいグローバル定数</title>
@@ -29,7 +29,7 @@
     <constant>CURL_HTTP_VERSION_3ONLY</constant>
    </member>
    <member>
-    <constant>CURL_TCP_KEEPCNT</constant>
+    <constant>CURLOPT_TCP_KEEPCNT</constant>
    </member>
    <member>
     <constant>CURLOPT_PREREQFUNCTION</constant>

--- a/appendices/migration85/new-classes.xml
+++ b/appendices/migration85/new-classes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ec45af749649dc0d6a23eaedeed1b601f7460813 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: e1b9f588815a51682acf68f9b8929f49ad612488 Maintainer: mumumu Status: ready -->
 <sect1 xml:id="migration85.new-classes" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>新しいクラスとインターフェイス</title>
 
@@ -29,6 +29,13 @@
    <member><classname>Filter\FilterFailedException</classname></member>
   </simplelist>
   <!-- RFC: https://wiki.php.net/rfc/filter_throw_on_failure -->
+ </sect2>
+
+ <sect2 xml:id="migration85.new-classes.intl">
+  <title>Intl</title>
+  <simplelist>
+   <member><classname>IntlListFormatter</classname></member>
+  </simplelist>
  </sect2>
 
  <sect2 xml:id="migration85.new-classes.uri">

--- a/chapters/intro.xml
+++ b/chapters/intro.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 77f5f3b3a8bbe1ad7727201c7603d1419dd7840f Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 0bae88c19601e7f67ae6a22a8f9aa44cb9342cc1 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: shimooka,takagi -->
  <chapter xml:id="introduction" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <info>
@@ -147,16 +147,12 @@
     <link linkend="book.curl">cURL</link> あるいは <link linkend="book.sockets">ソケット</link>
     を使う CouchDB のような例もあります。
    </para>
-   <para>
+   <simpara>
     PHP は、IMAP、SNMP、NNTP、POP3、HTTP、COM (Windowsのみ) やその他
     数え切れない程多くのプロトコルを用いる他のサービスの状態を追跡する
     機能もサポートしています。低レベルのネットワークソケットをオープンし、
-    他のプロトコルを用いて通信を行うことも可能です。また、PHPはWDDXを
-    サポートし、基本的に全てのウェブプログラミング言語間で複雑なデータ交換
-    を行うことができます。相互接続機能としては、他にJavaオブジェクトの
-    インスタンスを作成してそれをPHPのオブジェクトとして透過的にアクセス
-    する機能があります。
-   </para>
+    他のプロトコルを用いて通信を行うことも可能です。
+   </simpara>
    <para>
     PHP には便利な <link linkend="refs.basic.text">テキスト処理</link> 機能が用意されています。
     Perl 互換の正規表現 (<link linkend="book.pcre">PCRE</link>) や、

--- a/features/commandline.xml
+++ b/features/commandline.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: b08b472de7041be8dbae153556b714efa93f20c0 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 07b2f1dcff1d8beb846f5671e5f4bf2ab8d33ebf Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa,shimooka,mumumu -->
 <chapter xml:id="features.commandline" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>PHP をコマンドラインから使用する</title>
  <titleabbrev>コマンドラインの使用法</titleabbrev>
  
- <!--Introduction: {{{-->
  <section xml:id="features.commandline.introduction" annotations="chunk:false">
   <title>はじめに</title>
   
@@ -86,9 +85,7 @@
    </para>
   </note>
  </section>
- <!--}}}-->
- 
- <!--Differences: {{{-->
+
  <section xml:id="features.commandline.differences">
   <title>他の <acronym>SAPI</acronym> との違い</title>
   
@@ -323,9 +320,7 @@ $ php -f another_directory/test.php
    </itemizedlist>
   </para>
  </section>
- <!--}}}-->
- 
- <!--Options: {{{-->
+
  <section xml:id="features.commandline.options">
   <title>コマンドラインオプション</title>
   <titleabbrev>オプション</titleabbrev>
@@ -1046,9 +1041,7 @@ date.sunrise_zenith => 90.583333 => 90.583333
    </para>
   </note>
  </section>
- <!--}}}-->
- 
- <!--Usage: {{{-->
+
  <section xml:id="features.commandline.usage">
   <title>PHP ファイルの実行</title>
   <titleabbrev>PHP ファイルの実行</titleabbrev>
@@ -1341,9 +1334,7 @@ if ($argc != 2 || in_array($argv[1], array('--help', '-help', '-h', '-?'))) {
    </para>
   </note>
  </section>
- <!--}}}-->
- 
- <!--I/O Streams: {{{-->
+
  <section xml:id="features.commandline.io-streams">
   <title>入出力ストリーム</title>
   <titleabbrev>I/O ストリーム</titleabbrev>
@@ -1442,9 +1433,7 @@ php -r 'fwrite(STDERR, "stderr\n");'
    </para>
   </note>
  </section>
- <!--}}}-->
 
- <!--Interactive shell: {{{-->
  <section xml:id="features.commandline.interactive">
   <title>対話シェル</title>
 
@@ -1667,9 +1656,7 @@ php >
    </para>
   </section>
  </section>
- <!--}}}-->
 
- <!--Built-in CLI Web Server: {{{-->
  <section xml:id="features.commandline.webserver">
   <title>ビルトインウェブサーバー</title>
 
@@ -1776,7 +1763,7 @@ php >
    サーバーを起動する前に欲しいワーカーの数を <envar>PHP_CLI_SERVER_WORKERS</envar> 環境変数に設定してください。
   </simpara>
   <note>
-   <simpara>この機能は Windows ではサポートされていません。</simpara>
+   <simpara>複数のワーカーは Windows ではサポートされていません。</simpara>
   </note>
   <note>
    <simpara>
@@ -1948,7 +1935,6 @@ $ php -S 0.0.0.0:8000
   </example>
 
  </section>
- <!--}}}-->
 
   <section xml:id="features.commandline.ini">
    <title>INI 設定</title>

--- a/install/windows/commandline.xml
+++ b/install/windows/commandline.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 2dbf3d9064d4cb07f0a2f7d06641c877a2e5ed24 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 10e6a2b042104bd7481b6c21ddbfda594683e3c4 Maintainer: mumumu Status: ready -->
 
 <sect1 xml:id="install.windows.commandline" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Windows で PHP をコマンドラインで動かす</title>
@@ -184,14 +184,10 @@ Windows Registry Editor Version 5.00
 ]]>
    </screen>
 
-   この件に関する詳細な情報は <link
-   xlink:href="http://support.microsoft.com/default.aspx?scid=kb;en-us;321788">Microsoft
-   Knowledgebase Article : 321788</link> を参照ください。
+   この件に関する詳細な情報は Microsoft
+   Knowledgebase Article 321788 を参照ください。
    Windows 10 ではこの設定が変更されたようです。Windows 10 をインストールしたデフォルトの状態で、
-   コンソールのハンドルが自動的に引き継がれるようになります。この件に関しては、
-   <link
-   xlink:href="https://social.msdn.microsoft.com/Forums/en-US/f19d740d-21c8-4dc2-a9ab-d5c0527e932b/nasty-file-association-regression-bug-in-windows-10-console?forum=windowssdk">
-   Microsoft のフォーラムへの投稿</link> に説明があります。
+   コンソールのハンドルが自動的に引き継がれるようになります。
   </para>
  </note>
 </sect1>

--- a/language/types/relative-class-types.xml
+++ b/language/types/relative-class-types.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 161dde4fe721309398dd324edbf02aec409f127b Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 339ba3f0f4440af1f8d83e73b2c3be06b3cb2315 Maintainer: mumumu Status: ready -->
 <sect1 xml:id="language.types.relative-class-types">
  <title>クラス内での関係を示す相対型</title>
 

--- a/reference/curl/constants_curl_getinfo.xml
+++ b/reference/curl/constants_curl_getinfo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ee972f53e1a95967cd65c6de63ea4b422b987bd3 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 5cdc4c99779c1bd1b770b15a5fc6438b39223c28 Maintainer: mumumu Status: ready -->
 <variablelist xml:id="constant.curl-getinfo.constants" role="constant_list">
  <title><function>curl_getinfo</function></title>
  <varlistentry xml:id="constant.curlinfo-appconnect-time">
@@ -116,6 +116,8 @@
    <simpara>
     ダウンロードしたコンテンツのサイズ。
     Content-Length: サイズから読み取ります。
+    cURL 7.55.0 以降は非推奨となっています。
+    代わりに <constant>CURLINFO_CONTENT_LENGTH_DOWNLOAD_T</constant> を使用してください。
    </simpara>
   </listitem>
  </varlistentry>
@@ -140,7 +142,9 @@
   </term>
   <listitem>
    <simpara>
-    指定されたアップロードサイズ
+    指定されたアップロードサイズ。
+    cURL 7.55.0 以降は非推奨となっています。
+    代わりに <constant>CURLINFO_CONTENT_LENGTH_UPLOAD_T</constant> を使用してください。
    </simpara>
   </listitem>
  </varlistentry>
@@ -471,6 +475,8 @@
     直近の HTTP 接続で使用したプロトコル。
     返される値は、<constant>CURLPROTO_<replaceable>*</replaceable></constant> の値のうち、いずれか1つです。
     PHP 7.3.0 以降 および cURL 7.52.0 以降で利用可能です。
+    cURL 7.85.0 以降は非推奨となっています。
+    代わりに <constant>CURLINFO_SCHEME</constant> を使用してください。
    </simpara>
   </listitem>
  </varlistentry>
@@ -703,7 +709,9 @@
   </term>
   <listitem>
    <simpara>
-    ダウンロードした合計バイト数
+    ダウンロードした合計バイト数。
+    cURL 7.55.0 以降は非推奨となっています。
+    代わりに <constant>CURLINFO_SIZE_DOWNLOAD_T</constant> を使用してください。
    </simpara>
   </listitem>
  </varlistentry>
@@ -727,7 +735,9 @@
   </term>
   <listitem>
    <simpara>
-    アップロードした合計バイト数
+    アップロードした合計バイト数。
+    cURL 7.55.0 以降は非推奨となっています。
+    代わりに <constant>CURLINFO_SIZE_UPLOAD_T</constant> を使用してください。
    </simpara>
   </listitem>
  </varlistentry>
@@ -750,7 +760,9 @@
   </term>
   <listitem>
    <simpara>
-    ダウンロード速度の平均
+    ダウンロード速度の平均。
+    cURL 7.55.0 以降は非推奨となっています。
+    代わりに <constant>CURLINFO_SPEED_DOWNLOAD_T</constant> を使用してください。
    </simpara>
   </listitem>
  </varlistentry>
@@ -773,7 +785,9 @@
   </term>
   <listitem>
    <simpara>
-    アップロード速度の平均
+    アップロード速度の平均。
+    cURL 7.55.0 以降は非推奨となっています。
+    代わりに <constant>CURLINFO_SPEED_UPLOAD_T</constant> を使用してください。
    </simpara>
   </listitem>
  </varlistentry>

--- a/reference/curl/constants_curl_setopt.xml
+++ b/reference/curl/constants_curl_setopt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e7e81a179eabc75e1b37947c7696afd557cef656 Maintainer: nsfisis Status: ready -->
+<!-- EN-Revision: 5cdc4c99779c1bd1b770b15a5fc6438b39223c28 Maintainer: nsfisis Status: ready -->
  <variablelist role="constant_list">
   <title><function>curl_setopt</function></title>
   <varlistentry xml:id="constant.curlopt-abstract-unix-socket">
@@ -1510,7 +1510,7 @@
      <literal>private</literal> が使われます。
      このオプションを &null; に設定すると、FTP の Kerberos サポートが無効になります。
      デフォルト値は &null; です。
-     cURL 7.16.4 以降で利用可能です。
+     cURL 7.16.4 以降で利用可能ですが、cURL 8.17.0 以降は非推奨となりました。
     </para>
    </listitem>
   </varlistentry>
@@ -2241,13 +2241,13 @@
     (<type>int</type>)
    </term>
    <listitem>
-    <para>
+    <simpara>
      <constant>CURLPROTO_<replaceable>*</replaceable></constant> 値のビットマスクを指定します。
      これが使われた場合、cURL が転送で使用できるプロトコルを制限します。
      デフォルトは <constant>CURLPROTO_ALL</constant> で、cURL はサポートするすべてのプロトコルを受け入れます。
-     <constant>CURLOPT_REDIR_PROTOCOLS</constant> も参照してください。
+     <constant>CURLOPT_REDIR_PROTOCOLS_STR</constant> も参照してください。
      cURL 7.19.4 以降で利用可能ですが、cURL 7.85.0 以降は非推奨となりました。
-    </para>
+    </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.curlopt-protocols-str">
@@ -3650,12 +3650,13 @@
     (<type>int</type>)
    </term>
    <listitem>
-    <para>
+    <simpara>
      &true; を指定すると TLS の False Start が有効になり、&false; を指定すると無効になります。
      False Start モードは、TLS クライアントがサーバーの <literal>Finished</literal> メッセージを検証する前に
      アプリケーションデータの送信を開始するモードです。
      PHP 7.0.7 以降かつ cURL 7.42.0 以降で利用可能です。
-    </para>
+     cURL 8.15.0 以降は非推奨となっています。
+    </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.curlopt-ssl-options">

--- a/reference/dom/dom/dom-document.xml
+++ b/reference/dom/dom/dom-document.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ae7db14ea8cb8f3041e114f0ef865d86a95f72d6 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 34314b7c6eab4d9b7efabd42154b38fcc5db1fef Maintainer: mumumu Status: ready -->
 <reference xml:id="class.dom-document" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>Dom\Document クラス</title>
  <titleabbrev>Dom\Document</titleabbrev>
@@ -107,6 +107,12 @@
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>Dom\HTMLCollection</type>
+     <varname linkend="dom-document.props.children">children</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
      <type class="union"><type>Dom\HTMLElement</type><type>null</type></type>
      <varname linkend="dom-document.props.body">body</varname>
     </fieldsynopsis>
@@ -207,6 +213,11 @@
     </varlistentry>
     <varlistentry xml:id="dom-document.props.childelementcount">
      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.props.childelementcount')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom-document.props.children">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('dom-parentnode.props.children')/*)">
       <xi:fallback/>
      </xi:include>
     </varlistentry>

--- a/reference/dom/dom/dom-documentfragment.xml
+++ b/reference/dom/dom/dom-documentfragment.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ae7db14ea8cb8f3041e114f0ef865d86a95f72d6 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 34314b7c6eab4d9b7efabd42154b38fcc5db1fef Maintainer: mumumu Status: ready -->
 <reference xml:id="class.dom-documentfragment" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>Dom\DocumentFragment クラス</title>
  <titleabbrev>Dom\DocumentFragment</titleabbrev>
@@ -61,6 +61,12 @@
      <type>int</type>
      <varname linkend="dom-documentfragment.props.childelementcount">childElementCount</varname>
     </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>Dom\HTMLCollection</type>
+     <varname linkend="dom-documentfragment.props.children">children</varname>
+    </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
@@ -96,6 +102,11 @@
     </varlistentry>
     <varlistentry xml:id="dom-documentfragment.props.childelementcount">
      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocumentfragment.props.childelementcount')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom-documentfragment.props.children">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('dom-parentnode.props.children')/*)">
       <xi:fallback/>
      </xi:include>
     </varlistentry>

--- a/reference/dom/dom/dom-element.xml
+++ b/reference/dom/dom/dom-element.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ae7db14ea8cb8f3041e114f0ef865d86a95f72d6 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 34314b7c6eab4d9b7efabd42154b38fcc5db1fef Maintainer: mumumu Status: ready -->
 <reference xml:id="class.dom-element" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>Dom\Element クラス</title>
  <titleabbrev>Dom\Element</titleabbrev>
@@ -124,8 +124,19 @@
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>Dom\HTMLCollection</type>
+     <varname linkend="dom-element.props.children">children</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
      <type>string</type>
      <varname linkend="dom-element.props.innerhtml">innerHTML</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <type>string</type>
+     <varname linkend="dom-element.props.outerhtml">outerHTML</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
@@ -232,10 +243,24 @@
       <xi:fallback/>
      </xi:include>
     </varlistentry>
+    <varlistentry xml:id="dom-element.props.children">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('dom-parentnode.props.children')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
     <varlistentry xml:id="dom-element.props.innerhtml">
      <term><varname>innerHTML</varname></term>
      <listitem>
       <simpara>要素の inner HTML (またはXML文書のXML)</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="dom-element.props.outerhtml">
+     <term><varname>outerHTML</varname></term>
+     <listitem>
+      <simpara>
+       要素自身を含む、要素の outer HTML (またはXML文書のXML)。
+       PHP 8.5.0 以降で利用可能です。
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="dom-element.props.substitutednodevalue">

--- a/reference/dom/dom/dom-parentnode.xml
+++ b/reference/dom/dom/dom-parentnode.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ae7db14ea8cb8f3041e114f0ef865d86a95f72d6 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 34314b7c6eab4d9b7efabd42154b38fcc5db1fef Maintainer: mumumu Status: ready -->
 <reference xml:id="class.dom-parentnode" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>Dom\ParentNode インターフェイス</title>
  <titleabbrev>Dom\ParentNode</titleabbrev>
@@ -23,12 +23,35 @@
      <interfacename>Dom\ParentNode</interfacename>
     </oointerface>
 
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>Dom\HTMLCollection</type>
+     <varname linkend="dom-parentnode.props.children">children</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-parentnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\ParentNode'])">
      <xi:fallback/>
     </xi:include>
    </classsynopsis>
 
+  </section>
+
+  <section xml:id="dom-parentnode.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="dom-parentnode.props.children">
+     <term><varname>children</varname></term>
+     <listitem>
+      <simpara>
+       このノードのすべての子要素を含む
+       <classname>Dom\HTMLCollection</classname>。PHP 8.5.0 以降で利用可能です。
+      </simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
   </section>
 
  </partintro>

--- a/reference/intl/book.xml
+++ b/reference/intl/book.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 91791cdde04dd89898656fbec1aa8e7e0bf0460d Maintainer: takagi Status: ready -->
+<!-- EN-Revision: e1b9f588815a51682acf68f9b8929f49ad612488 Maintainer: takagi Status: ready -->
 
 <book xml:id="book.intl" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <?phpdoc extension-membership="bundled" ?>
@@ -10,27 +10,27 @@
  <!-- {{{ Preface -->
  <preface xml:id="intro.intl">
   &reftitle.intro;
-  <para>
+  <simpara>
    国際化用拡張モジュール (これ以降では Intl と略します)
    は <link xlink:href="&url.icu.home;">ICU</link> ライブラリのラッパーです。
    PHP プログラマが、ロケール関連のさまざまな操作を行えるようにします。
    フォーマット、音訳、エンコード変換、カレンダーの処理、
    <link xlink:href="&url.icu.uca;">UCA</link> 準拠の照合順序 (collation)、
    テキストの区切り、ロケール識別子やタイムゾーンや書記素を用いた操作などが可能です。
-  </para>
+  </simpara>
 
-  <para>
+  <simpara>
    ICU の API に従って作成されているので、
    C/C++ や Java で ICU を使ったことがあるかたは簡単に PHP の API
    も使えることでしょう。
    また、ICU のドキュメントを参考にすればさまざまな
    ICU の関数について知ることができます。
-  </para>
+  </simpara>
 
-  <para>
+  <simpara>
    Intl はいくつかのモジュールで構成されており、
    各モジュールが対応する ICU API を公開しています。
-  </para>
+  </simpara>
 
   <itemizedlist>
    <listitem>
@@ -90,13 +90,13 @@
    <title>リンク</title>
    <itemizedlist>
     <listitem>
-     <para><link xlink:href="&url.icu.docs;">ICU のドキュメント</link></para>
+     <simpara><link xlink:href="&url.icu.docs;">ICU のドキュメント</link></simpara>
     </listitem>
     <listitem>
-     <para><link xlink:href="&url.icu.userguide;">ICU ユーザーガイド</link></para>
+     <simpara><link xlink:href="&url.icu.userguide;">ICU ユーザーガイド</link></simpara>
     </listitem>
     <listitem>
-     <para><link xlink:href="&url.icu.uca;">Unicode Collation Algorithm</link></para>
+     <simpara><link xlink:href="&url.icu.uca;">Unicode Collation Algorithm</link></simpara>
     </listitem>
    </itemizedlist>
   </section>
@@ -125,6 +125,7 @@
  &reference.intl.intlrulebasedbreakiterator;
  &reference.intl.intlcodepointbreakiterator;
  &reference.intl.intldatepatterngenerator;
+ &reference.intl.intllistformatter;
  &reference.intl.intlpartsiterator;
  &reference.intl.uconverter;
 

--- a/reference/intl/grapheme/grapheme-strripos.xml
+++ b/reference/intl/grapheme/grapheme-strripos.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9a8c593c09cf7d84085989e42f3b2b23536279db Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 2583cd865645eea478d9a9b265d95c28a1ee5525 Maintainer: takagi Status: ready -->
 <refentry xml:id="function.grapheme-strripos" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>grapheme_strripos</refname>
@@ -50,6 +50,15 @@
        <parameter>offset</parameter> の値にかかわらず、返される値は常に <parameter>haystack</parameter>
        の先頭からの位置になります。
       </para>
+      <simpara>
+       オプションの <parameter>offset</parameter> パラメータで、<parameter>haystack</parameter>
+       のどの位置 (バイト数や文字数ではなく、書記素単位) から探し始めるのかを指定します。
+       <parameter>offset</parameter> が負の場合は、文字列の末尾からの相対位置として扱われます。
+       <parameter>offset</parameter> の値にかかわらず、返される値は常に <parameter>haystack</parameter>
+       の先頭からの位置になります。
+       検索は右から左に行われ、検索を開始した書記素クラスターから
+       <parameter>needle</parameter> が最初にあらわれる場所を探します。
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/intl/grapheme/grapheme-strrpos.xml
+++ b/reference/intl/grapheme/grapheme-strrpos.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9a8c593c09cf7d84085989e42f3b2b23536279db Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 2583cd865645eea478d9a9b265d95c28a1ee5525 Maintainer: takagi Status: ready -->
 <refentry xml:id="function.grapheme-strrpos" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>grapheme_strrpos</refname>
@@ -50,6 +50,15 @@
        <parameter>offset</parameter> の値にかかわらず、返される値は常に <parameter>haystack</parameter>
        の先頭からの位置になります。
       </para>
+      <simpara>
+       オプションの <parameter>offset</parameter> パラメータで、<parameter>haystack</parameter>
+       のどの位置 (バイト数や文字数ではなく、書記素単位) から探し始めるのかを指定します。
+       <parameter>offset</parameter> が負の場合は、文字列の末尾からの相対位置として扱われます。
+       <parameter>offset</parameter> の値にかかわらず、返される値は常に <parameter>haystack</parameter>
+       の先頭からの位置になります。
+       検索は右から左に行われ、検索を開始した書記素クラスターから
+       <parameter>needle</parameter> が最初にあらわれる場所を探します。
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/intl/intlbreakiterator/getpartsiterator.xml
+++ b/reference/intl/intlbreakiterator/getpartsiterator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c142be811735a5542c8a2e4c4ed2f81e8cc3acc6 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 0f83ceff02d7f368686fbc55b44c89ee562e3ae7 Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="intlbreakiterator.getpartsiterator" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -12,7 +12,7 @@
   &reftitle.description;
   <methodsynopsis role="IntlBreakIterator">
    <modifier>public</modifier> <type>IntlPartsIterator</type><methodname>IntlBreakIterator::getPartsIterator</methodname>
-   <methodparam choice="opt"><type>string</type><parameter>type</parameter><initializer><constant>IntlPartsIterator::KEY_SEQUENTIAL</constant></initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>type</parameter><initializer><constant>IntlPartsIterator::KEY_SEQUENTIAL</constant></initializer></methodparam>
   </methodsynopsis>
   <para>
 

--- a/reference/intl/intllistformatter.xml
+++ b/reference/intl/intllistformatter.xml
@@ -1,0 +1,179 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: e1b9f588815a51682acf68f9b8929f49ad612488 Maintainer: KentarouTakeda Status: ready -->
+<reference xml:id="class.intllistformatter" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>IntlListFormatter クラス</title>
+ <titleabbrev>IntlListFormatter</titleabbrev>
+
+ <partintro>
+
+  <!-- {{{ IntlListFormatter intro -->
+  <section xml:id="intllistformatter.intro">
+   &reftitle.intro;
+   <simpara>
+    ロケール固有のルールに従って、項目のリストのフォーマット、順序付け、句読点の付与を行います。
+    ICU 67 以降が必要です。
+   </simpara>
+  </section>
+  <!-- }}} -->
+
+  <section xml:id="intllistformatter.synopsis">
+   &reftitle.classsynopsis;
+
+   <!-- {{{ Synopsis -->
+   <classsynopsis class="class">
+    <ooclass>
+     <classname>IntlListFormatter</classname>
+    </ooclass>
+
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="intllistformatter.constants.type-and">IntlListFormatter::TYPE_AND</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="intllistformatter.constants.type-or">IntlListFormatter::TYPE_OR</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="intllistformatter.constants.type-units">IntlListFormatter::TYPE_UNITS</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="intllistformatter.constants.width-wide">IntlListFormatter::WIDTH_WIDE</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="intllistformatter.constants.width-short">IntlListFormatter::WIDTH_SHORT</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="intllistformatter.constants.width-narrow">IntlListFormatter::WIDTH_NARROW</varname>
+    </fieldsynopsis>
+
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intllistformatter')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='IntlListFormatter'])">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intllistformatter')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlListFormatter'])">
+     <xi:fallback/>
+    </xi:include>
+   </classsynopsis>
+   <!-- }}} -->
+
+  </section>
+
+  <section xml:id="intllistformatter.constants">
+   &reftitle.constants;
+   <variablelist>
+    <varlistentry xml:id="intllistformatter.constants.type-and">
+     <term><constant>IntlListFormatter::TYPE_AND</constant></term>
+     <listitem>
+      <simpara>
+       「and」にあたる接続詞を使ってリストをフォーマットします (例: "A, B, and C")。
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="intllistformatter.constants.type-or">
+     <term><constant>IntlListFormatter::TYPE_OR</constant></term>
+     <listitem>
+      <simpara>
+       「or」にあたる接続詞を使ってリストをフォーマットします (例: "A, B, or C")。
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="intllistformatter.constants.type-units">
+     <term><constant>IntlListFormatter::TYPE_UNITS</constant></term>
+     <listitem>
+      <simpara>
+       単位のリストをフォーマットします (例: "3 ft, 7 in")。
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="intllistformatter.constants.width-wide">
+     <term><constant>IntlListFormatter::WIDTH_WIDE</constant></term>
+     <listitem>
+      <simpara>
+       最も幅の広い (最も冗長な) リスト形式を使用します。通常、接続詞は省略されずに完全な形で表記されます。
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="intllistformatter.constants.width-short">
+     <term><constant>IntlListFormatter::WIDTH_SHORT</constant></term>
+     <listitem>
+      <simpara>
+       短いリスト形式を使用します。通常は省略形が使われます。
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="intllistformatter.constants.width-narrow">
+     <term><constant>IntlListFormatter::WIDTH_NARROW</constant></term>
+     <listitem>
+      <simpara>
+       最も幅の狭いリスト形式を使用します。句読点は最小限になります。
+      </simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+
+  <section role="changelog" xml:id="intllistformatter.changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.5.0</entry>
+       <entry>
+        このクラスが追加されました。
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
+
+ </partintro>
+
+ &reference.intl.entities.intllistformatter;
+
+</reference>
+<!-- Keep this comment at the end of the file
+ Local variables:
+ mode: sgml
+ sgml-omittag:t
+ sgml-shorttag:t
+ sgml-minimize-attributes:nil
+ sgml-always-quote-attributes:t
+ sgml-indent-step:1
+ sgml-indent-data:t
+ indent-tabs-mode:nil
+ sgml-parent-document:nil
+ sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+ sgml-exposed-tags:nil
+ sgml-local-catalogs:nil
+ sgml-local-ecat-files:nil
+ End:
+ vim600: syn=xml fen fdm=syntax fdl=2 si
+ vim: et tw=78 syn=sgml
+ vi: ts=1 sw=1
+-->

--- a/reference/intl/intllistformatter/construct.xml
+++ b/reference/intl/intllistformatter/construct.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: e1b9f588815a51682acf68f9b8929f49ad612488 Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="intllistformatter.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>IntlListFormatter::__construct</refname>
+  <refpurpose>新しい IntlListFormatter のインスタンスを作成する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <constructorsynopsis role="IntlListFormatter">
+   <modifier>public</modifier> <methodname>IntlListFormatter::__construct</methodname>
+   <methodparam><type>string</type><parameter>locale</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>type</parameter><initializer><constant>IntlListFormatter::TYPE_AND</constant></initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>width</parameter><initializer><constant>IntlListFormatter::WIDTH_WIDE</constant></initializer></methodparam>
+  </constructorsynopsis>
+  <simpara>
+   指定したロケール用の新しい <classname>IntlListFormatter</classname> のインスタンスを作成します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>locale</parameter></term>
+    <listitem>
+     <simpara>
+      フォーマットに使用するロケール。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>type</parameter></term>
+    <listitem>
+     <simpara>
+      リストの種類。<constant>IntlListFormatter::TYPE_<replaceable>*</replaceable></constant> 定数
+      (<constant>IntlListFormatter::TYPE_AND</constant>,
+      <constant>IntlListFormatter::TYPE_OR</constant>,
+      <constant>IntlListFormatter::TYPE_UNITS</constant>) のいずれかです。
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>width</parameter></term>
+    <listitem>
+     <simpara>
+      リストの幅。<constant>IntlListFormatter::WIDTH_<replaceable>*</replaceable></constant> 定数
+      (<constant>IntlListFormatter::WIDTH_WIDE</constant>,
+      <constant>IntlListFormatter::WIDTH_SHORT</constant>,
+      <constant>IntlListFormatter::WIDTH_NARROW</constant>) のいずれかです。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   フォーマッタを作成できない場合 (ロケールが不正な場合や、ICU のバージョンが 67 未満の場合など)、
+   <exceptionname>IntlException</exceptionname> をスローします。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       このクラスが追加されました。
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>IntlListFormatter::format</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/intllistformatter/format.xml
+++ b/reference/intl/intllistformatter/format.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: e1b9f588815a51682acf68f9b8929f49ad612488 Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="intllistformatter.format" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>IntlListFormatter::format</refname>
+  <refpurpose>項目のリストをフォーマットする</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="IntlListFormatter">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>false</type></type><methodname>IntlListFormatter::format</methodname>
+   <methodparam><type>array</type><parameter>list</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   項目のリストを、ロケールに応じた文字列にフォーマットします。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>list</parameter></term>
+    <listitem>
+     <simpara>
+      リストとしてフォーマットする文字列の配列。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   フォーマットしたリストを文字列で返します。失敗した場合は &false; を返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><methodname>IntlListFormatter::format</methodname> の例</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$fmt = new IntlListFormatter('en_US', IntlListFormatter::TYPE_AND, IntlListFormatter::WIDTH_WIDE);
+echo $fmt->format(['one', 'two', 'three']);
+// one, two, and three
+
+$fmt = new IntlListFormatter('en_US', IntlListFormatter::TYPE_OR, IntlListFormatter::WIDTH_WIDE);
+echo $fmt->format(['one', 'two', 'three']);
+// one, two, or three
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>IntlListFormatter::__construct</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/locale/isrighttoleft.xml
+++ b/reference/intl/locale/isrighttoleft.xml
@@ -1,17 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: facf6996ca5a6057f7092761079e4aa00c5b7713 Maintainer: KentarouTakeda Status: ready -->
+<!-- EN-Revision: fe74bcd7c2697f7e955372f4e8d2f755c0f0c779 Maintainer: KentarouTakeda Status: ready -->
 <refentry xml:id="locale.isrighttoleft"
           xmlns="http://docbook.org/ns/docbook"
           xmlns:xlink="http://www.w3.org/1999/xlink">
 
  <refnamediv>
   <refname>Locale::isRightToLeft</refname>
+  <refname>locale_is_right_to_left</refname>
   <refpurpose>ロケールが右から左に書く文字体系を使うかどうかを調べる</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
+  <para>
+   &style.oop;
+  </para>
   <methodsynopsis role="Locale">
    <modifier>public</modifier>
    <modifier>static</modifier>
@@ -22,6 +26,13 @@
     <initializer>""</initializer>
    </methodparam>
   </methodsynopsis>
+  <para>
+   &style.procedural;
+  </para>
+  <methodsynopsis>
+   <type>bool</type><methodname>locale_is_right_to_left</methodname>
+   <methodparam><type>string</type><parameter>locale</parameter><initializer>""</initializer></methodparam>
+  </methodsynopsis>
 
   <simpara>
    ロケールが右から左に書く文字体系を使うかどうかを調べます。
@@ -30,10 +41,6 @@
   <simpara>
    このメソッドは ICU ライブラリに依存しており、
    ロケールに関連付けられた主要な文字体系を評価します。
-  </simpara>
-
-  <simpara>
-   空文字列が指定された場合、デフォルトのロケールが使用されます。
   </simpara>
  </refsect1>
 

--- a/reference/ldap/constants.xml
+++ b/reference/ldap/constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 5b3a84935252a553528cb81b3dacb88647b57c7b Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 10e6a2b042104bd7481b6c21ddbfda594683e3c4 Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <appendix xml:id="ldap.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.constants;
@@ -577,7 +577,7 @@
    </term>
    <listitem>
     <simpara>
-     コントロール定数 - Assertion (<link xlink:href="&url.rfc;45282">RFC 4528</link>).
+     コントロール定数 - Assertion (<link xlink:href="&url.rfc;4528">RFC 4528</link>).
      PHP 7.3.0 以降で利用可能です。
     </simpara>
    </listitem>

--- a/reference/ldap/functions/ldap-count-entries.xml
+++ b/reference/ldap/functions/ldap-count-entries.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: bc90525a5a5ebcf8412ef34b8355d2de12166fff Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: cf27955fcbad1b75678cd6bb12bfdfa1e2005b63 Maintainer: hirokawa Status: ready -->
 <refentry xml:id="function.ldap-count-entries" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ldap_count_entries</refname>
@@ -45,10 +45,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    結果のエントリ数を返します。
-   &return.falseforfailure;
-  </para>
+   エラーの場合は <literal>-1</literal> を返します。
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/ldap/functions/ldap-exop.xml
+++ b/reference/ldap/functions/ldap-exop.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9faf0215daa7a2b5d84525d7d2b3d6b066cc85ec Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 6400027855e1ef2a1a95f62db200fc1ae35a7b2e Maintainer: mumumu Status: ready -->
 
 <refentry xml:id="function.ldap-exop" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -11,11 +11,11 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>mixed</type><methodname>ldap_exop</methodname>
+   <type class="union"><type>LDAP\Result</type><type>bool</type></type><methodname>ldap_exop</methodname>
    <methodparam><type>LDAP\Connection</type><parameter>ldap</parameter></methodparam>
    <methodparam><type>string</type><parameter>request_oid</parameter></methodparam>
-   <methodparam choice="opt"><type>string</type><parameter>request_data</parameter><initializer>&null;</initializer></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>controls</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>request_data</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>controls</parameter><initializer>&null;</initializer></methodparam>
    <methodparam choice="opt"><type>string</type><parameter role="reference">response_data</parameter></methodparam>
    <methodparam choice="opt"><type>string</type><parameter role="reference">response_oid</parameter></methodparam>
   </methodsynopsis>

--- a/reference/libxml/constants.xml
+++ b/reference/libxml/constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 64e1182c986582df32ed7e629e42b4fea204de2e Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 7dce5910421f42a97717220587841423ef1fa27a Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa,mumumu -->
 <appendix xml:id="libxml.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
@@ -275,11 +275,19 @@
    </term>
    <listitem>
     <simpara>
-     パーサーでハードコーディングされたすべての制限を緩和するための
+     パーサーでハードコーディングされた一部の制限を引き上げるための
      XML_PARSE_HUGE フラグを設定する。
-     これは、ドキュメントやエンティティの再帰の最大数や
-     テキストノードのサイズなどの制限に影響する。
+     これは、ドキュメントの最大の深さやエンティティの再帰、
+     そしてテキストノードのサイズなどの制限に影響する。
     </simpara>
+    <caution>
+     <simpara>
+      これはハードコーディングされた制限を引き上げるため、信頼できるデータに対してのみ使用すべきです。
+      信頼できない入力に対して深さの制限を引き上げると、
+      深くネストされたドキュメントの処理中にスタックオーバーフローが発生するなど、
+      リソースを過度に消費する可能性があります。
+     </simpara>
+    </caution>
     <note>
      <para>
       Libxml &gt;= 2.7.0 (PHP &gt;= 5.3.2 あるいは PHP &gt;= 5.2.12) でのみ有効

--- a/reference/pcntl/functions/pcntl-setcpuaffinity.xml
+++ b/reference/pcntl/functions/pcntl-setcpuaffinity.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: aa120f36c5762e99f9ee121d8caf910e0a67121e Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 74b6239160f459a2b089263d31cb84a47117b4a6 Maintainer: mumumu Status: ready -->
 <refentry xml:id="function.pcntl-setcpuaffinity" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>pcntl_setcpuaffinity</refname>
@@ -47,7 +47,6 @@
   <simpara>
    &return.success;
   </simpara>
-  &return.falseproblem;
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/pdo/pdo/getattribute.xml
+++ b/reference/pdo/pdo/getattribute.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 911fe79de766ef4475bf22446903667a0f3a24d3 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 91183ddf1c54c6ce3051fdf0f5b9987272d51fbe Maintainer: takagi Status: ready -->
 <!-- CREDITS: shimooka -->
 <refentry xml:id="pdo.getattribute" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -83,6 +83,29 @@
    <methodname>PDO::getAttribute</methodname> は
    <exceptionname>PDOException</exceptionname> をスローします。
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       <constant>PDO::ATTR_STRINGIFY_FETCHES</constant> 属性の値を
+       取得できるようになりました。
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/pgsql/functions/pg-fetch-result.xml
+++ b/reference/pgsql/functions/pg-fetch-result.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 <!-- splitted from ./ja/functions/pgsql.xml, last change in rev 1.14 -->
-<!-- EN-Revision: 87c67b277e1772956eeb7906f04af18b0284ca7c Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 91183ddf1c54c6ce3051fdf0f5b9987272d51fbe Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi,mumumu -->
 <refentry xml:id="function.pg-fetch-result" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -92,6 +92,15 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       <function>pg_fetch_result</function> の 2 引数のシグネチャ
+       （<parameter>result</parameter>, <parameter>field</parameter>）は非推奨となりました。
+       代わりに <parameter>row</parameter> を &null; に設定した 3 引数のシグネチャを
+       使用してください。
+      </entry>
+     </row>
      <row>
       <entry>8.3.0</entry>
       <entry>

--- a/reference/pgsql/functions/pg-field-is-null.xml
+++ b/reference/pgsql/functions/pg-field-is-null.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 <!-- splitted from ./ja/functions/pgsql.xml, last change in rev 1.1 -->
-<!-- EN-Revision: 39bb8a868935a56cfce438b0169e13c02c93211c Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 91183ddf1c54c6ce3051fdf0f5b9987272d51fbe Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi,mumumu -->
 <refentry xml:id="function.pg-field-is-null" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -87,6 +87,15 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       <function>pg_field_is_null</function> の 2 引数のシグネチャ
+       （<parameter>result</parameter>, <parameter>field</parameter>）は非推奨となりました。
+       代わりに <parameter>row</parameter> を &null; に設定した 3 引数のシグネチャを
+       使用してください。
+      </entry>
+     </row>
      <row>
       <entry>8.3.0</entry>
       <entry>

--- a/reference/pgsql/functions/pg-field-prtlen.xml
+++ b/reference/pgsql/functions/pg-field-prtlen.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 <!-- splitted from ./ja/functions/pgsql.xml, last change in rev 1.1 -->
-<!-- EN-Revision: 39bb8a868935a56cfce438b0169e13c02c93211c Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 91183ddf1c54c6ce3051fdf0f5b9987272d51fbe Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi -->
 <refentry xml:id="function.pg-field-prtlen" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -85,6 +85,16 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       <function>pg_field_prtlen</function> の 2 引数のシグネチャ
+       （<parameter>result</parameter>,
+       <parameter>field_name_or_number</parameter>）は非推奨となりました。
+       代わりに <parameter>row</parameter> を &null; に設定した 3 引数のシグネチャを
+       使用してください。
+      </entry>
+     </row>
      <row>
       <entry>8.3.0</entry>
       <entry>

--- a/reference/reflection/reflectionconstant/getattributes.xml
+++ b/reference/reflection/reflectionconstant/getattributes.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 543f9825542891ca85581c3ac9cda5b8f01258b5 Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="reflectionconstant.getattributes" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ReflectionConstant::getAttributes</refname>
+  <refpurpose>アトリビュートを取得する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="ReflectionConstant">
+   <modifier>public</modifier> <type>array</type><methodname>ReflectionConstant::getAttributes</methodname>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>name</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   このグローバル定数で宣言されている全てのアトリビュートを
+   <classname>ReflectionAttribute</classname> の配列として返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   &reflection.getattributes.param.name;
+   &reflection.getattributes.param.flags;
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   アトリビュートの配列を、
+   <classname>ReflectionAttribute</classname> オブジェクトの配列として返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.5.0</entry>
+       <entry>
+        このメソッドが追加されました。
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>基本的な使い方</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+#[Attribute]
+class Fruit {
+}
+
+#[Attribute]
+class Red {
+}
+
+#[Fruit]
+#[Red]
+const APPLE = 'apple';
+
+$constant = new ReflectionConstant('APPLE');
+$attributes = $constant->getAttributes();
+print_r(array_map(fn($attribute) => $attribute->getName(), $attributes));
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+Array
+(
+    [0] => Fruit
+    [1] => Red
+)
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>ReflectionClass::getAttributes</methodname></member>
+   <member><methodname>ReflectionClassConstant::getAttributes</methodname></member>
+   <member><methodname>ReflectionFunctionAbstract::getAttributes</methodname></member>
+   <member><methodname>ReflectionProperty::getAttributes</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/reflection/reflectionproperty/getmangledname.xml
+++ b/reference/reflection/reflectionproperty/getmangledname.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 844a420240e6944d391d6ae022af239c4961ed04 Maintainer: KentarouTakeda Status: ready -->
+<refentry xml:id="reflectionproperty.getmangledname" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ReflectionProperty::getMangledName</refname>
+  <refpurpose>プロパティのマングリングされた名前を取得する</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="ReflectionProperty">
+   <modifier>public</modifier> <type>string</type><methodname>ReflectionProperty::getMangledName</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   プロパティのマングリングされた名前（内部的な名前）を返します。
+   private および protected プロパティの場合、
+   この名前にはアクセス権のスコープが埋め込まれています。
+  </simpara>
+  <simpara>
+   public プロパティの場合、マングリングされた名前はプロパティ名と同一です。
+   protected プロパティの場合、マングリングされた名前は
+   <literal>\0*\0<replaceable>name</replaceable></literal> という形式になります。
+   private プロパティの場合、マングリングされた名前は
+   <literal>\0<replaceable>ClassName</replaceable>\0<replaceable>name</replaceable></literal>
+   という形式になります。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   調べているプロパティのマングリングされた名前を返します。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       このメソッドが追加されました。
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>ReflectionProperty::getName</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/reflection/reflectionzendextension.xml
+++ b/reference/reflection/reflectionzendextension.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 99154194059ad3523a16c284133e05afe5c66c2c Maintainer: takagi Status: ready -->
 <reference xml:id="class.reflectionzendextension" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>ReflectionZendExtension クラス</title>
@@ -11,9 +11,10 @@
 <!-- {{{ ReflectionZendExtension intro -->
   <section xml:id="reflectionzendextension.intro">
    &reftitle.intro;
-   <para>
-
-   </para>
+   <simpara>
+    <classname>ReflectionZendExtension</classname> クラスは
+    Zend 拡張モジュールについての情報を報告します。
+   </simpara>
   </section>
 <!-- }}} -->
 

--- a/reference/sodium/functions/sodium-crypto-aead-chacha20poly1305-encrypt.xml
+++ b/reference/sodium/functions/sodium-crypto-aead-chacha20poly1305-encrypt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 96a8863cc0403bb23a99caff9a113b64f3524671 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: cc7976fa40eef4c07fc1e90813146be1503fb464 Maintainer: mumumu Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.sodium-crypto-aead-chacha20poly1305-encrypt">
  <refnamediv>
   <refname>sodium_crypto_aead_chacha20poly1305_encrypt</refname>
@@ -68,9 +68,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   成功時には、暗号化されたテキストと、
-   認証タグを返します。
-   &return.falseforfailure;.
+   暗号化されたテキストと、
+   認証タグを生のバイナリのバイト列に含めた文字列を返します。
   </simpara>
  </refsect1>
 

--- a/reference/sodium/functions/sodium-crypto-aead-chacha20poly1305-ietf-encrypt.xml
+++ b/reference/sodium/functions/sodium-crypto-aead-chacha20poly1305-ietf-encrypt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 96a8863cc0403bb23a99caff9a113b64f3524671 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: cc7976fa40eef4c07fc1e90813146be1503fb464 Maintainer: mumumu Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.sodium-crypto-aead-chacha20poly1305-ietf-encrypt">
  <refnamediv>
   <refname>sodium_crypto_aead_chacha20poly1305_ietf_encrypt</refname>
@@ -73,9 +73,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   成功時には、
-   暗号化されたテキストと認証タグを返します。
-   &return.falseforfailure;.
+   暗号化されたテキストと、
+   認証タグを生のバイナリのバイト列に含めた文字列を返します。
   </simpara>
  </refsect1>
 

--- a/reference/sodium/functions/sodium-crypto-aead-xchacha20poly1305-ietf-encrypt.xml
+++ b/reference/sodium/functions/sodium-crypto-aead-xchacha20poly1305-ietf-encrypt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 96a8863cc0403bb23a99caff9a113b64f3524671 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: cc7976fa40eef4c07fc1e90813146be1503fb464 Maintainer: mumumu Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.sodium-crypto-aead-xchacha20poly1305-ietf-encrypt">
  <refnamediv>
   <refname>sodium_crypto_aead_xchacha20poly1305_ietf_encrypt</refname>
@@ -76,8 +76,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   成功時に、暗号化されたテキストとタグを返します。
-   &return.falseforfailure;.
+   暗号化されたテキストと、
+   認証タグを生のバイナリのバイト列に含めた文字列を返します。
   </simpara>
  </refsect1>
 

--- a/reference/sodium/functions/sodium-crypto-stream-xchacha20-xor-ic.xml
+++ b/reference/sodium/functions/sodium-crypto-stream-xchacha20-xor-ic.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 96a8863cc0403bb23a99caff9a113b64f3524671 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: cc7976fa40eef4c07fc1e90813146be1503fb464 Maintainer: mumumu Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.sodium-crypto-stream-xchacha20-xor-ic">
  <refnamediv>
   <refname>sodium_crypto_stream_xchacha20_xor_ic</refname>
@@ -78,7 +78,6 @@
   &reftitle.returnvalues;
   <simpara>
    暗号化されたメッセージを返します。
-   &return.falseforfailure;
   </simpara>
  </refsect1>
 


### PR DESCRIPTION
curl / dom / intl / ldap / libxml / pcntl / pdo / pgsql / reflection / sodium の
10 モジュールを完訳しました。

新規翻訳は PHP 8.5 で追加された `IntlListFormatter`（クラス・コンストラクタ・
`format()`）、`ReflectionConstant::getAttributes()`、
`ReflectionProperty::getMangledName()` の 5 ファイルです。

## 翻訳内容

### IntlListFormatter（PHP 8.5 新クラス・5件）

- reference/intl/intllistformatter.xml — クラス概要と定義済み定数の新規翻訳
  1. php/doc-en@e1b9f58881
- reference/intl/intllistformatter/construct.xml — コンストラクタの新規翻訳
  1. php/doc-en@e1b9f58881
- reference/intl/intllistformatter/format.xml — `format()` の新規翻訳
  1. php/doc-en@e1b9f58881
- reference/intl/book.xml — クラス一覧に IntlListFormatter を追加し、para → simpara を同期
  1. php/doc-en@e1b9f58881
- appendices/migration85/new-classes.xml — Intl のセクションを追加
  1. php/doc-en@e1b9f58881

### reference/intl（4件）

- reference/intl/locale/isrighttoleft.xml — 手続き型 `locale_is_right_to_left()` を追加
  1. php/doc-en@fe74bcd7c2
- reference/intl/grapheme/grapheme-strripos.xml — 負の `offset` の説明を追加
  1. php/doc-en@2583cd8656
- reference/intl/grapheme/grapheme-strrpos.xml — 負の `offset` の説明を追加
  1. php/doc-en@2583cd8656
- reference/intl/intlbreakiterator/getpartsiterator.xml — `type` パラメータの型を `int` に修正
  1. php/doc-en@0f83ceff02

### reference/dom（4件）

- reference/dom/dom/dom-element.xml — `$children` と `$outerHTML` プロパティを追加
  1. php/doc-en@9a5e44a0ca
  2. php/doc-en@34314b7c6e
- reference/dom/dom/dom-parentnode.xml — `$children` プロパティを追加（定義元）
  1. php/doc-en@34314b7c6e
- reference/dom/dom/dom-document.xml — `$children` プロパティへの参照を追加
  1. php/doc-en@34314b7c6e
- reference/dom/dom/dom-documentfragment.xml — `$children` プロパティへの参照を追加
  1. php/doc-en@34314b7c6e

### reference/pdo・reference/pgsql（4件）

- reference/pdo/pdo/getattribute.xml — PHP 8.4.0 の changelog を追加
  1. php/doc-en@91183ddf1c
- reference/pgsql/functions/pg-fetch-result.xml — 2 引数のシグネチャ非推奨の changelog を追加
  1. php/doc-en@91183ddf1c
- reference/pgsql/functions/pg-field-is-null.xml — 2 引数のシグネチャ非推奨の changelog を追加
  1. php/doc-en@91183ddf1c
- reference/pgsql/functions/pg-field-prtlen.xml — 2 引数のシグネチャ非推奨の changelog を追加
  1. php/doc-en@91183ddf1c

### reference/reflection（3件）

- reference/reflection/reflectionconstant/getattributes.xml — 新規翻訳（PHP 8.5）
  1. php/doc-en@543f982554
- reference/reflection/reflectionproperty/getmangledname.xml — 新規翻訳（PHP 8.5）
  1. php/doc-en@844a420240
- reference/reflection/reflectionzendextension.xml — クラス概要の説明を追加
  1. php/doc-en@4d17b7b494
  2. php/doc-en@9915419405

### reference/sodium（4件）

`SodiumException` をスローするため `false` は返さない旨、返り値の記述の誤りを原文に合わせて修正。

- reference/sodium/functions/sodium-crypto-aead-chacha20poly1305-encrypt.xml
  1. php/doc-en@cc7976fa40
- reference/sodium/functions/sodium-crypto-aead-chacha20poly1305-ietf-encrypt.xml
  1. php/doc-en@cc7976fa40
- reference/sodium/functions/sodium-crypto-aead-xchacha20poly1305-ietf-encrypt.xml
  1. php/doc-en@cc7976fa40
- reference/sodium/functions/sodium-crypto-stream-xchacha20-xor-ic.xml
  1. php/doc-en@cc7976fa40

### reference/curl（2件）

- reference/curl/constants_curl_getinfo.xml — 非推奨になった定数と代替を追記
  1. php/doc-en@5cdc4c9977
- reference/curl/constants_curl_setopt.xml — 非推奨になった定数と代替を追記
  1. php/doc-en@5cdc4c9977

### reference/ldap（3件）

- reference/ldap/constants.xml — RFC 4528 の URL の誤りを原文に合わせて修正
  1. php/doc-en@10e6a2b042
- reference/ldap/functions/ldap-exop.xml — シグネチャをスタブに合わせて修正
  1. php/doc-en@6400027855
- reference/ldap/functions/ldap-count-entries.xml — エラー時の返り値が `-1` であることを明記
  1. php/doc-en@cf27955fcb

### 独立ファイル（7件）

- reference/libxml/constants.xml — `LIBXML_PARSEHUGE` に caution を追加し、「制限を撤廃する」を「制限を引き上げる」に修正
  1. php/doc-en@77ae1d1908
  2. php/doc-en@7dce591042
- reference/pcntl/functions/pcntl-setcpuaffinity.xml — `&return.falseproblem;` を削除
  1. php/doc-en@74b6239160
- install/windows/commandline.xml — 失効した Microsoft のリンクを除去
  1. php/doc-en@10e6a2b042
- chapters/intro.xml — 廃れた WDDX と Java 連携の記述を削除
  1. php/doc-en@0bae88c196
- features/commandline.xml — ビルトインウェブサーバの「Windows では非対応」注記の対象を複数ワーカーに限定し、スケルトンコメントを削除
  1. php/doc-en@c62ef37e0d
  2. php/doc-en@07b2f1dcff
- appendices/migration84/constants.xml — `CURL_TCP_KEEPCNT` を `CURLOPT_TCP_KEEPCNT` に修正
  1. php/doc-en@d0ac0a55fc
- language/types/relative-class-types.xml — EN-Revision の更新のみ（原文の変更は `$Revision$` コメントの追加だけ）
  1. php/doc-en@339ba3f0f4
