### PR TITLE
doc-en と同期し 7 モジュールを完訳（既訳更新 20 件）

### DIFF
--- a/language/predefined/attributes/returntypewillchange.xml
+++ b/language/predefined/attributes/returntypewillchange.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 0019a7e201442447fd746c2852d28ba839ed15ae Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 52e88759354dd18104d8c067780be9f582f20136 Maintainer: mumumu Status: ready -->
 <reference xml:id="class.returntypewillchange" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>ReturnTypeWillChange アトリビュート</title>
  <titleabbrev>ReturnTypeWillChange</titleabbrev>
@@ -10,31 +10,47 @@
   <section xml:id="returntypewillchange.intro">
    &reftitle.intro;
    <simpara>
+    PHP 8.1.0 以降、内部クラスのメソッドが戻り値の型を宣言するようになる、
+    暫定的な移行フェーズが始まりました。
+   </simpara>
+
+   <simpara>
     ほとんどの final でない内部メソッドは、
-    それをオーバライドする際、
+    それをオーバーライドする際、
     互換性がある戻り値の型を宣言することが必須になっています。
     そうしない場合、継承が有効かを検証する際に、
-    推奨されない警告が発生します。
-    これは、暫定的な戻り値の型のフェーズを導入するものです。
-    つまり、戻り値の型に互換性がない場合、将来のバージョンでそれが強制されるまでは、
-    エンジンは致命的なエラーではなく、推奨されない警告を発生させます。
+    シグネチャが共変性のルールに違反しているという推奨されない警告が発生します。
+   </simpara>
+
+   <simpara>
+    将来のバージョンの PHP では、メソッドのシグネチャが厳密にチェックされるようになり、
+    互換性がない場合は致命的なエラーが発生するようになります。
+   </simpara>
+
+   <simpara>
     PHP のバージョン間の互換性を保ちたいがために、
-    戻り値の型を宣言できない場合、
+    戻り値の型を宣言できない場合や、
+    オーバーライドするメソッドが互換性のない戻り値の型を宣言している場合は、
     アトリビュート <code>#[\ReturnTypeWillChange]</code>
     を追加することで警告を抑止できます。
    </simpara>
 
    <warning>
     <simpara>
+     ユーザー定義のクラスで定義されたメソッドをオーバーライドする場合、
+     戻り値の型は厳密にチェックされます。
+     オーバーライドするメソッドにこのアトリビュートが指定されていても、
+     型に互換性がない場合は致命的なエラーが発生します。
+    </simpara>
+
+    <simpara>
      <classname>ReturnTypeWillChange</classname> アトリビュートが推奨されない警告を抑止するのは、
      暫定的な戻り値の型のフェーズの間<emphasis>だけ</emphasis>です。
-     ユーザー定義のクラスで定義されたメソッドをオーバーライドする場合には、何の効果もありません。
-     内部メソッドが strict な型を採用すると、
-     オーバーライドするメソッドのシグネチャの不一致は致命的なエラーを引き起こすようになり、
-     このアトリビュートは何の効果も持たなくなります。
+     厳密な型チェックが強制されるようになると、このアトリビュートは機能しなくなり、
+     内部クラスのメソッドをオーバーライドする際にシグネチャの互換性がないと、
+     致命的なエラーが発生するようになります。
     </simpara>
    </warning>
-
   </section>
 
   <section xml:id="returntypewillchange.synopsis">
@@ -48,9 +64,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.returntypewillchange')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReturnTypeWillChange'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.returntypewillchange')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReturnTypeWillChange'])"/>
    </classsynopsis>
 
   </section>

--- a/reference/array/functions/array-merge.xml
+++ b/reference/array/functions/array-merge.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 2e60c5134e7a847c99f81eb3f7ecee1f5efeeace Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 52209b319aabbecad59f887b6dff3fb15156f1ff Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: shimooka,mumumu -->
 <refentry xml:id="function.array-merge" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -83,11 +83,13 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-$array1 = array("color" => "red", 2, 4);
-$array2 = array("a", "b", "color" => "green", "shape" => "trapezoid", 4);
+
+$array1 = ["color" => "red", 2, 4];
+$array2 = ["a", "b", "color" => "green", "shape" => "trapezoid", 4];
+
 $result = array_merge($array1, $array2);
+
 print_r($result);
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -113,11 +115,13 @@ Array
     <programlisting role="php">
 <![CDATA[
 <?php
-$array1 = array();
-$array2 = array(1 => "data");
+
+$array1 = [];
+$array2 = [1 => "data"];
+
 $result = array_merge($array1, $array2);
+
 print_r($result);
-?>
 ]]>
     </programlisting>
     <para>
