### PR TITLE
doc-en と同期し control-structures のコード例を実行可能な形式に更新（16ファイル）

### DIFF
--- a/language/control-structures.xml
+++ b/language/control-structures.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ede9d209f64d4cd71bf22fcfaed14c6fc269523c Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi,shimooka,mumumu -->
-<chapter xml:id="language.control-structures" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<chapter xml:id="language.control-structures" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="interactive">
  <title>制御構造</title>
 
  <sect1 xml:id="control-structures.intro">

--- a/language/control-structures/alternative-syntax.xml
+++ b/language/control-structures/alternative-syntax.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 22583751fbfdaa3eaa41aeb6470d1343f5cb2c78 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: takagi Status: ready -->
 
 <sect1 xml:id="control-structures.alternative-syntax"  xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>制御構造に関する別の構文</title>
@@ -18,11 +18,19 @@
   <informalexample>
    <programlisting role="php">
 <![CDATA[
-<?php if ($a == 5): ?>
+<?php
+$a = 5;
+if ($a == 5): ?>
 Aは5に等しい
 <?php endif; ?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+Aは5に等しい
+]]>
+   </screen>
   </informalexample>
  </para>
  <simpara>
@@ -39,6 +47,7 @@ Aは5に等しい
    <programlisting role="php">
 <![CDATA[
 <?php
+$a = 5;
 if ($a == 5):
     echo "aは5に等しい";
     echo "...";
@@ -48,9 +57,14 @@ elseif ($a == 6):
 else:
     echo "aは5でも6でもない";
 endif;
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+aは5に等しい...
+]]>
+   </screen>
   </informalexample>
  </para>
  <note>
@@ -67,12 +81,20 @@ endif;
   <informalexample>
    <programlisting role="php">
 <![CDATA[
-<?php switch ($foo): ?>
+<?php
+$foo = 1;
+switch ($foo): ?>
     <?php case 1: ?>
-    // ...
+    Fooは1
 <?php endswitch; ?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+Parse error: syntax error, unexpected T_INLINE_HTML "    ", expecting "endswitch" or "case" or "default" in script on line 4
+]]>
+   </screen>
   </informalexample>
   <para>
    一方、以下のコードは有効です。というのも、
@@ -84,12 +106,20 @@ endif;
   <informalexample>
    <programlisting role="php">
 <![CDATA[
-<?php switch ($foo): ?>
+<?php
+$foo = 1;
+switch ($foo): ?>
 <?php case 1: ?>
-    ...
+    Fooは1
 <?php endswitch; ?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+    Fooは1
+]]>
+   </screen>
   </informalexample>
  </warning>
  <para>

--- a/language/control-structures/break.xml
+++ b/language/control-structures/break.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 7104ee97ced1768a3231588dfc0bc0d7eb1117ad Maintainer: takagi Status: ready -->
+<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: takagi Status: ready -->
 <!-- CREDITS: mumumu -->
 
 <sect1 xml:id="control-structures.break" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -27,27 +27,61 @@ foreach ($arr as $val) {
     if ($val == 'stop') {
         break;    /* ここでは、'break 1;'と書くこともできます */
     }
-    echo "$val<br />\n";
+    echo "$val\n";
 }
-
-/* オプション引数を使用します */
-
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+one
+two
+three
+four
+]]>
+   </screen>
+  </informalexample>
+ </para>
+ <simpara>
+  オプションの引数を使う例:
+ </simpara>
+ <para>
+  <informalexample>
+   <programlisting role="php">
+<![CDATA[
+<?php
 $i = 0;
 while (++$i) {
     switch ($i) {
         case 5:
-            echo "At 5<br />\n";
+            echo "At 5\n";
             break 1;  /* switch 構造のみを抜けます */
         case 10:
-            echo "At 10; quitting<br />\n";
+            echo "At 10; quitting\n";
             break 2;  /* switch と while を抜けます */
         default:
             break;
     }
+    echo "$i\n";
 }
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+1
+2
+3
+4
+At 5
+5
+6
+7
+8
+9
+At 10; quitting
+]]>
+   </screen>
   </informalexample>
  </para>
 

--- a/language/control-structures/continue.xml
+++ b/language/control-structures/continue.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 16389a7b31069481d6c8c0705172bee5ef1ddf5f Maintainer: takagi Status: ready -->
+<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 
 <sect1 xml:id="control-structures.continue" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -40,7 +40,6 @@ foreach ($arr as $key => $value) {
     }
     echo $value . "\n";
 }