@@ -140,11 +144,13 @@ Array
     <programlisting role="php">
 <![CDATA[
 <?php
-$array1 = array(0 => 'zero_a', 2 => 'two_a', 3 => 'three_a');
-$array2 = array(1 => 'one_b', 3 => 'three_b', 4 => 'four_b');
+
+$array1 = [0 => 'zero_a', 2 => 'two_a', 3 => 'three_a'];
+$array2 = [1 => 'one_b', 3 => 'three_b', 4 => 'four_b'];
+
 $result = $array1 + $array2;
+
 var_dump($result);
-?>
 ]]>
     </programlisting>
     <para>
@@ -166,31 +172,6 @@ array(5) {
   [4]=>
   string(6) "four_b"
 }
-]]>
-    </screen>
-   </example>
-  </para>
-  <para>
-   <example>
-    <title><function>array_merge</function> で配列以外の型を扱う例</title>
-    <programlisting role="php">
-<![CDATA[
-<?php
-$beginning = 'foo';
-$end = array(1 => 'bar');
-$result = array_merge((array) $beginning, (array) $end);
-print_r($result);
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen role="php">
-<![CDATA[
-Array
-(
-    [0] => foo
-    [1] => bar
-)
 ]]>
     </screen>
    </example>

--- a/reference/exec/functions/exec.xml
+++ b/reference/exec/functions/exec.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: b412bbd26214f7281ac7dd858710e09952a275f2 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 462dddda87baa86fd760dcb1e3a0d2096e00a59b Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: shimooka,mumumu -->
 <!-- splitted from ./en/functions/exec.xml, last change in rev 1.2 -->
 <refentry xml:id="function.exec" xmlns="http://docbook.org/ns/docbook">
@@ -130,10 +130,8 @@
 <?php
 // ("whoami" コマンドをパスに有するシステム上で)
 // 実行中のphp/httpdプロセスを所有するユーザーの名前を出力
-$output=null;
-$retval=null;
-exec('whoami', $output, $retval);
-echo "Returned with status $retval and output:\n";
+exec('whoami', $output, $result_code);
+echo "Returned with status $result_code and output:\n";
 print_r($output);
 ?>
 ]]>

--- a/reference/imagick/imagickdrawexception.xml
+++ b/reference/imagick/imagickdrawexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4947a993e6d5050f4271f3c5eb7b1cd4b7c1c2e4 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 1fe6141098fa1ea26b0030cc9cbd3a8516c25961 Maintainer: mumumu Status: ready -->
 <reference role="exception" xml:id="class.imagickdrawexception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>The ImagickDrawException class</title>
  <titleabbrev>ImagickDrawException</titleabbrev>
@@ -40,20 +40,12 @@
      </oointerface>
     </classsynopsisinfo>
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('exception.synopsis')/descendant::db:fieldsynopsis)">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('exception.synopsis')/descendant::db:fieldsynopsis)"/>
 
-
-    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.imagickdrawexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ImagickDrawException'])">
-     <xi:fallback/>
-    </xi:include>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ImagickDrawException'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
 
    </classsynopsis>
 <!-- }}} -->

--- a/reference/imagick/imagickexception.xml
+++ b/reference/imagick/imagickexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4947a993e6d5050f4271f3c5eb7b1cd4b7c1c2e4 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 1fe6141098fa1ea26b0030cc9cbd3a8516c25961 Maintainer: mumumu Status: ready -->
 <reference role="exception" xml:id="class.imagickexception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>The ImagickException class</title>
  <titleabbrev>ImagickException</titleabbrev>
@@ -40,20 +40,12 @@
      </oointerface>
     </classsynopsisinfo>
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('exception.synopsis')/descendant::db:fieldsynopsis)">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('exception.synopsis')/descendant::db:fieldsynopsis)"/>
 
-
-    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.imagickexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ImagickException'])">
-     <xi:fallback/>
-    </xi:include>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ImagickException'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
 
    </classsynopsis>
 <!-- }}} -->

--- a/reference/imagick/imagickkernelexception.xml
+++ b/reference/imagick/imagickkernelexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4947a993e6d5050f4271f3c5eb7b1cd4b7c1c2e4 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 1fe6141098fa1ea26b0030cc9cbd3a8516c25961 Maintainer: mumumu Status: ready -->
 
 <reference xml:id="class.imagickkernelexception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -38,20 +38,12 @@
     </classsynopsisinfo>
 <!-- }}} -->
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('exception.synopsis')/descendant::db:fieldsynopsis)">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('exception.synopsis')/descendant::db:fieldsynopsis)"/>
 
-
-    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.imagickkernelexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ImagickKernelException'])">
-     <xi:fallback/>
-    </xi:include>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ImagickKernelException'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
 
    </classsynopsis>
 <!-- }}} -->

--- a/reference/imagick/imagickpixelexception.xml
+++ b/reference/imagick/imagickpixelexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4947a993e6d5050f4271f3c5eb7b1cd4b7c1c2e4 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 1fe6141098fa1ea26b0030cc9cbd3a8516c25961 Maintainer: mumumu Status: ready -->
 <reference role="exception" xml:id="class.imagickpixelexception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>The ImagickPixelException class</title>
  <titleabbrev>ImagickPixelException</titleabbrev>
@@ -40,20 +40,12 @@
      </oointerface>
     </classsynopsisinfo>
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('exception.synopsis')/descendant::db:fieldsynopsis)">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('exception.synopsis')/descendant::db:fieldsynopsis)"/>
 
-
-    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.imagickpixelexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ImagickPixelException'])">
-     <xi:fallback/>
-    </xi:include>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ImagickPixelException'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
 
    </classsynopsis>
 <!-- }}} -->

--- a/reference/imagick/imagickpixeliteratorexception.xml
+++ b/reference/imagick/imagickpixeliteratorexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4947a993e6d5050f4271f3c5eb7b1cd4b7c1c2e4 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 1fe6141098fa1ea26b0030cc9cbd3a8516c25961 Maintainer: mumumu Status: ready -->
 <reference role="exception" xml:id="class.imagickpixeliteratorexception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>The ImagickPixelIteratorException class</title>
  <titleabbrev>ImagickPixelIteratorException</titleabbrev>
@@ -40,20 +40,12 @@
      </oointerface>
     </classsynopsisinfo>
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('exception.synopsis')/descendant::db:fieldsynopsis)">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('exception.synopsis')/descendant::db:fieldsynopsis)"/>
 
-
-    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.imagickpixeliteratorexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ImagickPixelIteratorException'])">
-     <xi:fallback/>
-    </xi:include>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ImagickPixelIteratorException'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
 
    </classsynopsis>
 <!-- }}} -->

--- a/reference/intl/functions/intl-get-error-message.xml
+++ b/reference/intl/functions/intl-get-error-message.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: fed3682684f1af372dc9a7f15d0468e5a884ab16 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: d5e705df751e5d590449c2f910be5753896a7722 Maintainer: takagi Status: ready -->
 <refentry xml:id="function.intl-get-error-message">
  <refnamediv>
   <refname>intl_get_error_message</refname>