-?>
 ]]>
    </programlisting>
    &examples.outputs;
@@ -67,7 +66,6 @@ while ($i++ < 5) {
     }
     echo "Neither does this.\n";
 }
-?>
 ]]>
    </programlisting>
    &examples.outputs;
@@ -90,36 +88,6 @@ Middle
 Inner
 ]]>
    </screen>
-   </informalexample>
-  </para>
-  <para>
-   <literal>continue</literal> の後のセミコロンを省略すると混乱を生じることがあります。
-   以下の例のようなことをしてはいけません。
-  </para>
-  <para>
-   <informalexample>
-    <programlisting role="php">
-<![CDATA[
-<?php
-for ($i = 0; $i < 5; ++$i) {
-    if ($i == 2)
-        continue
-    print "$i\n";
-}
-?>
-]]>
-    </programlisting>
-    <para>
-     これは、以下のような結果になることを期待していたのでしょう。
-    </para>
-    <screen>
-<![CDATA[
-0
-1
-3
-4
-]]>
-    </screen>
    </informalexample>
   </para>
   <para>

--- a/language/control-structures/declare.xml
+++ b/language/control-structures/declare.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 5499acf9df7e1338d540bde207acc859792cd139 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 
 <sect1 xml:id="control-structures.declare" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -36,7 +36,7 @@ declare (ディレクティブ)
   ディレクティブの値として渡せるのは、リテラルだけとなります。
   変数や定数は、使えません。以下に例を示します。
   <informalexample>
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 // これは有効です
@@ -45,7 +45,6 @@ declare(ticks=1);
 // これは無効です
 const TICK_VALUE = 1;
 declare(ticks=TICK_VALUE);
-?>
 ]]>
    </programlisting>
   </informalexample>
@@ -61,7 +60,7 @@ declare(ticks=TICK_VALUE);
   (しかし、<literal>declare</literal> を含むファイルがインクルードされた場合は、
   親ファイルにはその影響は及びません)。
   <informalexample>
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 // 以下は同じ意味です
@@ -74,7 +73,6 @@ declare(ticks=1) {
 // こうすることもできます
 declare(ticks=1);
 // ここにすべてのスクリプトを書きます
-?>
 ]]>
    </programlisting>
   </informalexample>
@@ -119,12 +117,20 @@ $a = 1; // tick イベント発生
 
 if ($a > 0) {
     $a += 2;   // tick イベント発生
-    print $a; // tick イベント発生
+    print $a . "\n"; // tick イベント発生
 }
-
-?>
 ]]>
    </programlisting>
+  &example.outputs;
+   <screen>
+<![CDATA[
+tick_handler() called
+tick_handler() called
+tick_handler() called
+3
+tick_handler() called
+]]>
+   </screen>
   </example>
  </para>
  <simpara>
@@ -139,12 +145,11 @@ if ($a > 0) {
     <literal>encoding</literal> ディレクティブを使用します。
   <example>
    <title>スクリプトのエンコーディングの宣言</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 declare(encoding='ISO-8859-1');
 // ここにコードを書きます
-?>
 ]]>
     </programlisting>
    </example>

--- a/language/control-structures/do-while.xml
+++ b/language/control-structures/do-while.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 53fb200fed6d316b0616a915eb87a40de1d80f51 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 
 <sect1 xml:id="control-structures.do.while" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -27,9 +27,14 @@ $i = 0;
 do {
     echo $i;
 } while ($i > 0);
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+0
+]]>
+   </screen>
   </informalexample>
  </para>
  <simpara>
@@ -48,23 +53,32 @@ do {
    <programlisting role="php">
 <![CDATA[
 <?php
+$i = 50;
+$factor = 0.5;
+$minimum_limit = 20;
 do {
     if ($i < 5) {
-        echo "i は十分大きくはありません。";
+        echo "i は十分大きくはありません。\n";
         break;
     }
     $i *= $factor;
     if ($i < $minimum_limit) {
+        echo "factor をかけた後、i は最小の制限値より小さいです。\n";
         break;
     }
-    echo "iはOKです。";
+    echo $i ."はOKです。\n";
 
     /* i を処理します */
 
 } while (0);
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+25はOKです。
+]]>
+   </screen>
   </informalexample>
  </para>
  <simpara>

--- a/language/control-structures/else.xml
+++ b/language/control-structures/else.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 3725fe1c95b201563518c30e1988b2f32ee099aa Maintainer: takagi Status: ready -->
+<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: takagi Status: ready -->
 
 <sect1 xml:id="control-structures.else" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>else</title>
@@ -22,14 +22,21 @@
    <programlisting role="php">
 <![CDATA[
 <?php
+$a = 3;
+$b = 5;
 if ($a > $b) {
-  echo "aはbよりも大きい";
+  echo "aはbよりも大きい\n";
 } else {
-  echo "aはbよりも大きくない";
+  echo "aはbよりも大きくない\n";
 }
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+aはbよりも大きくない
+]]>
+   </screen>
   </informalexample>
 
   <literal>else</literal> 文は、<literal>if</literal>式が
@@ -57,9 +64,14 @@ if ($a)
         echo "b";
 else
     echo "c";
-?>
 ]]>
     </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+
+]]>
+   </screen>
    </informalexample>
    どうインデントされているかに関わらず
    (PHP では、インデントは結果に影響しません)、

--- a/language/control-structures/elseif.xml
+++ b/language/control-structures/elseif.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 22583751fbfdaa3eaa41aeb6470d1343f5cb2c78 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: takagi Status: ready -->
 
 <sect1 xml:id="control-structures.elseif" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>elseif/else if</title>
@@ -20,6 +20,8 @@
    <programlisting role="php">
 <![CDATA[
 <?php
+$a = 1;
+$b = 1;
 if ($a > $b) {
     echo "aはbより大きい";
 } elseif ($a == $b) {
@@ -27,9 +29,14 @@ if ($a > $b) {
 } else {
     echo "aはbより小さい";
 }
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+aはbと等しい
+]]>
+   </screen>
   </informalexample>
  </para>
  <simpara>
@@ -62,6 +69,8 @@ if ($a > $b) {
    <programlisting role="php">
 <![CDATA[
 <?php
+$a = 3;
+$b = 1;
 
 /* 間違った方法 */
 if ($a > $b):
@@ -71,12 +80,21 @@ else if ($a == $b): // コンパイル不能
 endif;
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+Parse error: syntax error, unexpected token "if", expecting ":" in script on line 8
+]]>
+   </screen>
   </informalexample>
 
   <informalexample>
    <programlisting role="php">
 <![CDATA[
 <?php
+$a = 3;
+$b = 1;
+
 /* 正しい方法 */
 if ($a > $b):
     echo $a." is greater than ".$b;
@@ -85,10 +103,14 @@ elseif ($a == $b): // 二つの単語を分割せず組み合わせているこ�
 else:
     echo $a." is neither greater than or equal to ".$b;
 endif;
-
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+3 is greater than 1
+]]>
+   </screen>
   </informalexample>
  </para>
 </sect1>

--- a/language/control-structures/for.xml
+++ b/language/control-structures/for.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: takagi Status: ready -->
 
 <sect1 xml:id="control-structures.for" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>for</title>
@@ -48,38 +48,71 @@ for (式1; 式2; 式3)
    <programlisting role="php">
 <![CDATA[
 <?php
-/* 例 1 */
-
 for ($i = 1; $i <= 10; $i++) {
-    echo $i;
+    echo $i . " ";
 }
-
-/* 例 2 */
-
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+1 2 3 4 5 6 7 8 9 10
+]]>
+   </screen>
+  </informalexample>
+  <informalexample>
+   <programlisting role="php">
+<![CDATA[
+<?php
 for ($i = 1; ; $i++) {
     if ($i > 10) {
         break;
     }
-    echo $i;
+    echo $i . " ";
 }
-
-/* 例 3 */
-
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+1 2 3 4 5 6 7 8 9 10
+]]>
+   </screen>
+  </informalexample>
+  <informalexample>
+   <programlisting role="php">
+<![CDATA[
+<?php
 $i = 1;
 for (; ; ) {
     if ($i > 10) {
         break;
     }
-    echo $i;
+    echo $i . " ";
     $i++;
 }
-
-/* 例 4 */
-
-for ($i = 1, $j = 0; $i <= 10; $j += $i, print $i, $i++);
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+1 2 3 4 5 6 7 8 9 10
+]]>
+   </screen>
+  </informalexample>
+  <informalexample>
+   <programlisting role="php">
+<![CDATA[
+<?php
+for ($i = 1, $j = 0; $i <= 10; $j += $i, print $i . " ", $i++);
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+1 2 3 4 5 6 7 8 9 10
+]]>
+   </screen>
   </informalexample>
  </para>
  <simpara>
@@ -119,11 +152,32 @@ $people = array(
 );
 
 for($i = 0; $i < count($people); ++$i) {
-    $people[$i]['salt'] = mt_rand(000000, 999999);
+    $people[$i]['salt'] = random_int(100000, 999999);
 }
-?>
+var_dump($people);
 ]]>
    </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+array(2) {
+  [0]=>
+  array(2) {
+    ["name"]=>
+    string(5) "Kalle"
+    ["salt"]=>
+    int(454478)
+  }
+  [1]=>
+  array(2) {
+    ["name"]=>
+    string(6) "Pierre"
+    ["salt"]=>
+    int(776978)
+  }
+}
+]]>
+   </screen>
   </informalexample>
  </para>
  <simpara>