@@ -32,20 +32,30 @@
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example>
-    <title><function>intl_get_error_message</function> の例</title>
-    <programlisting role="php">
+  <example>
+   <title><function>intl_get_error_message</function> の例</title>
+   <programlisting role="php">
 <![CDATA[
 <?php
-if( Collator::getAvailableLocales() === false ) {
-    show_error( intl_get_error_message() );
+
+$bundle = resourcebundle_create('en_US', __DIR__ . '/does-not-exist', false);
+
+if ($bundle === null) {
+    $errorCode = intl_get_error_code();
+
+    printf("Error name: %s\n", intl_error_name($errorCode));
+    printf("Error message: %s\n", intl_get_error_message());
 }
-?>
 ]]>
-    </programlisting>
-   </example>
-  </para>
+   </programlisting>
+  </example>
+  &example.outputs;
+  <screen>
+<![CDATA[
+Error name: U_MISSING_RESOURCE_ERROR
+Error message: resourcebundle_create(): Cannot load libICU resource bundle: U_MISSING_RESOURCE_ERROR
+]]>
+  </screen>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/reflection/reflectionfunctionabstract/gettentativereturntype.xml
+++ b/reference/reflection/reflectionfunctionabstract/gettentativereturntype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ec2fe9a592f794978114ef5021db9f1d00c2e05d Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 52e88759354dd18104d8c067780be9f582f20136 Maintainer: mumumu Status: ready -->
 <refentry xml:id="reflectionfunctionabstract.gettentativereturntype" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ReflectionFunctionAbstract::getTentativeReturnType</refname>
@@ -13,9 +13,9 @@
    <modifier>public</modifier> <type class="union"><type>ReflectionType</type><type>null</type></type><methodname>ReflectionFunctionAbstract::getTentativeReturnType</methodname>
    <void/>
   </methodsynopsis>
-  <para>
-   関数に関連付けられた仮の戻り値の型を返します。
-  </para>
+  <simpara>
+   関数に関連付けられた<link linkend="class.returntypewillchange">仮の戻り値の型</link>を返します。
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/reflection/reflectionfunctionabstract/hastentativereturntype.xml
+++ b/reference/reflection/reflectionfunctionabstract/hastentativereturntype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ec2fe9a592f794978114ef5021db9f1d00c2e05d Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 52e88759354dd18104d8c067780be9f582f20136 Maintainer: mumumu Status: ready -->
 <refentry xml:id="reflectionfunctionabstract.hastentativereturntype" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ReflectionFunctionAbstract::hasTentativeReturnType</refname>
@@ -13,9 +13,9 @@
    <modifier>public</modifier> <type>bool</type><methodname>ReflectionFunctionAbstract::hasTentativeReturnType</methodname>
    <void/>
   </methodsynopsis>
-  <para>
-   関数が戻り値の型を仮で(とりあえず)宣言しているかどうかを返します。
-  </para>
+  <simpara>
+   関数が<link linkend="class.returntypewillchange">仮の戻り値の型</link>を宣言しているかどうかを返します。
+  </simpara>
 
  </refsect1>
 
@@ -27,7 +27,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   関数が仮の(とりあえず)戻り値の型を持つ場合、&true; を返します。
+   関数が仮の戻り値の型を持つ場合、&true; を返します。
    そうでない場合、&false; を返します。
   </para>
  </refsect1>

--- a/reference/snmp/functions/snmp2-getnext.xml
+++ b/reference/snmp/functions/snmp2-getnext.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 40906725410aac6fe8cac4913a557a1784bf04b9 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 84534c795fc64cc1866ae267fec3574249ec5f74 Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.snmp2-getnext">
  <refnamediv>
@@ -19,7 +19,7 @@
    <methodparam choice="opt"><type>int</type><parameter>retries</parameter><initializer>-1</initializer></methodparam>
   </methodsynopsis>
   <simpara>
-   <function>snmp2_get_next</function> 関数は、
+   <function>snmp2_getnext</function> 関数は、
    <parameter>object_id</parameter> で指定したオブジェクトに続く
    <acronym>SNMP</acronym> オブジェクトの値を取得します。
   </simpara>
@@ -83,11 +83,11 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title><function>snmp2_get_next</function> の使用法</title>
+   <title><function>snmp2_getnext</function> の使用法</title>
    <programlisting role="php">
 <![CDATA[
 <?php
-$nameOfSecondInterface = snmp2_get_next('localhost', 'public', 'IF-MIB::ifName.1');
+$nameOfSecondInterface = snmp2_getnext('localhost', 'public', 'IF-MIB::ifName.1');
 ?>
 ]]>
    </programlisting>

--- a/reference/soap/soapclient/getlastrequestheaders.xml
+++ b/reference/soap/soapclient/getlastrequestheaders.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: fe4e8b87d18f17394e7177917c498774b062448c Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 84534c795fc64cc1866ae267fec3574249ec5f74 Maintainer: takagi Status: ready -->
 <!-- CREDITS: shimooka -->
 
 <refentry xml:id="soapclient.getlastrequestheaders" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -46,7 +46,7 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-$client = SoapClient("some.wsdl", array('trace' => 1));
+$client = new SoapClient("some.wsdl", array('trace' => 1));
 $result = $client->SomeFunction();
 echo "REQUEST HEADERS:\n" . $client->__getLastRequestHeaders() . "\n";
 ?>

--- a/reference/soap/soapclient/getlastresponse.xml
+++ b/reference/soap/soapclient/getlastresponse.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: fe4e8b87d18f17394e7177917c498774b062448c Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 84534c795fc64cc1866ae267fec3574249ec5f74 Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa,shimooka -->
 
 <refentry xml:id="soapclient.getlastresponse" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -46,7 +46,7 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-$client = SoapClient("some.wsdl", array('trace' => 1));
+$client = new SoapClient("some.wsdl", array('trace' => 1));
 $result = $client->SomeFunction();
 echo "Response:\n" . $client->__getLastResponse() . "\n";
 ?>

--- a/reference/soap/soapclient/getlastresponseheaders.xml
+++ b/reference/soap/soapclient/getlastresponseheaders.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: fe4e8b87d18f17394e7177917c498774b062448c Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 84534c795fc64cc1866ae267fec3574249ec5f74 Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa,shimooka -->
 
 <refentry xml:id="soapclient.getlastresponseheaders" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -46,7 +46,7 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-$client = SoapClient("some.wsdl", array('trace' => 1));
+$client = new SoapClient("some.wsdl", array('trace' => 1));
 $result = $client->SomeFunction();
 echo "RESPONSE HEADERS:\n" . $client->__getLastResponseHeaders() . "\n";
 ?>

--- a/reference/soap/soapserver/getlastresponse.xml
+++ b/reference/soap/soapserver/getlastresponse.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 7e1f81cbbe7613ce7bbe65cc93c45fae38e0942b Maintainer: ippey Status: ready -->
+<!-- EN-Revision: 84534c795fc64cc1866ae267fec3574249ec5f74 Maintainer: ippey Status: ready -->
 <!-- CREDITS: ippey -->
 
 <refentry xml:id="soapserver.getlastresponse" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -45,7 +45,7 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$server = SoapServer("some.wsdl", ["trace" => 1]);
+$server = new SoapServer("some.wsdl", ["trace" => 1]);
 $server->handle();
 echo "Response:\n" . $server->__getLastResponse() . "\n";
 ?>

--- a/reference/ssh2/functions/ssh2-sftp-lstat.xml
+++ b/reference/ssh2/functions/ssh2-sftp-lstat.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 12f0e72200ea9249d0fc2f118528bd24b24c44a6 Maintainer: shimooka Status: ready -->
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.ssh2-sftp-lstat">
+<!-- EN-Revision: cad275c0c1bac225cc295e2ee52ecf2564b6fcda Maintainer: shimooka Status: ready -->
+<refentry xml:id="function.ssh2-sftp-lstat" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ssh2_sftp_lstat</refname>
   <refpurpose>シンボリックリンクの情報を取得する</refpurpose>
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>array</type><methodname>ssh2_sftp_lstat</methodname>
+   <type class="union"><type>array</type><type>false</type></type><methodname>ssh2_sftp_lstat</methodname>
    <methodparam><type>resource</type><parameter>sftp</parameter></methodparam>
    <methodparam><type>string</type><parameter>path</parameter></methodparam>
   </methodsynopsis>
@@ -50,6 +50,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
+   成功した場合、指定したシンボリックリンクの統計情報の配列を返します。
+   &return.falseforfailure;。
    戻り値の詳細については
    <function>stat</function> のドキュメントを参照ください。
   </simpara>

--- a/reference/ssh2/functions/ssh2-sftp-readlink.xml
+++ b/reference/ssh2/functions/ssh2-sftp-readlink.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 12f0e72200ea9249d0fc2f118528bd24b24c44a6 Maintainer: shimooka Status: ready -->
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.ssh2-sftp-readlink">
+<!-- EN-Revision: cad275c0c1bac225cc295e2ee52ecf2564b6fcda Maintainer: shimooka Status: ready -->
+<refentry xml:id="function.ssh2-sftp-readlink" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ssh2_sftp_readlink</refname>
   <refpurpose>シンボリックリンクのターゲットを返す</refpurpose>
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>string</type><methodname>ssh2_sftp_readlink</methodname>
+   <type class="union"><type>string</type><type>false</type></type><methodname>ssh2_sftp_readlink</methodname>
    <methodparam><type>resource</type><parameter>sftp</parameter></methodparam>
    <methodparam><type>string</type><parameter>link</parameter></methodparam>
   </methodsynopsis>
@@ -44,7 +44,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   シンボリックリンク <parameter>link</parameter> のターゲットを返します。
+   シンボリックリンク <parameter>link</parameter> のターゲットを返します。&return.falseforfailure;。
   </simpara>
  </refsect1>
 

--- a/reference/ssh2/functions/ssh2-sftp-realpath.xml
+++ b/reference/ssh2/functions/ssh2-sftp-realpath.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 12f0e72200ea9249d0fc2f118528bd24b24c44a6 Maintainer: shimooka Status: ready -->
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.ssh2-sftp-realpath">
+<!-- EN-Revision: cad275c0c1bac225cc295e2ee52ecf2564b6fcda Maintainer: shimooka Status: ready -->
+<refentry xml:id="function.ssh2-sftp-realpath" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ssh2_sftp_realpath</refname>
   <refpurpose>指定されたパス文字列の実パスを解決する</refpurpose>
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>string</type><methodname>ssh2_sftp_realpath</methodname>
+   <type class="union"><type>string</type><type>false</type></type><methodname>ssh2_sftp_realpath</methodname>
    <methodparam><type>resource</type><parameter>sftp</parameter></methodparam>
    <methodparam><type>string</type><parameter>filename</parameter></methodparam>
   </methodsynopsis>
@@ -44,7 +44,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   実際のパスを表す文字列を返します。
+   実際のパスを表す文字列を返します。&return.falseforfailure;。
   </simpara>
  </refsect1>
 

--- a/reference/ssh2/functions/ssh2-sftp-stat.xml
+++ b/reference/ssh2/functions/ssh2-sftp-stat.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 12f0e72200ea9249d0fc2f118528bd24b24c44a6 Maintainer: shimooka Status: ready -->
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.ssh2-sftp-stat">
+<!-- EN-Revision: cad275c0c1bac225cc295e2ee52ecf2564b6fcda Maintainer: shimooka Status: ready -->
+<refentry xml:id="function.ssh2-sftp-stat" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ssh2_sftp_stat</refname>
   <refpurpose>リモートファイルシステム上のファイルの情報を取得する</refpurpose>
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>array</type><methodname>ssh2_sftp_stat</methodname>
+   <type class="union"><type>array</type><type>false</type></type><methodname>ssh2_sftp_stat</methodname>
    <methodparam><type>resource</type><parameter>sftp</parameter></methodparam>
    <methodparam><type>string</type><parameter>path</parameter></methodparam>
   </methodsynopsis>
@@ -49,6 +49,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
+   成功した場合、指定したファイルの統計情報の配列を返します。
+   &return.falseforfailure;。
    どのような値が返されるのかについての詳細は、
    <function>stat</function> を参照ください。
   </simpara>


### PR DESCRIPTION
doc-en の更新に追随し、20 ファイルを同期しました。これにより intl・reflection・imagick・array・snmp・exec・soap の 7 モジュールが完訳になります。

## 訳文の変更を伴う同期（7ファイル）

### ReturnTypeWillChange の説明の改稿 — php/doc-en@52e8875935 / php/doc-en@603435cd84

暫定的な戻り値の型のフェーズについての説明が書き直され、ユーザー定義クラスのメソッドをオーバーライドする場合の挙動が独立した段落になりました。空の `xi:fallback` の除去もあわせて反映しています。

- language/predefined/attributes/returntypewillchange.xml
- reference/reflection/reflectionfunctionabstract/ (2) — getTentativeReturnType・hasTentativeReturnType。説明文に `class.returntypewillchange` へのリンクが追加されました

### ssh2_sftp_* の戻り値型への false の追加 — php/doc-en@cad275c0c1

失敗時に `false` を返す旨が、シグネチャと戻り値の節の両方に追加されました。

- reference/ssh2/functions/ (4) — lstat・readlink・realpath・stat

## コード例・マークアップのみの同期（13ファイル・訳文の変更なし）

### 例外クラスの methodsynopsis xpointer の誤りを修正 — php/doc-en@1fe6141098

自前のメソッドを持たない例外クラスで、`&Methods;` の include が存在しない refentry を指しており、`&InheritedMethods;` も role にクラス名自身を使っていたため、どちらも空のノードセットを選択していました。原文と同じく `&Methods;` を削除し、role を `Exception` に修正しています。

- reference/imagick/ (5) — Imagick・ImagickDraw・ImagickKernel・ImagickPixel・ImagickPixelIterator の各 Exception

### サンプルコードの `new` 演算子の欠落を修正 — php/doc-en@84534c795f

- reference/soap/ (4) — soapclient の getlastrequestheaders・getlastresponse・getlastresponseheaders、soapserver の getlastresponse

### 関数名の誤りを修正（`snmp2_get_next` → `snmp2_getnext`） — php/doc-en@84534c795f

- reference/snmp/functions/snmp2-getnext.xml

### コード例の修正

- reference/array/functions/array-merge.xml — 短縮配列構文への変更と、`(array)` キャストの例の削除 — php/doc-en@52209b319a
- reference/exec/functions/exec.xml — 不要な初期化の削除と、`$retval` の `$result_code` への改名 — php/doc-en@462dddda87
- reference/intl/functions/intl-get-error-message.xml — サンプルの差し替えと出力例の追加 — php/doc-en@d5e705df75