@@ -144,11 +198,32 @@ $people = array(
 );
 
 for($i = 0, $size = count($people); $i < $size; ++$i) {
-    $people[$i]['salt'] = mt_rand(000000, 999999);
+    $people[$i]['salt'] = random_int(100000, 999999);
 }
-?>
+var_dump($people);
 ]]>
    </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+array(2) {
+  [0]=>
+  array(2) {
+    ["name"]=>
+    string(5) "Kalle"
+    ["salt"]=>
+    int(454478)
+  }
+  [1]=>
+  array(2) {
+    ["name"]=>
+    string(6) "Pierre"
+    ["salt"]=>
+    int(776978)
+  }
+}
+]]>
+   </screen>
   </informalexample>
  </para>
 </sect1>

--- a/language/control-structures/foreach.xml
+++ b/language/control-structures/foreach.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ba7093cf7f30dbcd301c62536ac7ef8664d891f4 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: mumumu Status: ready -->
 <sect1 xml:id="control-structures.foreach" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>foreach</title>
  <?phpdoc print-version-for="foreach"?>
@@ -53,14 +53,14 @@ foreach (iterable_expression as $key => $value) {
 <![CDATA[
 <?php
 
-/* 例: 値のみ */
+echo "Value only\n";
 $array = [1, 2, 3, 17];
 
 foreach ($array as $value) {
     echo "Current element of \$array: $value.\n";
 }
 
-/* 例: キーと値 */
+echo "\n\nKey and value:\n";
 $array = [
     "one" => 1,
     "two" => 2,
@@ -72,7 +72,7 @@ foreach ($array as $key => $value) {
     echo "Key: $key => Value: $value\n";
 }
 
-/* 例: 多次元のキーと値の配列 */
+echo "\n\nMulti-dimensional key-value arrays:\n";
 $grid = [];
 $grid[0][0] = "a";
 $grid[0][1] = "b";
@@ -85,13 +85,44 @@ foreach ($grid as $y => $row) {
     }
 }
 
-/* Example: dynamic arrays */
+echo "\n\nDynamic arrays:\n";
 foreach (range(1, 5) as $value) {
     echo "$value\n";
 }
-?>
 ]]>
   </programlisting>
+  &example.outputs;
+  <screen>
+<![CDATA[
+Value only
+Current element of $array: 1.
+Current element of $array: 2.
+Current element of $array: 3.
+Current element of $array: 17.
+
+
+Key and value:
+Key: one => Value: 1
+Key: two => Value: 2
+Key: three => Value: 3
+Key: seventeen => Value: 17
+
+
+Multi-dimensional key-value arrays:
+Value at position x=0 and y=0: a
+Value at position x=1 and y=0: b
+Value at position x=0 and y=1: y
+Value at position x=1 and y=1: z
+
+
+Dynamic arrays:
+1
+2
+3
+4
+5
+]]>
+  </screen>
  </example>
  <note>
   <para>
@@ -141,7 +172,6 @@ foreach ($array as [$a, $b]) {
 foreach ($array as list($a, $b)) {
     echo "A: $a; B: $b\n";
 }
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -176,7 +206,6 @@ foreach ($array as [, , $c]) {
     // Skipping over $a and $b
     echo "$c\n";
 }
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -206,7 +235,6 @@ $array = [
 foreach ($array as [$a, $b, $c]) {
     echo "A: $a; B: $b; C: $c\n";
 }
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -240,10 +268,25 @@ foreach ($arr as &$value) {
     $value = $value * 2;
 }
 // $arr is now [2, 4, 6, 8]
+var_dump($arr);
 unset($value); // break the reference with the last element
-?>
 ]]>
     </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+array(4) {
+  [0]=>
+  int(2)
+  [1]=>
+  int(4)
+  [2]=>
+  int(6)
+  [3]=>
+  &int(8)
+}
+]]>
+    </screen>
    </informalexample>
   </para>
   <warning>
@@ -262,25 +305,48 @@ foreach ($arr as &$value) {
     $value = $value * 2;
 }
 // $arr は現在 [2, 4, 6, 8]
+var_dump($arr);
 
 // unset($value) しないと、$value はまだ最後の要素 $arr[3] を指した状態のままです
 
+echo "\nAnother loop:\n";
 foreach ($arr as $key => $value) {
     // $arr[3] は $arr の値ごとに更新され続けてしまいます...
-    echo "{$key} => {$value} ";
-    print_r($arr);
+    echo "{$key} => {$value}\n";
 }
 // ...最終的に、最後から2番目の値が最後の値にコピーされるまで
-?>
+var_dump($arr);
 ]]>
     </programlisting>
     &example.outputs;
     <screen>
 <![CDATA[
-0 => 2 Array ( [0] => 2, [1] => 4, [2] => 6, [3] => 2 )
-1 => 4 Array ( [0] => 2, [1] => 4, [2] => 6, [3] => 4 )
-2 => 6 Array ( [0] => 2, [1] => 4, [2] => 6, [3] => 6 )
-3 => 6 Array ( [0] => 2, [1] => 4, [2] => 6, [3] => 6 )
+array(4) {
+  [0]=>
+  int(2)
+  [1]=>
+  int(4)
+  [2]=>
+  int(6)
+  [3]=>
+  &int(8)
+}
+
+Another loop:
+0 => 2
+1 => 4
+2 => 6
+3 => 6
+array(4) {
+  [0]=>
+  int(2)
+  [1]=>
+  int(4)
+  [2]=>
+  int(6)
+  [3]=>
+  &int(6)
+}
 ]]>
     </screen>
    </informalexample>
@@ -292,10 +358,19 @@ foreach ($arr as $key => $value) {
 <?php
 foreach ([1, 2, 3, 4] as &$value) {
     $value = $value * 2;
+    echo $value . "\n";
 }
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+2
+4
+6
+8
+]]>
+   </screen>
   </example>
  </sect2>
 

--- a/language/control-structures/goto.xml
+++ b/language/control-structures/goto.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 7204e2dbb9b484c8b67bb5ad4a93fa1369c5b317 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 
 <sect1 xml:id="control-structures.goto" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -40,14 +40,11 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-
 goto a;
 echo 'Foo';
 
 a:
 echo 'Bar';
-
-?>
 ]]>
    </programlisting>
    &example.outputs;
@@ -64,7 +61,6 @@ Bar
    <programlisting role="php">
 <![CDATA[
 <?php
-
 for ($i = 0, $j = 50; $i < 100; $i++) {
     while ($j--) {
         if ($j == 17) {
@@ -75,8 +71,6 @@ for ($i = 0, $j = 50; $i < 100; $i++) {
 echo "i = $i";
 end:
 echo 'j hit 17';
-
-?>
 ]]>
    </programlisting>
    &example.outputs;
@@ -93,7 +87,6 @@ j hit 17
    <programlisting role="php">
 <![CDATA[
 <?php
-
 goto loop;
 for ($i = 0, $j = 50; $i < 100; $i++) {
     while ($j--) {
@@ -101,15 +94,12 @@ for ($i = 0, $j = 50; $i < 100; $i++) {
     }
 }
 echo "$i = $i";
-
-?>
 ]]>
    </programlisting>
    &example.outputs;
    <screen>
 <![CDATA[
-Fatal error: 'goto' into loop or switch statement is disallowed in
-script on line 2
+Fatal error: 'goto' into loop or switch statement is disallowed in script on line 2
 ]]>
    </screen>
   </example>

--- a/language/control-structures/if.xml
+++ b/language/control-structures/if.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 7104ee97ced1768a3231588dfc0bc0d7eb1117ad Maintainer: takagi Status: ready -->
+<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: takagi Status: ready -->
 
 <sect1 xml:id="control-structures.if" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>if</title>
@@ -37,11 +37,18 @@ if (式)
    <programlisting role="php">
 <![CDATA[
 <?php
+$a = 3;
+$b = 1;
 if ($a > $b)
-  echo "aはbより大きい";
-?>
+  echo "aはbより大きい\n";
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+aはbより大きい
+]]>
+   </screen>
   </informalexample>
  </para>
  <para>
@@ -57,13 +64,22 @@ if ($a > $b)
    <programlisting role="php">
 <![CDATA[
 <?php
+$a = 3;
+$b = 1;
 if ($a > $b) {
-  echo "aはbより大きい";
+  echo "aはbより大きい\n";
   $b = $a;
 }
-?>
+var_dump($b);
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+aはbより大きい
+int(3)
+]]>
+   </screen>
   </informalexample>
  </para>
  <simpara>

--- a/language/control-structures/include.xml
+++ b/language/control-structures/include.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 911fe79de766ef4475bf22446903667a0f3a24d3 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 
 <sect1 xml:id="function.include" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -56,7 +56,7 @@
  <para>
   <example>
    <title>基本的な <literal>include</literal> の例</title>
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 vars.php
 <?php
@@ -92,7 +92,7 @@ echo "A $color $fruit"; // A green apple
  <para>
   <example>
    <title>関数内での読み込み</title>
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 
@@ -112,8 +112,6 @@ function foo()
 
 foo();                    // A green apple
 echo "A $color $fruit";   // A green
-
-?>
 ]]>
    </programlisting>
   </example>
@@ -138,7 +136,7 @@ echo "A $color $fruit";   // A green
  <para>
   <example>
    <title>HTTP経由の <literal>include</literal></title>
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 
@@ -156,7 +154,6 @@ include 'file.php?foo=1&bar=2';
 
 // 動作します。
 include 'http://www.example.com/file.php?foo=1&bar=2';
-?>
 ]]>
    </programlisting>
   </example>
@@ -199,7 +196,7 @@ include 'http://www.example.com/file.php?foo=1&bar=2';
   戻り値を比較する際には注意してください。
   <example>
    <title>インクルードの戻り値を比較する</title>
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 // 動作しません。include(('vars.php') == TRUE) つまり、include('1') と評価されます
@@ -211,7 +208,6 @@ if (include('vars.php') == TRUE) {
 if ((include 'vars.php') == TRUE) {
     echo 'OK';
 }
-?>
 ]]>
    </programlisting>
   </example>
@@ -219,7 +215,7 @@ if ((include 'vars.php') == TRUE) {
  <para>
   <example>
    <title><literal>include</literal> と <function>return</function> 文</title>
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 return.php
 <?php
@@ -279,7 +275,7 @@ echo $bar; // 1が出力されます
  <para>
   <example>
    <title>出力バッファリングを用い、 PHP ファイルの内容を文字列として読み込む</title>
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 $string = get_include_contents('somefile.php');
@@ -292,8 +288,6 @@ function get_include_contents($filename) {
     }
     return false;
 }
-
-?>
 ]]>
    </programlisting>
   </example>

--- a/language/control-structures/match.xml
+++ b/language/control-structures/match.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 840bdb9be79855ee4b2cc66c22cf3e88b781398a Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: mumumu Status: ready -->
 
 <sect1 xml:id="control-structures.match" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>match</title>
@@ -19,14 +19,13 @@
 
  <example>
   <title><literal>match</literal> 式の構造</title>
-  <programlisting role="php">
+  <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 $return_value = match (制約式) {
     単一の条件式 => 返却式,
     条件式1, 条件式2 => 返却式,
 };
-?>
 ]]>
   </programlisting>
 
@@ -44,7 +43,6 @@ $return_value = match ($food) {
 };
 
 var_dump($return_value);
-?>
 ]]>
   </programlisting>
   &example.outputs;
@@ -71,7 +69,6 @@ $output = match (true) {
 };
 
 var_dump($output);
-?>
 ]]>
   </programlisting>
   &example.outputs;
@@ -133,7 +130,7 @@ string(8) "Teenager"
   条件式に一致する式が評価された場合に、返却式が評価されます。
   たとえば、以下のようになります:
   <informalexample>
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 $result = match ($x) {
@@ -142,7 +139,6 @@ $result = match ($x) {
     $this->baz => beep(), // $x === $this->baz でなければ beep() は呼び出されません。
     // などなど
 };
-?>
 ]]>
    </programlisting>
   </informalexample>
@@ -154,7 +150,7 @@ $result = match ($x) {
  </para>
  <para>
   <informalexample>
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 $result = match ($x) {
@@ -165,7 +161,6 @@ $result = match ($x) {
     $b => 5,
     $c => 5,
 };
-?>
 ]]>
    </programlisting>
   </informalexample>
@@ -175,7 +170,7 @@ $result = match ($x) {
   このパターンは前の分岐にマッチしなかったあらゆる場合にマッチします。
   たとえば、以下のようになります:
   <informalexample>
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 $expressionResult = match ($condition) {
@@ -183,7 +178,6 @@ $expressionResult = match ($condition) {
     3, 4 => bar(),
     default => baz(),
 };
-?>
 ]]>
    </programlisting>
   </informalexample>
@@ -217,7 +211,6 @@ try {
 } catch (\UnhandledMatchError $e) {
     var_dump($e);
 }
-?>
 ]]>
   </programlisting>
   &example.outputs;
@@ -225,13 +218,13 @@ try {
 <![CDATA[
 object(UnhandledMatchError)#1 (7) {
   ["message":protected]=>
-  string(33) "Unhandled match value of type int"
+  string(22) "Unhandled match case 5"
   ["string":"Error":private]=>
   string(0) ""
   ["code":protected]=>
   int(0)
   ["file":protected]=>
-  string(9) "/in/ICgGK"
+  string(6) "script"
   ["line":protected]=>
   int(6)
   ["trace":"Error":private]=>
@@ -256,7 +249,6 @@ object(UnhandledMatchError)#1 (7) {
    <programlisting role="php">
 <![CDATA[
 <?php
-
 $age = 23;
 
 $result = match (true) {
@@ -267,7 +259,6 @@ $result = match (true) {
 };
 
 var_dump($result);
-?>
 ]]>
    </programlisting>
    &example.outputs;
@@ -293,7 +284,6 @@ $result = match (true) {
 };
 
 var_dump($result);
-?>
 ]]>
    </programlisting>
    &example.outputs;

--- a/language/control-structures/switch.xml
+++ b/language/control-structures/switch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d149b6ddca64beb9de38cbd4bfd8d19d3bd0b60e Maintainer: takagi Status: ready -->
+<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 
 <sect1 xml:id="control-structures.switch" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -40,32 +40,39 @@
    <programlisting role="php">
 <![CDATA[
 <?php
+$i = 1;
+
 // これが switch 文です:
 
 switch ($i) {
     case 0:
-        echo "iは0に等しい";
+        echo "iは0に等しい\n";
         break;
     case 1:
-        echo "iは1に等しい";
+        echo "iは1に等しい\n";
         break;
     case 2:
-        echo "iは2に等しい";
+        echo "iは2に等しい\n";
         break;
 }
 
 // 上記は、下記と同じです:
 if ($i == 0) {
-    echo "iは0に等しい";
+    echo "iは0に等しい\n";
 } elseif ($i == 1) {
-    echo "iは1に等しい";
+    echo "iは1に等しい\n";
 } elseif ($i == 2) {
-    echo "iは2に等しい";
+    echo "iは2に等しい\n";
 }
-
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+iは1に等しい
+iは1に等しい
+]]>
+   </screen>
   </example>
  </para>
  <para>
@@ -84,17 +91,25 @@ if ($i == 0) {
    <programlisting role="php">
 <![CDATA[
 <?php
+$i = 1;
+
 switch ($i) {
     case 0:
-        echo "iは0に等しい";
+        echo "iは0に等しい\n";
     case 1:
-        echo "iは1に等しい";
+        echo "iは1に等しい\n";
     case 2:
-        echo "iは2に等しい";
+        echo "iは2に等しい\n";
 }
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+iは1に等しい
+iは2に等しい
+]]>
+   </screen>
   </informalexample>
  </para>
  <simpara>
@@ -122,6 +137,8 @@ switch ($i) {
    <programlisting role="php">
 <![CDATA[
 <?php
+$i = 1;
+
 switch ($i) {
     case 0:
     case 1:
@@ -131,9 +148,14 @@ switch ($i) {
     case 3:
         echo "iは3です";
 }
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+iは3より小さいですが負ではありません
+]]>
+   </screen>
   </informalexample>
  </para>
  <para>
@@ -143,6 +165,8 @@ switch ($i) {
    <programlisting role="php">
 <![CDATA[
 <?php
+$i = 4;
+
 switch ($i) {
     case 0:
         echo "iは0に等しい";
@@ -156,9 +180,14 @@ switch ($i) {
     default:
        echo "iは0,1,2に等しくない";
 }
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+iは0,1,2に等しくない
+]]>
+   </screen>
   </informalexample>
   <note>
    <simpara>
@@ -208,10 +237,14 @@ switch ($target) {
         print "D";
         break;
 }
-// "B" を出力します。
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+B
+]]>
+   </screen>
   </informalexample>
  </para>
  <para>
@@ -221,7 +254,7 @@ switch ($target) {
   <literal>if</literal>-<literal>else</literal>ブロックが使えます。
   <informalexample>
    <programlisting role="php">
-    <![CDATA[
+<![CDATA[
 <?php
 $offset = 1;
 $start = 3;
@@ -239,10 +272,14 @@ switch (true) {
         print "D";
         break;
 }
-// "B" を出力します。
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+B
+]]>
+   </screen>
   </informalexample>
  </para>
  <para>
@@ -253,6 +290,8 @@ switch (true) {
    <programlisting role="php">
 <![CDATA[
 <?php
+$i = 1;
+
 switch ($i):
     case 0:
         echo "iは0に等しい";
@@ -266,17 +305,25 @@ switch ($i):
     default:
         echo "iは0でも1でも2でもない";
 endswitch;
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+iは1に等しい
+]]>
+   </screen>
   </informalexample>
  </para>
  <para>
-  case の最後はコロンではなくセミコロンとすることもできます。たとえば次のようになります。
+  case の最後はコロンではなくセミコロンとすることもできますが、
+  PHP 8.5.0 以降、この構文は非推奨です。
   <informalexample>
    <programlisting role="php">
 <![CDATA[
 <?php
+$beer = 'コーラ';
+
 switch($beer)
 {
     case 'ツボルグ';
@@ -289,9 +336,22 @@ switch($beer)
         echo 'ほかのを選んでみませんか?';
         break;
 }
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+
+Deprecated: Case statements followed by a semicolon (;) are deprecated, use a colon (:) instead in script on line 6
+
+Deprecated: Case statements followed by a semicolon (;) are deprecated, use a colon (:) instead in script on line 7
+
+Deprecated: Case statements followed by a semicolon (;) are deprecated, use a colon (:) instead in script on line 8
+
+Deprecated: Case statements followed by a semicolon (;) are deprecated, use a colon (:) instead in script on line 11
+ほかのを選んでみませんか?
+]]>
+   </screen>
   </informalexample>
   &warn.deprecated.feature-8-5-0;
  </para>

--- a/language/control-structures/while.xml
+++ b/language/control-structures/while.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 7104ee97ced1768a3231588dfc0bc0d7eb1117ad Maintainer: takagi Status: ready -->
+<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: takagi Status: ready -->
 
 <sect1 xml:id="control-structures.while" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>while</title>
@@ -49,25 +49,56 @@ endwhile;
    <programlisting role="php">
 <![CDATA[
 <?php
-/* 例 1 */
-
 $i = 1;
 while ($i <= 10) {
-    echo $i++;  /* 出力される値は、足される前の
-                    $iの値です。
-                    (後置加算) */
+    echo $i++ . "\n";  /* 出力される値は、足される前の
+                           $iの値です。
+                           (後置加算) */
 }
-
-/* 例 2 */
-
-$i = 1;
-while ($i <= 10):
-    echo $i;
-    $i++;
-endwhile;
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+]]>
+   </screen>
+  </informalexample>
+  <informalexample>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$i = 1;
+while ($i <= 10):
+    echo $i . "\n";
+    $i++;
+endwhile;
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+]]>
+   </screen>
   </informalexample>
  </para>
 </sect1>


### PR DESCRIPTION
原文の php/doc-en#5462 に追随し、language/control-structures 配下の 16 ファイルを同期しました。

### コード例の実行可能化（16件） — php/doc-en@b8147b7

- 複数の例を `informalexample` 単位に分割し、`&example.outputs;` + `<screen>` の出力ブロックを追加
- 例中で未定義だった変数の初期化を補い、末尾の `?>` を除去
- 実行対象外の例に `annotations="non-interactive"`、`language/control-structures.xml` の `<chapter>` に `annotations="interactive"` を付与

`<screen>` の内容は、各ファイルの訳文コードが実際に出力する内容に合わせています。コード中の文字列が訳出済みの箇所は日本語、PHP 本体が出力するメッセージは原文のままです。

対象: control-structures.xml, alternative-syntax.xml, break.xml, continue.xml,
declare.xml, do-while.xml, else.xml, elseif.xml, for.xml, foreach.xml, goto.xml,
if.xml, include.xml, match.xml, switch.xml, while.xml

### 原文側の内容変更の反映（3件）

- switch.xml — case のセミコロン構文が PHP 8.5.0 で非推奨になった旨の記述を追加（php/doc-en@b8147b7）
- continue.xml — `continue` 後のセミコロン省略に関する段落が原文で削除されたため、対応する訳文を削除（php/doc-en@b8147b7）
- else.xml — 原文の綴りの誤りの修正に追随（php/doc-en@690c3ea）。訳文への影響はありません
