### PR TITLE
doc-en と同期し 空の xi:fallback と不要なコメントを除去（win32service の同種1件を含む・訳文の変更なし）

### DIFF
--- a/appendices/ini.list.xml
+++ b/appendices/ini.list.xml
@@ -110,7 +110,7 @@
        <entry><constant>INI_PERDIR</constant></entry>
        <entry></entry>
       </row>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('bc.configuration.list')/*)"><xi:fallback/></xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('bc.configuration.list')/*)"/>
       <row>
        <entry><link linkend="ini.browscap">browscap</link></entry>
        <entry>&null;</entry>
@@ -165,12 +165,12 @@
        <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('readline.configuration.list')/*)"><xi:fallback/></xi:include>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('features.commandline.ini.list')/*)"><xi:fallback/></xi:include>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('com.configuration.list')/*)"><xi:fallback/></xi:include>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('curl.configuration.list')/*)"><xi:fallback/></xi:include>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('datetime.configuration.list')/*)"><xi:fallback/></xi:include>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('dba.configuration.list')/*)"><xi:fallback/></xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('readline.configuration.list')/*)"/>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('features.commandline.ini.list')/*)"/>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('com.configuration.list')/*)"/>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('curl.configuration.list')/*)"/>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('datetime.configuration.list')/*)"/>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('dba.configuration.list')/*)"/>
       <row>
        <entry><link linkend="ini.default-charset">default_charset</link></entry>
        <entry><literal>"UTF-8"</literal></entry>
@@ -298,14 +298,14 @@
        <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('exif.configuration.list')/*)"><xi:fallback/></xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('exif.configuration.list')/*)"/>
       <row>
        <entry><link linkend="ini.exit-on-timeout">exit_on_timeout</link></entry>
        <entry><literal>""</literal></entry>
        <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('expect.configuration.list')/*)"><xi:fallback/></xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('expect.configuration.list')/*)"/>
       <row>
        <entry><link linkend="ini.expose-php">expose_php</link></entry>
        <entry><literal>"1"</literal></entry>
@@ -342,15 +342,15 @@
        <entry><constant>INI_SYSTEM</constant></entry>
        <entry></entry>
       </row>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('filter.configuration.list')/*)"><xi:fallback/></xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('filter.configuration.list')/*)"/>
       <row>
        <entry><link linkend="ini.from">from</link></entry>
        <entry><literal>""</literal></entry>
        <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('image.configuration.list')/*)"><xi:fallback/></xi:include>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('geoip.configuration.list')/*)"><xi:fallback/></xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('image.configuration.list')/*)"/>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('geoip.configuration.list')/*)"/>
       <row>
        <entry>hard_timeout</entry>
        <entry>"2"</entry>
@@ -393,9 +393,9 @@
        <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('ibase.configuration.list')/*)"><xi:fallback/></xi:include>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('ibm-db2.configuration.list')/*)"><xi:fallback/></xi:include>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('iconv.configuration.list')/*)"><xi:fallback/></xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('ibase.configuration.list')/*)"/>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('ibm-db2.configuration.list')/*)"/>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('iconv.configuration.list')/*)"/>
       <row>
        <entry><link linkend="ini.ignore-repeated-errors">ignore_repeated_errors</link></entry>
        <entry><literal>"0"</literal></entry>
@@ -426,14 +426,14 @@
        <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('intl.configuration.list')/*)"><xi:fallback/></xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('intl.configuration.list')/*)"/>
       <row>
        <entry><link linkend="ini.last-modified">last_modified</link></entry>
        <entry><literal>"0"</literal></entry>
        <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('ldap.configuration.list')/*)"><xi:fallback/></xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('ldap.configuration.list')/*)"/>
       <row>
        <entry><link linkend="ini.log-errors">log_errors</link></entry>
        <entry><literal>"0"</literal></entry>
@@ -488,21 +488,21 @@
        <entry><constant>INI_PERDIR</constant></entry>
        <entry></entry>
       </row>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mbstring.configuration.list')/*)"><xi:fallback/></xi:include>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mcrypt.configuration.list')/*)"><xi:fallback/></xi:include>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('memcache.ini.list')/*)"><xi:fallback/></xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mbstring.configuration.list')/*)"/>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mcrypt.configuration.list')/*)"/>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('memcache.ini.list')/*)"/>
       <row>
        <entry><link linkend="ini.memory-limit">memory_limit</link></entry>
        <entry><literal>"128M"</literal></entry>
        <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysql.configuration.list')/*)"><xi:fallback/></xi:include>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqli.configuration.list')/*)"><xi:fallback/></xi:include>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.config.options.list')/*)"><xi:fallback/></xi:include>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('oci8.configuration.list')/*)"><xi:fallback/></xi:include>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('odbc.configuration.list')/*)"><xi:fallback/></xi:include>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('opcache.configuration.list')/*)"><xi:fallback/></xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysql.configuration.list')/*)"/>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqli.configuration.list')/*)"/>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.config.options.list')/*)"/>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('oci8.configuration.list')/*)"/>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('odbc.configuration.list')/*)"/>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('opcache.configuration.list')/*)"/>
       <row>
        <entry><link linkend="ini.open-basedir">open_basedir</link></entry>
        <entry>&null;</entry>
@@ -521,11 +521,11 @@
        <entry><constant>INI_PERDIR</constant></entry>
        <entry></entry>
       </row>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pcre.configuration.list')/*)"><xi:fallback/></xi:include>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo.configuration.list')/*)"><xi:fallback/></xi:include>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-odbc.configuration.list')/*)"><xi:fallback/></xi:include>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pgsql.configuration.list')/*)"><xi:fallback/></xi:include>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('phar.configuration.list')/*)"><xi:fallback/></xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pcre.configuration.list')/*)"/>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo.configuration.list')/*)"/>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-odbc.configuration.list')/*)"/>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pgsql.configuration.list')/*)"/>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('phar.configuration.list')/*)"/>
       <row>
        <entry><link linkend="ini.post-max-size">post_max_size</link></entry>
        <entry><literal>"8M"</literal></entry>
@@ -574,7 +574,7 @@
        <entry><constant>INI_PERDIR</constant></entry>
        <entry></entry>
       </row>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('runkit7.configuration.list')/*)"><xi:fallback/></xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('runkit7.configuration.list')/*)"/>
       <row>
        <entry><link linkend="ini.sendmail-from">sendmail_from</link></entry>
        <entry>&null;</entry>
@@ -595,7 +595,7 @@
         PHP 7.1.0 より前のバージョンでは、デフォルト値は <literal>17</literal> でした。
        </entry>
       </row>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('session.configuration.list')/*)"><xi:fallback/></xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('session.configuration.list')/*)"/>
       <row>
        <entry><link linkend="ini.short-open-tag">short_open_tag</link></entry>
        <entry><literal>"1"</literal></entry>
@@ -614,14 +614,14 @@
        <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('soap.configuration.list')/*)"><xi:fallback/></xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('soap.configuration.list')/*)"/>
       <row>
        <entry><link linkend="ini.sql.safe-mode">sql.safe_mode</link></entry>
        <entry><literal>"0"</literal></entry>
        <entry><constant>INI_SYSTEM</constant></entry>
        <entry>PHP 7.2.0 で削除</entry>
       </row>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('sqlite3.configuration.list')/*)"><xi:fallback/></xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('sqlite3.configuration.list')/*)"/>
       <row>
        <entry><link linkend="ini.syslog.facility">syslog.facility</link></entry>
        <entry><literal>"LOG_USER"</literal></entry>
@@ -646,15 +646,15 @@
        <entry><constant>INI_SYSTEM</constant></entry>
        <entry></entry>
       </row>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('sem.configuration.list')/*)"><xi:fallback/></xi:include>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('tidy.configuration.list')/*)"><xi:fallback/></xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('sem.configuration.list')/*)"/>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('tidy.configuration.list')/*)"/>
       <row>
        <entry><link linkend="ini.track-errors">track_errors</link></entry>
        <entry><literal>"0"</literal></entry>
        <entry><constant>INI_ALL</constant></entry>
        <entry>PHP 7.2.0 以降は非推奨になり、PHP 8.0.0 で 削除されました。</entry>
       </row>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('unserialize.configuration.list')/*)"><xi:fallback/></xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('unserialize.configuration.list')/*)"/>
       <row>
        <entry>uploadprogress.file.filename_template</entry>
        <entry><literal>"/tmp/upt_%s.txt"</literal></entry>
@@ -715,7 +715,7 @@
        <entry><constant>INI_SYSTEM</constant></entry>
        <entry></entry>
       </row>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('uopz.configuration.list')/*)"><xi:fallback/></xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('uopz.configuration.list')/*)"/>
       <row>
        <entry><link linkend="ini.variables-order">variables_order</link></entry>
        <entry><literal>"EGPCS"</literal></entry>
@@ -818,7 +818,7 @@
        <entry>&php.ini; のみ</entry>
        <entry></entry>
       </row>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('zlib.configuration.list')/*)"><xi:fallback/></xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('zlib.configuration.list')/*)"/>
      </tbody>
     </tgroup>
    </table>

--- a/install/ini.xml
+++ b/install/ini.xml
@@ -284,7 +284,7 @@ Replace everything inside the <variablelist> element with an <xi:include>
 once libxml2 gets XInclude 1.1 attribute copying support.
 The below <xi:include> will include the appropriate elements
 but needs all top-level xml:id's removed (see XInclude 1.1 set-xml-id).
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('constant.ini-mode')/*)"><xi:fallback/></xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('constant.ini-mode')/*)"/>
 -->
      <title>INI モードの定数</title>
      <varlistentry>

--- a/language/context/ftp.xml
+++ b/language/context/ftp.xml
@@ -16,7 +16,7 @@
   </para>
  </refsect1>
 
- <refsect1 role="options"><!-- {{{ -->
+ <refsect1 role="options">
   &reftitle.options;
   <para>
    <variablelist>
@@ -65,7 +65,7 @@
     </varlistentry>
    </variablelist>
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
  
  <refsect1 role="notes">
   &reftitle.notes;

--- a/language/context/http.xml
+++ b/language/context/http.xml
@@ -17,7 +17,7 @@
   </para>
  </refsect1>
 
- <refsect1 role="options"><!-- {{{ -->
+ <refsect1 role="options">
   &reftitle.options;
   <para>
    <variablelist>
@@ -202,13 +202,13 @@
     </varlistentry>
    </variablelist>
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
  
 
- <refsect1 role="examples"><!-- {{{ -->
+ <refsect1 role="examples">
   &reftitle.examples;
   <para>
-   <example xml:id="context.http.example-post"><!-- {{{ -->
+   <example xml:id="context.http.example-post">
     <title>ページの取得と POST データの送信</title>
     <programlisting role="php">
 <![CDATA[
@@ -236,10 +236,10 @@ $result = file_get_contents('http://example.com/submit.php', false, $context);
 ?>
 ]]>
     </programlisting>
-   </example><!-- }}} -->
+   </example>
   </para>
   <para>
-   <example xml:id="context.http.example-fetch-ignore-redirect"><!-- {{{ -->
+   <example xml:id="context.http.example-fetch-ignore-redirect">
     <title>リダイレクトを無視し、ヘッダとコンテンツの取得</title>
     <programlisting role="php">
 <![CDATA[
@@ -267,9 +267,9 @@ fclose($stream);
 ?>
 ]]>
     </programlisting>
-   </example><!-- }}} -->
+   </example>
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
 
  <refsect1 role="notes">
   &reftitle.notes;

--- a/language/context/parameters.xml
+++ b/language/context/parameters.xml
@@ -17,7 +17,7 @@
   </para>
  </refsect1>
 
- <refsect1 role="options"><!-- {{{ -->
+ <refsect1 role="options">
   &reftitle.parameters;
   <para>
    <variablelist>
@@ -38,7 +38,7 @@
     </varlistentry>
    </variablelist>
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
 
 </refentry>
  

--- a/language/context/phar.xml
+++ b/language/context/phar.xml
@@ -15,7 +15,7 @@
   </para>
  </refsect1>
 
- <refsect1 role="options"><!-- {{{ -->
+ <refsect1 role="options">
   &reftitle.options;
   <para>
    <variablelist>
@@ -44,7 +44,7 @@
     </varlistentry>
    </variablelist>
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
  
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/language/context/socket.xml
+++ b/language/context/socket.xml
@@ -9,16 +9,16 @@
   <refpurpose>ソケットコンテキストオプション一覧</refpurpose>
  </refnamediv>
  
- <refsect1 role="description"><!-- {{{ -->
+ <refsect1 role="description">
   &reftitle.description;
   <para>
    ここでは、ソケット越しに動作するラッパー
    すなわち <literal>tcp</literal>、<literal>http</literal>
    あるいは <literal>ftp</literal> でサポートされるオプションを扱います。
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
  
- <refsect1 role="options"><!-- {{{ -->
+ <refsect1 role="options">
   &reftitle.options;
   <para>
    <variablelist>
@@ -112,9 +112,9 @@
     </varlistentry>
    </variablelist>
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
  
- <refsect1 role="changelog"><!-- {{{ -->
+ <refsect1 role="changelog">
   &reftitle.changelog;
   <para>
    <informaltable>
@@ -142,12 +142,12 @@
     </tgroup>
    </informaltable>
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
  
- <refsect1 role="examples"><!-- {{{ -->
+ <refsect1 role="examples">
   &reftitle.examples;
   <para>
-   <example xml:id="context.socket.example-bindto"><!-- {{{ -->
+   <example xml:id="context.socket.example-bindto">
     <title>基本的な <parameter>bindto</parameter> の使用例</title>
     <programlisting role="php">
 <![CDATA[
@@ -193,9 +193,9 @@ echo file_get_contents('http://www.example.com', false, $context);
 ?>
 ]]>
     </programlisting>
-   </example><!-- }}} -->
+   </example>
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
  
 </refentry>
  

--- a/language/context/ssl.xml
+++ b/language/context/ssl.xml
@@ -17,7 +17,7 @@
   </para>
  </refsect1>
 
- <refsect1 role="options"><!-- {{{ -->
+ <refsect1 role="options">
   &reftitle.options;
   <para>
    <variablelist>
@@ -258,9 +258,9 @@
     </varlistentry>
    </variablelist>
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
  
- <refsect1 role="changelog"><!-- {{{ -->
+ <refsect1 role="changelog">
   &reftitle.changelog;
   <para>
    <informaltable>
@@ -283,7 +283,7 @@
     </tgroup>
    </informaltable>
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
 
  <refsect1 role="notes">
   &reftitle.notes;

--- a/language/context/zip.xml
+++ b/language/context/zip.xml
@@ -8,14 +8,14 @@
   <refpurpose>Zip コンテキストオプション一覧</refpurpose>
  </refnamediv>
  
- <refsect1 role="description"><!-- {{{ -->
+ <refsect1 role="description">
   &reftitle.description;
   <para>
    Zip コンテキストオプションは <literal>zip</literal> ラッパーで使用可能です。
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
  
- <refsect1 role="options"><!-- {{{ -->
+ <refsect1 role="options">
   &reftitle.options;
   <para>
    <variablelist>
@@ -29,9 +29,9 @@
     </varlistentry>
    </variablelist>
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
  
- <refsect1 role="changelog"><!-- {{{ -->
+ <refsect1 role="changelog">
   &reftitle.changelog;
   <para>
    <informaltable>
@@ -53,12 +53,12 @@
     </tgroup>
    </informaltable>
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
  
- <refsect1 role="examples"><!-- {{{ -->
+ <refsect1 role="examples">
   &reftitle.examples;
   <para>
-   <example xml:id="context.zip.example-password"><!-- {{{ -->
+   <example xml:id="context.zip.example-password">
     <title><parameter>password</parameter> の基本的な使用例</title>
     <programlisting role="php">
 <![CDATA[
@@ -78,9 +78,9 @@ echo file_get_contents('zip://test.zip#test.txt', false, $context);
 ?>
 ]]>
     </programlisting>
-   </example><!-- }}} -->
+   </example>
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
  
 </refentry>
  

--- a/language/fibers.xml
+++ b/language/fibers.xml
@@ -61,7 +61,7 @@
    </simpara>
   </note> 
 
-  <example xml:id="language.fiber.example.basic"><!-- {{{ -->
+  <example xml:id="language.fiber.example.basic">
    <title>ファイバーの基本的な使い方</title>
    <programlisting role="php">
     <![CDATA[
@@ -86,7 +86,7 @@ Value from fiber suspending: fiber
 Value used to resume fiber: test
 ]]>
    </screen>
-  </example><!-- }}} -->
+  </example>
 
  </simplesect>
 

--- a/language/predefined/argumentcounterror.xml
+++ b/language/predefined/argumentcounterror.xml
@@ -8,7 +8,6 @@
  
  <partintro>
  
-<!-- {{{ Error intro -->
   <section xml:id="argumentcounterror.intro">
    &reftitle.intro;
    <para>
@@ -19,12 +18,10 @@
     可変長引数でない組み込み関数に、多過ぎる引数を渡した場合にもスローされます。
    </para>
   </section>
-<!-- }}} -->
  
   <section xml:id="argumentcounterror.synopsis">
    &reftitle.classsynopsis;
  
-<!-- {{{ Synopsis -->
    <classsynopsis class="class">
     <ooexception>
      <exceptionname>ArgumentCountError</exceptionname>
@@ -36,20 +33,13 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])"/>
    </classsynopsis>
  
-<!-- }}} -->
  
   </section>
  </partintro>

--- a/language/predefined/arithmeticerror.xml
+++ b/language/predefined/arithmeticerror.xml
@@ -8,7 +8,6 @@
  
  <partintro>
  
-<!-- {{{ Error intro -->
   <section xml:id="arithmeticerror.intro">
    &reftitle.intro;
    <para>
@@ -19,12 +18,10 @@
     <function>intdiv</function> の呼び出しの際にも発生します。
    </para>
   </section>
-<!-- }}} -->
  
   <section xml:id="arithmeticerror.synopsis">
    &reftitle.classsynopsis;
  
-<!-- {{{ Synopsis -->
    <classsynopsis class="class">
     <ooexception>
      <exceptionname>ArithmeticError</exceptionname>
@@ -36,20 +33,13 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])"/>
    </classsynopsis>
  
-<!-- }}} -->
  
   </section>
  </partintro>

--- a/language/predefined/arrayaccess.xml
+++ b/language/predefined/arrayaccess.xml
@@ -9,36 +9,30 @@
 
  <partintro>
 
-<!-- {{{ ArrayAccess intro -->
   <section xml:id="arrayaccess.intro">
    &reftitle.intro;
    <para>
     配列としてオブジェクトにアクセスするための機能のインターフェイスです。
    </para>
   </section>
-<!-- }}} -->
 
   <section xml:id="arrayaccess.synopsis">
    &reftitle.interfacesynopsis;
 
-<!-- {{{ Synopsis -->
    <classsynopsis class="interface">
     <oointerface>
      <interfacename>ArrayAccess</interfacename>
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayaccess')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ArrayAccess'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayaccess')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ArrayAccess'])"/>
    </classsynopsis>
-<!-- }}} -->
 
   </section>
 
   <section xml:id="arrayaccess.examples">
    &reftitle.examples;
-   <example xml:id="arrayaccess.example.basic"><!-- {{{ -->
+   <example xml:id="arrayaccess.example.basic">
     <title>基本的な使用法</title>
     <programlisting role="php">
 <![CDATA[
@@ -107,7 +101,7 @@ Obj Object
 )
 ]]>
     </screen>
-   </example><!-- }}} -->
+   </example>
   </section>
 
  </partintro>

--- a/language/predefined/assertionerror.xml
+++ b/language/predefined/assertionerror.xml
@@ -7,7 +7,6 @@
  
  <partintro>
  
-<!-- {{{ Error intro -->
   <section xml:id="assertionerror.intro">
    &reftitle.intro;
    <para>
@@ -15,12 +14,10 @@
     は、<function>assert</function> によるアサーションが失敗したときにスローされます。
    </para>
   </section>
-<!-- }}} -->
  
   <section xml:id="assertionerror.synopsis">
    &reftitle.classsynopsis;
  
-<!-- {{{ Synopsis -->
    <classsynopsis class="class">
     <ooexception>
      <exceptionname>AssertionError</exceptionname>
@@ -32,20 +29,13 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])"/>
    </classsynopsis>
  
-<!-- }}} -->
  
   </section>
  </partintro>

--- a/language/predefined/attributes/allowdynamicproperties.xml
+++ b/language/predefined/attributes/allowdynamicproperties.xml
@@ -36,9 +36,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.allowdynamicproperties')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='AllowDynamicProperties'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.allowdynamicproperties')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='AllowDynamicProperties'])"/>
    </classsynopsis>
 
   </section>

--- a/language/predefined/attributes/attribute.xml
+++ b/language/predefined/attributes/attribute.xml
@@ -87,9 +87,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.attribute')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Attribute'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.attribute')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Attribute'])"/>
    </classsynopsis>
   </section>
 

--- a/language/predefined/attributes/deprecated.xml
+++ b/language/predefined/attributes/deprecated.xml
@@ -41,9 +41,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.deprecated')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Deprecated'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.deprecated')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Deprecated'])"/>
    </classsynopsis>
   </section>
 

--- a/language/predefined/attributes/nodiscard.xml
+++ b/language/predefined/attributes/nodiscard.xml
@@ -62,9 +62,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.nodiscard')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='NoDiscard'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.nodiscard')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='NoDiscard'])"/>
    </classsynopsis>
 
   </section>

--- a/language/predefined/attributes/override.xml
+++ b/language/predefined/attributes/override.xml
@@ -37,9 +37,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.override')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Override'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.override')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Override'])"/>
    </classsynopsis>
 
   </section>

--- a/language/predefined/attributes/sensitiveparameter.xml
+++ b/language/predefined/attributes/sensitiveparameter.xml
@@ -27,9 +27,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sensitiveparameter')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SensitiveParameter'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sensitiveparameter')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SensitiveParameter'])"/>
    </classsynopsis>
 
   </section>

--- a/language/predefined/backedenum.xml
+++ b/language/predefined/backedenum.xml
@@ -7,7 +7,6 @@
 
  <partintro>
 
-<!-- {{{ BackedEnum intro -->
   <section xml:id="backedenum.intro">
    &reftitle.intro;
    <para>
@@ -19,12 +18,10 @@
     このインターフェイスは、型チェックのためだけに存在しています。
    </para>
   </section>
-<!-- }}} -->
 
   <section xml:id="backedenum.synopsis">
    &reftitle.interfacesynopsis;
 
-<!-- {{{ Synopsis -->
    <classsynopsis class="interface">
     <oointerface>
      <interfacename>BackedEnum</interfacename>
@@ -36,16 +33,11 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.backedenum')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='BackedEnum'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.backedenum')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='BackedEnum'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.unitenum')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='UnitEnum'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.unitenum')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='UnitEnum'])"/>
    </classsynopsis>
-<!-- }}} -->
 
   </section>
 

--- a/language/predefined/closedgeneratorexception.xml
+++ b/language/predefined/closedgeneratorexception.xml
@@ -7,7 +7,6 @@
 
  <partintro>
 
-<!-- {{{ ClosedGeneratorException intro -->
   <section xml:id="closedgeneratorexception.intro">
    &reftitle.intro;
    <para>
@@ -16,12 +15,10 @@
     から値を取得しようとした場合にスローされます。
    </para>
   </section>
-<!-- }}} -->
 
   <section xml:id="closedgeneratorexception.synopsis">
    &reftitle.classsynopsis;
 
-<!-- {{{ Synopsis -->
    <classsynopsis class="class">
     <ooexception>
      <exceptionname>ClosedGeneratorException</exceptionname>
@@ -33,19 +30,12 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
-<!-- }}} -->
 
   </section>
 

--- a/language/predefined/closure.xml
+++ b/language/predefined/closure.xml
@@ -9,7 +9,6 @@
 
  <partintro>
 
-<!-- {{{ Closure intro -->
   <section xml:id="closure.intro">
    &reftitle.intro;
    <para>
@@ -31,12 +30,10 @@
    </para>
 
   </section>
-<!-- }}} -->
 
   <section xml:id="closure.synopsis">
    &reftitle.classsynopsis;
 
-<!-- {{{ Synopsis -->
    <classsynopsis class="class">
     <ooclass>
      <modifier>final</modifier>
@@ -44,14 +41,9 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.closure')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Closure'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.closure')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Closure'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.closure')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Closure'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.closure')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Closure'])"/>
    </classsynopsis>
-<!-- }}} -->
 
   </section>
 

--- a/language/predefined/closure/call.xml
+++ b/language/predefined/closure/call.xml
@@ -7,7 +7,7 @@
   <refname>Closure::call</refname>
   <refpurpose>クロージャを束縛して呼び出す</refpurpose>
  </refnamediv>
- <refsect1 role="description"><!-- {{{ -->
+ <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="Closure">
    <modifier>public</modifier> <type>mixed</type><methodname>Closure::call</methodname>
@@ -18,8 +18,8 @@
    クロージャを一時的に <parameter>newThis</parameter> に束縛し、
    指定したパラメータでそれを呼び出します。
   </para>
- </refsect1><!-- }}} -->
- <refsect1 role="parameters"><!-- {{{ -->
+ </refsect1>
+ <refsect1 role="parameters">
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
@@ -39,13 +39,13 @@
     </listitem>
    </varlistentry>
   </variablelist>
- </refsect1><!-- }}} -->
- <refsect1 role="returnvalues"><!-- {{{ -->
+ </refsect1>
+ <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
    クロージャの戻り値を返します。
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;
   <example>

--- a/language/predefined/compileerror.xml
+++ b/language/predefined/compileerror.xml
@@ -7,7 +7,6 @@
 
  <partintro>
 
-<!-- {{{ CompileError intro -->
   <section xml:id="compileerror.intro">
    &reftitle.intro;
    <para>
@@ -16,12 +15,10 @@
     以前は fatal error が発生していました。
    </para>
   </section>
-<!-- }}} -->
 
   <section xml:id="compileerror.synopsis">
    &reftitle.classsynopsis;
 
-<!-- {{{ Synopsis -->
    <classsynopsis class="class">
     <ooexception>
      <exceptionname>CompileError</exceptionname>
@@ -33,20 +30,13 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])"/>
    </classsynopsis>
 
-<!-- }}} -->
 
   </section>
  </partintro>

--- a/language/predefined/countable.xml
+++ b/language/predefined/countable.xml
@@ -8,7 +8,6 @@
 
  <partintro>
 
-<!-- {{{ Countable intro -->
   <section xml:id="countable.intro">
    &reftitle.intro;
    <para>
@@ -16,23 +15,18 @@
     <function>count</function> 関数で使用することができます。
    </para>
   </section>
-<!-- }}} -->
 
   <section xml:id="countable.synopsis">
    &reftitle.interfacesynopsis;
 
-<!-- {{{ Synopsis -->
    <classsynopsis class="interface">
     <oointerface>
      <interfacename>Countable</interfacename>
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.countable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Countable'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.countable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Countable'])"/>
    </classsynopsis>
-<!-- }}} -->
 
   </section>
 

--- a/language/predefined/divisionbyzeroerror.xml
+++ b/language/predefined/divisionbyzeroerror.xml
@@ -7,7 +7,6 @@
  
  <partintro>
  
-<!-- {{{ Error intro -->
   <section xml:id="divisionbyzeroerror.intro">
    &reftitle.intro;
    <para>
@@ -15,12 +14,10 @@
     は、数値をゼロで割ろうとした場合にスローされます。
    </para>
   </section>
-<!-- }}} -->
  
   <section xml:id="divisionbyzeroerror.synopsis">
    &reftitle.classsynopsis;
  
-<!-- {{{ Synopsis -->
    <classsynopsis class="class">
     <ooexception>
      <exceptionname>DivisionByZeroError</exceptionname>
@@ -32,20 +29,13 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])"/>
    </classsynopsis>
  
-<!-- }}} -->
  
   </section>
  </partintro>

--- a/language/predefined/error.xml
+++ b/language/predefined/error.xml
@@ -7,7 +7,6 @@
  
  <partintro>
  
-<!-- {{{ Error intro -->
   <section xml:id="error.intro">
    &reftitle.intro;
    <para>
@@ -15,12 +14,10 @@
     は、PHP のすべての内部エラーの基底クラスです。
    </para>
   </section>
-<!-- }}} -->
  
   <section xml:id="error.synopsis">
    &reftitle.classsynopsis;
  
-<!-- {{{ Synopsis -->
    <classsynopsis class="class">
     <ooexception>
      <exceptionname>Error</exceptionname>
@@ -74,18 +71,12 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])"/>
    </classsynopsis>
  
-<!-- }}} -->
  
   </section>
-  <!-- {{{ Error properties -->
     <section xml:id="error.props">
      &reftitle.properties;
      <variablelist>
@@ -133,7 +124,6 @@
       </varlistentry>
      </variablelist>
     </section>
-  <!-- }}} -->
 
  </partintro>
 

--- a/language/predefined/errorexception.xml
+++ b/language/predefined/errorexception.xml
@@ -7,19 +7,16 @@
  
  <partintro>
  
-<!-- {{{ ErrorException intro -->
   <section xml:id="errorexception.intro">
    &reftitle.intro;
    <para>
     エラー例外です。
    </para>
   </section>
-<!-- }}} -->
  
   <section xml:id="errorexception.synopsis">
    &reftitle.classsynopsis;
  
-<!-- {{{ Synopsis -->
    <classsynopsis class="class">
     <ooexception>
      <exceptionname>ErrorException</exceptionname>
@@ -39,28 +36,18 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.errorexception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ErrorException'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.errorexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ErrorException'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.errorexception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ErrorException'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.errorexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ErrorException'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
-<!-- }}} -->
  
   </section>
  
-<!-- {{{ ErrorException properties -->
   <section xml:id="errorexception.props">
    &reftitle.properties;
    <variablelist>
@@ -72,13 +59,11 @@
     </varlistentry>
    </variablelist>
   </section>
-<!-- }}} -->
-<!-- {{{ Example -->
 
   <section xml:id="errorexception.examples">
    &reftitle.examples;
    <para>
-    <example xml:id="errorexception.example.error-handler"><!-- {{{ -->
+    <example xml:id="errorexception.example.error-handler">
      <title><function>set_error_handler</function> を使用した、エラーメッセージから ErrorException への変換</title>
      <programlisting role="php">
  <![CDATA[
@@ -117,7 +102,7 @@ Stack trace:
   thrown in test.php on line 16
 ]]>
      </screen>
-    </example><!-- }}} -->
+    </example>
    </para>
   </section>
  

--- a/language/predefined/exception.xml
+++ b/language/predefined/exception.xml
@@ -8,7 +8,6 @@
  
  <partintro>
  
-<!-- {{{ Exception intro -->
   <section xml:id="exception.intro">
    &reftitle.intro;
    <para>
@@ -16,12 +15,10 @@
     すべてのユーザー例外の基底クラスです。
    </para>
   </section>
-<!-- }}} -->
  
   <section xml:id="exception.synopsis">
    &reftitle.classsynopsis;
  
-<!-- {{{ Synopsis -->
    <classsynopsis class="class">
     <ooexception>
      <exceptionname>Exception</exceptionname>
@@ -75,19 +72,13 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
  
-<!-- }}} -->
  
   </section>
  
-<!-- {{{ Exception properties -->
   <section xml:id="exception.props">
    &reftitle.properties;
    <variablelist>
@@ -135,7 +126,6 @@
     </varlistentry>
    </variablelist>
   </section>
-<!-- }}} -->
  
  </partintro>
  

--- a/language/predefined/fiber.xml
+++ b/language/predefined/fiber.xml
@@ -8,7 +8,6 @@
 
  <partintro>
 
-<!-- {{{ Fiber intro -->
   <section xml:id="fiber.intro">
    &reftitle.intro;
    <para>
@@ -17,12 +16,10 @@
     後に再開されるまで実行を停止したままにできます。
    </para>
   </section>
-<!-- }}} -->
 
   <section xml:id="fiber.synopsis">
    &reftitle.classsynopsis;
 
-<!-- {{{ Synopsis -->
    <classsynopsis class="class">
     <ooclass>
      <modifier>final</modifier>
@@ -30,14 +27,9 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.fiber')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Fiber'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.fiber')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Fiber'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.fiber')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Fiber'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.fiber')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Fiber'])"/>
    </classsynopsis>
-<!-- }}} -->
 
   </section>
 

--- a/language/predefined/fibererror.xml
+++ b/language/predefined/fibererror.xml
@@ -8,7 +8,6 @@
 
  <partintro>
 
-<!-- {{{ Error intro -->
   <section xml:id="fibererror.intro">
    &reftitle.intro;
    <para>
@@ -17,12 +16,10 @@
     に対して不正な操作が行われた場合にスローされます。
    </para>
   </section>
-<!-- }}} -->
 
   <section xml:id="fibererror.synopsis">
    &reftitle.classsynopsis;
 
-<!-- {{{ Synopsis -->
    <classsynopsis class="class">
     <ooexception>
      <modifier>final</modifier>
@@ -35,22 +32,15 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.fibererror')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='FiberError'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.fibererror')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='FiberError'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])"/>
    </classsynopsis>
 
-<!-- }}} -->
 
   </section>
  </partintro>

--- a/language/predefined/generator.xml
+++ b/language/predefined/generator.xml
@@ -9,7 +9,6 @@
 
  <partintro>
 
-<!-- {{{ Generator intro -->
   <section xml:id="generator.intro">
    &reftitle.intro;
    <para>
@@ -25,12 +24,10 @@
    </caution>
 
   </section>
-<!-- }}} -->
 
   <section xml:id="generator.synopsis">
    &reftitle.classsynopsis;
 
-<!-- {{{ Synopsis -->
    <classsynopsis class="class">
     <ooclass>
      <modifier>final</modifier>
@@ -43,11 +40,8 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.generator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Generator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.generator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Generator'])"/>
    </classsynopsis>
-<!-- }}} -->
 
   </section>
 

--- a/language/predefined/internaliterator.xml
+++ b/language/predefined/internaliterator.xml
@@ -7,7 +7,6 @@
 
  <partintro>
 
-<!-- {{{ InternalIterator intro -->
   <section xml:id="internaliterator.intro">
    &reftitle.intro;
    <para>
@@ -15,12 +14,10 @@
     <interfacename>IteratorAggregate</interfacename> を実装しやすくするためのクラスです。
    </para>
   </section>
-<!-- }}} -->
 
   <section xml:id="internaliterator.synopsis">
    &reftitle.classsynopsis;
 
-<!-- {{{ Synopsis -->
    <classsynopsis class="class">
     <ooclass>
      <modifier>final</modifier>
@@ -33,14 +30,9 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.internaliterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='InternalIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.internaliterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='InternalIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.internaliterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='InternalIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.internaliterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='InternalIterator'])"/>
    </classsynopsis>
-<!-- }}} -->
 
   </section>
 

--- a/language/predefined/iterator.xml
+++ b/language/predefined/iterator.xml
@@ -9,19 +9,16 @@
 
  <partintro>
 
-<!-- {{{ Iterator intro -->
   <section xml:id="iterator.intro">
    &reftitle.intro;
    <para>
     外部のイテレータあるいはオブジェクト自身から反復処理を行うためのインターフェイスです。
    </para>
   </section>
-<!-- }}} -->
 
   <section xml:id="iterator.synopsis">
    &reftitle.interfacesynopsis;
 
-<!-- {{{ Synopsis -->
    <classsynopsis class="interface">
     <oointerface>
      <interfacename>Iterator</interfacename>
@@ -33,11 +30,8 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Iterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Iterator'])"/>
    </classsynopsis>
-<!-- }}} -->
 
   </section>
   
@@ -51,7 +45,7 @@
 
   <section xml:id="iterator.examples">
    &reftitle.examples;
-   <example xml:id="iterator.example.basic"><!-- {{{ -->
+   <example xml:id="iterator.example.basic">
     <title>基本的な使用法</title>
     <para>
      この例は、イテレータで
@@ -137,7 +131,7 @@ string(16) "myIterator::next"
 string(17) "myIterator::valid"
 ]]>
     </screen>
-   </example><!-- }}} -->
+   </example>
   </section>
 
   <section xml:id="iterator.seealso">

--- a/language/predefined/iterator/key.xml
+++ b/language/predefined/iterator/key.xml
@@ -32,12 +32,12 @@
   </para>
  </refsect1>
 
- <refsect1 role="errors"><!-- {{{ -->
+ <refsect1 role="errors">
   &reftitle.errors;
   <para>
    失敗した場合に <constant>E_NOTICE</constant> を発行します。
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/language/predefined/iteratoraggregate.xml
+++ b/language/predefined/iteratoraggregate.xml
@@ -8,19 +8,16 @@
 
  <partintro>
 
-<!-- {{{ IteratorAggregate intro -->
   <section xml:id="iteratoraggregate.intro">
    &reftitle.intro;
    <para>
     外部イテレータを作成するためのインターフェイスです。
    </para>
   </section>
-<!-- }}} -->
 
   <section xml:id="iteratoraggregate.synopsis">
    &reftitle.interfacesynopsis;
 
-<!-- {{{ Synopsis -->
    <classsynopsis class="interface">
     <oointerface>
      <interfacename>IteratorAggregate</interfacename>
@@ -32,17 +29,14 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoraggregate')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorAggregate'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoraggregate')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorAggregate'])"/>
    </classsynopsis>
-<!-- }}} -->
 
   </section>
 
   <section xml:id="iteratoraggregate.examples">
    &reftitle.examples;
-   <example xml:id="iteratoraggregate.example.basic"><!-- {{{ -->
+   <example xml:id="iteratoraggregate.example.basic">
     <title>基本的な使用法</title>
     <programlisting role="php">
 <![CDATA[
@@ -82,7 +76,7 @@ string(10) "item three"
 
 ]]>
     </screen>
-   </example><!-- }}} -->
+   </example>
   </section>
 
 

--- a/language/predefined/iteratoraggregate/getiterator.xml
+++ b/language/predefined/iteratoraggregate/getiterator.xml
@@ -31,12 +31,12 @@
   </para>
  </refsect1>
 
- <refsect1 role="errors"><!-- {{{ -->
+ <refsect1 role="errors">
   &reftitle.errors;
   <para>
    失敗した場合は <classname>Exception</classname> をスローします。
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/language/predefined/parseerror.xml
+++ b/language/predefined/parseerror.xml
@@ -8,7 +8,6 @@
  
  <partintro>
  
-<!-- {{{ Error intro -->
   <section xml:id="parseerror.intro">
    &reftitle.intro;
    <para>
@@ -24,12 +23,10 @@
    </note> 
 
   </section>
-<!-- }}} -->
  
   <section xml:id="parseerror.synopsis">
    &reftitle.classsynopsis;
  
-<!-- {{{ Synopsis -->
    <classsynopsis class="class">
     <ooexception>
      <exceptionname>ParseError</exceptionname>
@@ -41,20 +38,13 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])"/>
    </classsynopsis>
  
-<!-- }}} -->
  
   </section>
  </partintro>

--- a/language/predefined/requestparsebodyexception.xml
+++ b/language/predefined/requestparsebodyexception.xml
@@ -8,7 +8,6 @@
 
  <partintro>
 
-<!-- {{{ Exception intro -->
   <section xml:id="RequestParseBodyException.intro">
    &reftitle.intro;
    <simpara>
@@ -17,12 +16,10 @@
     これは、 <literal>Content-Type</literal> ヘッダーに基づいて判断されます。
    </simpara>
   </section>
-<!-- }}} -->
 
   <section xml:id="RequestParseBodyException.synopsis">
    &reftitle.classsynopsis;
 
-<!-- {{{ Synopsis -->
    <classsynopsis class="class">
     <ooexception>
      <exceptionname>RequestParseBodyException</exceptionname>
@@ -34,20 +31,13 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 
-<!-- }}} -->
 
   </section>
  </partintro>

--- a/language/predefined/sensitiveparametervalue.xml
+++ b/language/predefined/sensitiveparametervalue.xml
@@ -7,7 +7,6 @@
 
  <partintro>
 
-<!-- {{{ SensitiveParameterValue intro -->
   <section xml:id="sensitiveparametervalue.intro">
    &reftitle.intro;
    <para>
@@ -21,12 +20,10 @@
     オブジェクトで自動的にラップされます。
    </para>
   </section>
-<!-- }}} -->
 
   <section xml:id="sensitiveparametervalue.synopsis">
    &reftitle.classsynopsis;
 
-<!-- {{{ Synopsis -->
    <classsynopsis class="class">
     <ooclass>
      <modifier>final</modifier>
@@ -42,14 +39,9 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sensitiveparametervalue')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SensitiveParameterValue'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sensitiveparametervalue')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SensitiveParameterValue'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sensitiveparametervalue')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SensitiveParameterValue'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sensitiveparametervalue')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SensitiveParameterValue'])"/>
    </classsynopsis>
-<!-- }}} -->
 
   </section>
 
@@ -67,7 +59,6 @@
     </varlistentry>
    </variablelist>
   </section>
-<!-- }}} -->
 
  </partintro>
 

--- a/language/predefined/serializable.xml
+++ b/language/predefined/serializable.xml
@@ -8,7 +8,6 @@
 
  <partintro>
 
-<!-- {{{ Serializable intro -->
   <section xml:id="serializable.intro">
    &reftitle.intro;
    <para>
@@ -37,29 +36,24 @@
     </para>
    </warning>
   </section>
-<!-- }}} -->
 
   <section xml:id="serializable.synopsis">
    &reftitle.interfacesynopsis;
 
-<!-- {{{ Synopsis -->
    <classsynopsis class="interface">
     <oointerface>
      <interfacename>Serializable</interfacename>
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.serializable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Serializable'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.serializable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Serializable'])"/>
    </classsynopsis>
-<!-- }}} -->
 
   </section>
 
   <section xml:id="serializable.examples">
    &reftitle.examples;
-   <example xml:id="serializable.example.basic"><!-- {{{ -->
+   <example xml:id="serializable.example.basic">
     <title>基本的な使用法</title>
     <programlisting role="php">
 <![CDATA[
@@ -99,7 +93,7 @@ string(38) "C:3:"obj":23:{s:15:"My private data";}"
 string(15) "My private data"
 ]]>
     </screen>
-   </example><!-- }}} -->
+   </example>
   </section>
 
 

--- a/language/predefined/stringable.xml
+++ b/language/predefined/stringable.xml
@@ -8,7 +8,6 @@
 
  <partintro>
 
-<!-- {{{ Stringable intro -->
   <section xml:id="stringable.intro">
    &reftitle.intro;
    <para>
@@ -32,23 +31,18 @@
     に対する型チェックを、関数ができるようにすることです。
    </para>
   </section>
-<!-- }}} -->
 
   <section xml:id="stringable.synopsis">
    &reftitle.interfacesynopsis;
 
-<!-- {{{ Synopsis -->
    <classsynopsis class="interface">
     <oointerface>
      <interfacename>Stringable</interfacename>
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.stringable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Stringable'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.stringable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Stringable'])"/>
    </classsynopsis>
-<!-- }}} -->
 
   </section>
 

--- a/language/predefined/throwable.xml
+++ b/language/predefined/throwable.xml
@@ -9,7 +9,6 @@
 
  <partintro>
 
-<!-- {{{ ThrowableInterface intro -->
   <section xml:id="throwable.intro">
    &reftitle.intro;
    <para>
@@ -25,12 +24,10 @@
     </para>
    </note>
   </section>
-<!-- }}} -->
 
   <section xml:id="throwable.synopsis">
    &reftitle.interfacesynopsis;
 
-<!-- {{{ Synopsis -->
    <classsynopsis class="interface">
     <oointerface>
      <interfacename>Throwable</interfacename>
@@ -42,16 +39,11 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.throwable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Throwable'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.throwable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Throwable'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.stringable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Stringable'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.stringable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Stringable'])"/>
    </classsynopsis>
-<!-- }}} -->
 
   </section>
 

--- a/language/predefined/traversable.xml
+++ b/language/predefined/traversable.xml
@@ -8,7 +8,6 @@
 
  <partintro>
 
-<!-- {{{ Traversable intro -->
   <section xml:id="traversable.intro">
    &reftitle.intro;
    <para>
@@ -20,18 +19,15 @@
     <interfacename>Iterator</interfacename> を実装しなければなりません。
    </para>
   </section>
-<!-- }}} -->
 
   <section xml:id="traversable.synopsis">
    &reftitle.interfacesynopsis;
 
-<!-- {{{ Synopsis -->
    <classsynopsis class="interface">
     <oointerface>
      <interfacename>Traversable</interfacename>
     </oointerface>
    </classsynopsis>
-<!-- }}} -->
 
    <para>
     このインターフェイスにはメソッドがありません。

--- a/language/predefined/typeerror.xml
+++ b/language/predefined/typeerror.xml
@@ -8,7 +8,6 @@
 
  <partintro>
 
-<!-- {{{ Error intro -->
   <section xml:id="typeerror.intro">
    &reftitle.intro;
    <para>
@@ -26,12 +25,10 @@
     </simplelist>
   </para>
   </section>
-<!-- }}} -->
 
   <section xml:id="typeerror.synopsis">
    &reftitle.classsynopsis;
 
-<!-- {{{ Synopsis -->
    <classsynopsis class="class">
     <ooexception>
      <exceptionname>TypeError</exceptionname>
@@ -43,20 +40,13 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])"/>
    </classsynopsis>
 
-<!-- }}} -->
 
   </section>
 

--- a/language/predefined/unhandledmatcherror.xml
+++ b/language/predefined/unhandledmatcherror.xml
@@ -7,7 +7,6 @@
 
  <partintro>
 
-<!-- {{{ Error intro -->
   <section xml:id="unhandledmatcherror.intro">
    &reftitle.intro;
    <para>
@@ -15,12 +14,10 @@
     &match; 式がどの分岐でも処理できなかったことを検知した場合にスローされます。
   </para>
   </section>
-<!-- }}} -->
 
   <section xml:id="unhandledmatcherror.synopsis">
    &reftitle.classsynopsis;
 
-<!-- {{{ Synopsis -->
    <classsynopsis class="class">
     <ooexception>
      <exceptionname>UnhandledMatchError</exceptionname>
@@ -32,20 +29,13 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])"/>
    </classsynopsis>
 
-<!-- }}} -->
 
   </section>
  </partintro>

--- a/language/predefined/unitenum.xml
+++ b/language/predefined/unitenum.xml
@@ -7,7 +7,6 @@
 
  <partintro>
 
-<!-- {{{ UnitEnum intro -->
   <section xml:id="unitenum.intro">
    &reftitle.intro;
    <para>
@@ -19,23 +18,18 @@
     このインターフェイスは、型チェックのためだけに存在しています。
    </para>
   </section>
-<!-- }}} -->
 
   <section xml:id="unitenum.synopsis">
    &reftitle.interfacesynopsis;
 
-<!-- {{{ Synopsis -->
    <classsynopsis class="interface">
     <oointerface>
      <interfacename>UnitEnum</interfacename>
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.unitenum')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='UnitEnum'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.unitenum')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='UnitEnum'])"/>
    </classsynopsis>
-<!-- }}} -->
 
   </section>
 

--- a/language/predefined/valueerror.xml
+++ b/language/predefined/valueerror.xml
@@ -7,7 +7,6 @@
 
  <partintro>
 
-<!-- {{{ Error intro -->
   <section xml:id="valueerror.intro">
    &reftitle.intro;
    <para>
@@ -17,12 +16,10 @@
     空でない文字列/配列を期待しているのに空の値を渡したりした場合です。
   </para>
   </section>
-<!-- }}} -->
 
   <section xml:id="valueerror.synopsis">
    &reftitle.classsynopsis;
 
-<!-- {{{ Synopsis -->
    <classsynopsis class="class">
     <ooexception>
      <exceptionname>ValueError</exceptionname>
@@ -34,19 +31,12 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])"/>
    </classsynopsis>
-<!-- }}} -->
   </section>
  </partintro>
 </reference>

--- a/language/predefined/weakmap.xml
+++ b/language/predefined/weakmap.xml
@@ -8,7 +8,6 @@
 
  <partintro>
 
-  <!-- {{{ WeakMap intro -->
   <section xml:id="weakmap.intro">
    &reftitle.intro;
    <para>
@@ -34,12 +33,10 @@
     連想配列と同じやり方で操作できます。
    </para>
   </section>
-  <!-- }}} -->
 
   <section xml:id="weakmap.synopsis">
    &reftitle.classsynopsis;
 
-   <!-- {{{ Synopsis -->
    <classsynopsis class="class">
     <ooclass>
      <modifier>final</modifier>
@@ -60,14 +57,10 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.weakmap')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='WeakMap'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.weakmap')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='WeakMap'])"/>
    </classsynopsis>
-   <!-- }}} -->
 
   </section>
-  <!-- {{{ weakmap examples -->
   <section xml:id="weakmap.examples">
    &reftitle.examples;
    <para>
@@ -108,7 +101,6 @@ int(0)
     </example>
    </para>
   </section>
-  <!-- }}} -->
 
  </partintro>
 

--- a/language/predefined/weakmap/getiterator.xml
+++ b/language/predefined/weakmap/getiterator.xml
@@ -32,12 +32,12 @@
   </para>
  </refsect1>
 
- <refsect1 role="errors"><!-- {{{ -->
+ <refsect1 role="errors">
   &reftitle.errors;
   <para>
    失敗した場合は <classname>Exception</classname> をスローします。
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/language/predefined/weakmap/offsetget.xml
+++ b/language/predefined/weakmap/offsetget.xml
@@ -39,7 +39,7 @@
   </para>
  </refsect1>
 
- <refsect1 role="errors"><!-- {{{ -->
+ <refsect1 role="errors">
   &reftitle.errors;
   <para>
    失敗した場合、<classname>Error</classname> をスローします。

--- a/language/predefined/weakreference.xml
+++ b/language/predefined/weakreference.xml
@@ -33,12 +33,8 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.weakreference')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='WeakReference'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.weakreference')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='WeakReference'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.weakreference')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='WeakReference'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.weakreference')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='WeakReference'])"/>
    </classsynopsis>
 
   </section>

--- a/language/wrappers/audio.xml
+++ b/language/wrappers/audio.xml
@@ -9,7 +9,7 @@
   <refpurpose>オーディオストリーム</refpurpose>
  </refnamediv>
 
- <refsect1 role="description"><!-- {{{ -->
+ <refsect1 role="description">
   &reftitle.description;
   <para>
    <filename>ogg://</filename> ラッパー経由で読み込みモードでオープンされた
@@ -37,18 +37,18 @@
     インストールする必要があります。
    </simpara>
   </note>
- </refsect1><!-- }}} -->
+ </refsect1>
 
- <refsect1 role="usage"> <!-- {{{ -->
+ <refsect1 role="usage">
   &reftitle.usage;
   <itemizedlist>
    <listitem><simpara><filename>ogg://soundfile.ogg</filename></simpara></listitem>
    <listitem><simpara><filename>ogg:///path/to/soundfile.ogg</filename></simpara></listitem>
    <listitem><simpara><filename>ogg://http://www.example.com/path/to/soundstream.ogg</filename></simpara></listitem>
   </itemizedlist>
- </refsect1> <!-- }}} -->
+ </refsect1>
 
- <refsect1 role="options"><!-- {{{ -->
+ <refsect1 role="options">
   &reftitle.options;
   <para>
    <table>
@@ -169,7 +169,7 @@
     </tgroup>
    </table>
   </para>
- </refsect1> <!-- }}} -->
+ </refsect1>
 
 </refentry>
 

--- a/language/wrappers/compression.xml
+++ b/language/wrappers/compression.xml
@@ -11,7 +11,7 @@
   <refpurpose>圧縮ストリーム</refpurpose>
  </refnamediv>
 
- <refsect1 role="description"><!-- {{{ -->
+ <refsect1 role="description">
   &reftitle.description;
   <simpara><filename>compress.zlib://</filename> および <filename>compress.bzip2://</filename></simpara>
 
@@ -39,18 +39,18 @@
    ストリームのコンテキストでパスワードを与えることが出来るようになりました。
    パスワードは、<literal>'password'</literal> コンテキストオプションで設定できます。
   </simpara>
- </refsect1><!-- }}} -->
+ </refsect1>
 
- <refsect1 role="usage"> <!-- {{{ -->
+ <refsect1 role="usage">
   &reftitle.usage;
   <itemizedlist>
    <listitem><simpara><filename>compress.zlib://file.gz</filename></simpara></listitem>
    <listitem><simpara><filename>compress.bzip2://file.bz2</filename></simpara></listitem>
    <listitem><simpara><filename>zip://archive.zip#dir/file.txt</filename></simpara></listitem>
   </itemizedlist>
- </refsect1> <!-- }}} -->
+ </refsect1>
 
- <refsect1 role="options"><!-- {{{ -->
+ <refsect1 role="options">
   &reftitle.options;
   <para>
    <table>
@@ -113,7 +113,7 @@
     </tgroup>
    </table>
   </para>
- </refsect1> <!-- }}} -->
+ </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/language/wrappers/data.xml
+++ b/language/wrappers/data.xml
@@ -9,23 +9,23 @@
   <refpurpose>データ (RFC 2397)</refpurpose>
  </refnamediv>
 
- <refsect1 role="description"><!-- {{{ -->
+ <refsect1 role="description">
   &reftitle.description;
   <para>
    <!-- TODO Proper description -->
    <filename>data:</filename> (<link xlink:href="&url.rfc;2397">RFC
    2397</link>) ストリームラッパーです。
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
 
- <refsect1 role="usage"> <!-- {{{ -->
+ <refsect1 role="usage">
   &reftitle.usage;
   <itemizedlist>
    <listitem><simpara><filename>data://text/plain;base64,</filename></simpara></listitem>
   </itemizedlist>
- </refsect1> <!-- }}} -->
+ </refsect1>
 
- <refsect1 role="options"><!-- {{{ -->
+ <refsect1 role="options">
   &reftitle.options;
   <para>
    <table>
@@ -86,9 +86,9 @@
     </tgroup>
    </table>
   </para>
- </refsect1> <!-- }}} -->
+ </refsect1>
 
- <refsect1 role="examples"><!-- {{{ -->
+ <refsect1 role="examples">
   &reftitle.examples;
   <example>
    <title>data:// の内容の表示</title>
@@ -116,7 +116,7 @@ echo $meta['mediatype'];
 ]]>
    </programlisting>
   </example>
- </refsect1><!-- }}} -->
+ </refsect1>
 
 </refentry>
 

--- a/language/wrappers/expect.xml
+++ b/language/wrappers/expect.xml
@@ -9,7 +9,7 @@
   <refpurpose>対話的プロセスストリーム</refpurpose>
  </refnamediv>
 
- <refsect1 role="description"><!-- {{{ -->
+ <refsect1 role="description">
   &reftitle.description;
   <simpara>
    <filename>expect://</filename> ラッパーでオープンしたストリームを使用すると、
@@ -26,16 +26,16 @@
    </simpara>
   </note>
   <simpara><filename>expect://</filename> (PECL) </simpara>
- </refsect1><!-- }}} -->
+ </refsect1>
 
- <refsect1 role="usage"> <!-- {{{ -->
+ <refsect1 role="usage">
   &reftitle.usage;
   <itemizedlist>
    <listitem><simpara><filename>expect://command</filename></simpara></listitem>
   </itemizedlist>
- </refsect1> <!-- }}} -->
+ </refsect1>
 
- <refsect1 role="options"><!-- {{{ -->
+ <refsect1 role="options">
   &reftitle.options;
   <para>
    <table>
@@ -92,7 +92,7 @@
     </tgroup>
    </table>
   </para>
- </refsect1> <!-- }}} -->
+ </refsect1>
 
 </refentry>
 

--- a/language/wrappers/file.xml
+++ b/language/wrappers/file.xml
@@ -9,7 +9,7 @@
   <refpurpose>ローカルファイルシステムへのアクセス</refpurpose>
  </refnamediv>
 
- <refsect1 role="description"><!-- {{{ -->
+ <refsect1 role="description">
   &reftitle.description;
   <para>
    <literal>file://</literal> is the default wrapper used with PHP and
@@ -35,9 +35,9 @@
    のようないくつかの関数については、相対パスと同時に <literal>include_path</literal>
    も検索されます。
   </simpara>
- </refsect1><!-- }}} -->
+ </refsect1>
 
- <refsect1 role="usage"> <!-- {{{ -->
+ <refsect1 role="usage">
   &reftitle.usage;
   <itemizedlist>
    <listitem><simpara><filename>/path/to/file.ext</filename></simpara></listitem>
@@ -48,9 +48,9 @@
    <listitem><simpara><filename>\\smbserver\share\path\to\winfile.ext</filename></simpara></listitem>
    <listitem><simpara><filename>file:///path/to/file.ext</filename></simpara></listitem>
   </itemizedlist>
- </refsect1> <!-- }}} -->
+ </refsect1>
 
- <refsect1 role="options"><!-- {{{ -->
+ <refsect1 role="options">
   &reftitle.options;
   <para>
    <table>
@@ -107,7 +107,7 @@
     </tgroup>
    </table>
   </para>
- </refsect1> <!-- }}} -->
+ </refsect1>
 
 </refentry>
 

--- a/language/wrappers/ftp.xml
+++ b/language/wrappers/ftp.xml
@@ -10,7 +10,7 @@
   <refpurpose>FTP(s) URL へのアクセス</refpurpose>
  </refnamediv>
 
- <refsect1 role="description"><!-- {{{ -->
+ <refsect1 role="description">
   &reftitle.description;
   <para>
    FTP 経由でのファイルの読み込みと新しいファイルの作成を許可します。
@@ -31,9 +31,9 @@
    &php.ini; で設定した場合、この値が
    anonymous FTP のパスワードとして送信されます。
   </simpara>
- </refsect1><!-- }}} -->
+ </refsect1>
 
- <refsect1 role="usage"> <!-- {{{ -->
+ <refsect1 role="usage">
   &reftitle.usage;
   <itemizedlist>
    <listitem><simpara><filename>ftp://example.com/pub/file.txt</filename></simpara></listitem>
@@ -41,9 +41,9 @@
    <listitem><simpara><filename>ftps://example.com/pub/file.txt</filename></simpara></listitem>
    <listitem><simpara><filename>ftps://user:password@example.com/pub/file.txt</filename></simpara></listitem>
   </itemizedlist>
- </refsect1> <!-- }}} -->
+ </refsect1>
 
- <refsect1 role="options"><!-- {{{ -->
+ <refsect1 role="options">
   &reftitle.options;
   <para>
    <table>
@@ -104,9 +104,9 @@
     </tgroup>
    </table>
   </para>
- </refsect1> <!-- }}} -->
+ </refsect1>
 
- <refsect1 role="notes"><!-- {{{ -->
+ <refsect1 role="notes">
   &reftitle.notes;
   <note>
    <para>
@@ -125,14 +125,14 @@
     ファイルの追記が可能です。
    </simpara>
   </note>
- </refsect1><!-- }}} -->
+ </refsect1>
 
- <refsect1 role="seealso"><!-- {{{ -->
+ <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
    <member><xref linkend="context.ftp" /></member>
   </simplelist>
- </refsect1><!-- }}} -->
+ </refsect1>
 
 </refentry>
 

--- a/language/wrappers/glob.xml
+++ b/language/wrappers/glob.xml
@@ -9,22 +9,22 @@
   <refpurpose>パターンにマッチするパス名の検索</refpurpose>
  </refnamediv>
 
- <refsect1 role="description"><!-- {{{ -->
+ <refsect1 role="description">
   &reftitle.description;
   <simpara>
    <!-- TODO Proper description -->
    <filename>glob:</filename> ストリームラッパーは、パターンにマッチするパス名の探索が行なえます。
   </simpara>
- </refsect1><!-- }}} -->
+ </refsect1>
 
- <refsect1 role="usage"> <!-- {{{ -->
+ <refsect1 role="usage">
   &reftitle.usage;
   <itemizedlist>
    <listitem><simpara><filename>glob://</filename></simpara></listitem>
   </itemizedlist>
- </refsect1> <!-- }}} -->
+ </refsect1>
 
- <refsect1 role="options"><!-- {{{ -->
+ <refsect1 role="options">
   &reftitle.options;
   <para>
    <table>
@@ -85,9 +85,9 @@
     </tgroup>
    </table>
   </para>
- </refsect1> <!-- }}} -->
+ </refsect1>
 
- <refsect1 role="examples"><!-- {{{ -->
+ <refsect1 role="examples">
   &reftitle.examples;
   <example>
    <title>基本的な使用法</title>
@@ -118,7 +118,7 @@ class_tree.php: 1.8K
 ]]>
    </screen>
   </example>
- </refsect1><!-- }}} -->
+ </refsect1>
 
 </refentry>
 

--- a/language/wrappers/http.xml
+++ b/language/wrappers/http.xml
@@ -10,7 +10,7 @@
   <refpurpose>HTTP(s) URL へのアクセス</refpurpose>
  </refnamediv>
 
- <refsect1 role="description"><!-- {{{ -->
+ <refsect1 role="description">
   &reftitle.description;
   <para>
    HTTP GET メソッドを用いて、
@@ -34,9 +34,9 @@
    <xref linkend="context" /> で上書きされていない場合は、その値が
    <literal>From:</literal> ヘッダとなります。
   </simpara>
- </refsect1><!-- }}} -->
+ </refsect1>
 
- <refsect1 role="usage"> <!-- {{{ -->
+ <refsect1 role="usage">
   &reftitle.usage;
   <itemizedlist>
    <listitem><simpara><filename>http://example.com</filename></simpara></listitem>
@@ -46,9 +46,9 @@
    <listitem><simpara><filename>https://example.com/file.php?var1=val1&amp;var2=val2</filename></simpara></listitem>
    <listitem><simpara><filename>https://user:password@example.com</filename></simpara></listitem>
   </itemizedlist>
- </refsect1> <!-- }}} -->
+ </refsect1>
 
- <refsect1 role="options"><!-- {{{ -->
+ <refsect1 role="options">
   &reftitle.options;
   <para>
    <table>
@@ -105,11 +105,11 @@
     </tgroup>
    </table>
   </para>
- </refsect1> <!-- }}} -->
+ </refsect1>
 
- <refsect1 role="examples"><!-- {{{ -->
+ <refsect1 role="examples">
   &reftitle.examples;
-  <example xml:id="wrappers.http.example.basic"><!-- {{{ -->
+  <example xml:id="wrappers.http.example.basic">
    <title>リダイレクト後の URL の検出</title>
    <programlisting role="php">
 <![CDATA[
@@ -133,10 +133,10 @@ foreach ($meta_data['wrapper_data'] as $response) {
 ?>
 ]]>
    </programlisting>
-  </example><!-- }}} -->
- </refsect1><!-- }}} -->
+  </example>
+ </refsect1>
 
- <refsect1 role="notes"><!-- {{{ -->
+ <refsect1 role="notes">
   &reftitle.notes;
   <note>
    <simpara>
@@ -152,16 +152,16 @@ foreach ($meta_data['wrapper_data'] as $response) {
    たとえば <emphasis>POST</emphasis> および <emphasis>PUT</emphasis> リクエストを送信することも、
    <link linkend="context.http">HTTP コンテキスト</link> を使えば可能です。
   </simpara>
- </refsect1><!-- }}} -->
+ </refsect1>
 
- <refsect1 role="seealso"><!-- {{{ -->
+ <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
    <member><xref linkend="context.http" /></member>
    <member><varname>$http_response_header</varname></member>
    <member><function>stream_get_meta_data</function></member>
   </simplelist>
- </refsect1><!-- }}} -->
+ </refsect1>
 
 </refentry>
 

--- a/language/wrappers/phar.xml
+++ b/language/wrappers/phar.xml
@@ -9,7 +9,7 @@
   <refpurpose>PHP アーカイブ</refpurpose>
  </refnamediv>
 
- <refsect1 role="description"><!-- {{{ -->
+ <refsect1 role="description">
   &reftitle.description;
   <!-- TODO Import description? -->
   <simpara>
@@ -17,16 +17,16 @@
    <link linkend="phar.using.stream">Phar ストリームラッパー</link>
    を参照ください。
   </simpara>
- </refsect1><!-- }}} -->
+ </refsect1>
 
- <refsect1 role="usage"> <!-- {{{ -->
+ <refsect1 role="usage">
   &reftitle.usage;
   <itemizedlist>
    <listitem><simpara><filename>phar://</filename></simpara></listitem>
   </itemizedlist>
- </refsect1> <!-- }}} -->
+ </refsect1>
 
- <refsect1 role="options"><!-- {{{ -->
+ <refsect1 role="options">
   &reftitle.options;
   <para>
    <table>
@@ -87,14 +87,14 @@
     </tgroup>
    </table>
   </para>
- </refsect1> <!-- }}} -->
+ </refsect1>
 
- <refsect1 role="seealso"><!-- {{{ -->
+ <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
    <member><xref linkend="context.phar" /></member>
   </simplelist>
- </refsect1><!-- }}} -->
+ </refsect1>
 
 </refentry>
 

--- a/language/wrappers/php.xml
+++ b/language/wrappers/php.xml
@@ -163,7 +163,7 @@
   </refsect2>
  </refsect1>
 
- <refsect1 role="options"><!-- {{{ -->
+ <refsect1 role="options">
   &reftitle.options;
   <para>
    <table>
@@ -270,11 +270,11 @@
     </tgroup>
    </table>
   </para>
- </refsect1> <!-- }}} -->
+ </refsect1>
 
- <refsect1 role="examples"><!-- {{{ -->
+ <refsect1 role="examples">
   &reftitle.examples;
-  <example><!-- {{{ -->
+  <example>
    <title>php://temp/maxmemory</title>
    <para>
     このオプションパラメータは、<filename>php://temp</filename>
@@ -295,8 +295,8 @@ echo stream_get_contents($fp);
 ?>
 ]]>
    </programlisting>
-  </example><!-- }}} -->
-  <example><!-- {{{ -->
+  </example>
+  <example>
    <title>php://filter/resource=&lt;フィルタの対象となるストリーム&gt;</title>
    <para>
     このパラメータは、
@@ -314,8 +314,8 @@ readfile("php://filter/resource=http://www.example.com");
 ?>
 ]]>
    </programlisting>
-  </example><!-- }}} -->
-  <example><!-- {{{ -->
+  </example>
+  <example>
    <title>php://filter/read=&lt;読み込みチェーンに適用するフィルタのリスト&gt;</title>
    <para>
     このパラメータは 1 つ以上のフィルタ名を
@@ -334,8 +334,8 @@ readfile("php://filter/read=string.toupper|string.rot13/resource=http://www.exam
 ?>
 ]]>
    </programlisting>
-  </example><!-- }}} -->
-  <example><!-- {{{ -->
+  </example>
+  <example>
    <title>php://filter/write=&lt;書き込みチェーンに適用するフィルタのリスト&gt;</title>
    <para>
     このパラメータは 1 つ以上のフィルタ名を
@@ -351,7 +351,7 @@ file_put_contents("php://filter/write=string.rot13/resource=example.txt","Hello 
 ?>
 ]]>
    </programlisting>
-  </example><!-- }}} -->
+  </example>
   <example>
    <title>php://memory と php://temp は再利用できない</title>
    <para>
@@ -388,7 +388,7 @@ print_r($json_array);
 ]]>
    </programlisting>
   </example>
- </refsect1><!-- }}} -->
+ </refsect1>
 </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/language/wrappers/rar.xml
+++ b/language/wrappers/rar.xml
@@ -9,7 +9,7 @@
   <refpurpose>RAR</refpurpose>
  </refnamediv>
 
- <refsect1 role="description"><!-- {{{ -->
+ <refsect1 role="description">
   &reftitle.description;
   <para>
    このラッパーが受け取るのは、RAR アーカイブへの URL エンコードされたパス
@@ -51,16 +51,16 @@
    は、PECL rar 3.0.0 以降で使用可能です。
   </simpara>
 
- </refsect1><!-- }}} -->
+ </refsect1>
 
- <refsect1 role="usage"> <!-- {{{ -->
+ <refsect1 role="usage">
   &reftitle.usage;
   <itemizedlist>
    <listitem><simpara><filename>rar://&lt;url encoded archive name&gt;[*][#[&lt;url encoded entry name&gt;]]</filename></simpara></listitem>
   </itemizedlist>
- </refsect1> <!-- }}} -->
+ </refsect1>
 
- <refsect1 role="options"><!-- {{{ -->
+ <refsect1 role="options">
   &reftitle.options;
   <para>
    <table>
@@ -171,9 +171,9 @@
     </tgroup>
    </table>
   </para>
- </refsect1> <!-- }}} -->
+ </refsect1>
 
- <refsect1 role="examples"><!-- {{{ -->
+ <refsect1 role="examples">
   &reftitle.examples;
   <example>
    <title>RAR アーカイブの走査</title>
@@ -278,7 +278,7 @@ Array
 ]]>
    </screen>
   </example>
- </refsect1><!-- }}} -->
+ </refsect1>
 
 </refentry>
 

--- a/language/wrappers/ssh2.xml
+++ b/language/wrappers/ssh2.xml
@@ -9,7 +9,7 @@
   <refpurpose>Secure Shell 2</refpurpose>
  </refnamediv>
 
- <refsect1 role="description"><!-- {{{ -->
+ <refsect1 role="description">
   &reftitle.description;
   <para>
    <filename>ssh2.shell://</filename>
@@ -34,9 +34,9 @@
    ssh2 ラッパーでは、URL のホスト部分に接続リソースを渡すことで既にオープン
    している接続を再利用することが可能です。
   </simpara>
- </refsect1><!-- }}} -->
+ </refsect1>
 
- <refsect1 role="usage"> <!-- {{{ -->
+ <refsect1 role="usage">
   &reftitle.usage;
   <itemizedlist>
    <listitem><simpara><filename>ssh2.shell://user:pass@example.com:22/xterm</filename></simpara></listitem>
@@ -44,9 +44,9 @@
    <listitem><simpara><filename>ssh2.tunnel://user:pass@example.com:22/192.168.0.1:14</filename></simpara></listitem>
    <listitem><simpara><filename>ssh2.sftp://user:pass@example.com:22/path/to/filename</filename></simpara></listitem>
   </itemizedlist>
- </refsect1> <!-- }}} -->
+ </refsect1>
 
- <refsect1 role="options"><!-- {{{ -->
+ <refsect1 role="options">
   &reftitle.options;
   <para>
    <table>
@@ -231,9 +231,9 @@
     </tgroup>
    </table>
   </para>
- </refsect1> <!-- }}} -->
+ </refsect1>
 
- <refsect1 role="examples"><!-- {{{ -->
+ <refsect1 role="examples">
   &reftitle.examples;
   <example>
    <title>アクティブな接続からストリームをオープンする</title>
@@ -276,7 +276,7 @@ $stream = fopen($connection_string . "path/to/file", 'r');
    </simpara>
   </example>
 
- </refsect1><!-- }}} -->
+ </refsect1>
 
 </refentry>
 

--- a/reference/apcu/apcuiterator.xml
+++ b/reference/apcu/apcuiterator.xml
@@ -45,12 +45,8 @@
 <!-- }}} -->
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.apcuiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.apcuiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.apcuiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.apcuiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
 
    </classsynopsis>
 <!-- }}} -->

--- a/reference/bc/bcmath.number.xml
+++ b/reference/bc/bcmath.number.xml
@@ -65,12 +65,8 @@
      </fieldsynopsis>
 
      <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.bcmath-number')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='BcMath\\Number'])">
-      <xi:fallback/>
-     </xi:include>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.bcmath-number')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='BcMath\\Number'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.bcmath-number')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='BcMath\\Number'])"/>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.bcmath-number')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='BcMath\\Number'])"/>
     </classsynopsis>
    </packagesynopsis>
   </section>

--- a/reference/bc/book.xml
+++ b/reference/bc/book.xml
@@ -8,7 +8,6 @@
  <title>BCMath 任意精度数学関数</title>
  <titleabbrev>BC Math</titleabbrev>
  
- <!-- {{{ preface -->
  <preface xml:id="intro.bc">
   &reftitle.intro;
   <para>
@@ -51,7 +50,6 @@ echo bcsub($num1, $num2, 1); // => '0.0'
   </caution>
 
  </preface>
- <!-- }}} -->
 
  &reference.bc.setup;
  &reference.bc.reference;

--- a/reference/bc/functions/bcmod.xml
+++ b/reference/bc/functions/bcmod.xml
@@ -37,7 +37,7 @@
 
  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.bcdiv')/db:refsect1[@role='errors'])" />
 
- <refsect1 role="changelog"><!-- {{{ -->
+ <refsect1 role="changelog">
   &reftitle.changelog;
   <informaltable>
    <tgroup cols="2">
@@ -80,7 +80,7 @@
     </tbody>
    </tgroup>
   </informaltable>
- </refsect1><!-- }}} -->
+ </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/bc/functions/bcmul.xml
+++ b/reference/bc/functions/bcmul.xml
@@ -35,7 +35,7 @@
  
  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.bcadd')/db:refsect1[@role='errors'])" />
 
- <refsect1 role="changelog"><!-- {{{ -->
+ <refsect1 role="changelog">
   &reftitle.changelog;
   <informaltable>
    <tgroup cols="2">
@@ -63,7 +63,7 @@
     </tbody>
    </tgroup>
   </informaltable>
- </refsect1><!-- }}} -->
+ </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/bc/functions/bcpow.xml
+++ b/reference/bc/functions/bcpow.xml
@@ -74,7 +74,7 @@
   </simpara>
  </refsect1>
 
- <refsect1 role="changelog"><!-- {{{ -->
+ <refsect1 role="changelog">
   &reftitle.changelog;
   <informaltable>
    <tgroup cols="2">
@@ -110,7 +110,7 @@
     </tbody>
    </tgroup>
   </informaltable>
- </refsect1><!-- }}} -->
+ </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/bc/setup.xml
+++ b/reference/bc/setup.xml
@@ -8,11 +8,9 @@
 
  <!-- {{{ Installation -->
  &reference.bc.configure;
- <!-- }}} -->
 
  <!-- {{{ Configuration -->
  &reference.bc.ini;
- <!-- }}} -->
 
 </chapter>
 

--- a/reference/com/com-exception.xml
+++ b/reference/com/com-exception.xml
@@ -33,17 +33,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/com/com.xml
+++ b/reference/com/com.xml
@@ -33,9 +33,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.com')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='com'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.com')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='com'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/com/compersisthelper.xml
+++ b/reference/com/compersisthelper.xml
@@ -31,12 +31,8 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.compersisthelper')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='COMPersistHelper'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.compersisthelper')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='COMPersistHelper'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.compersisthelper')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='COMPersistHelper'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.compersisthelper')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='COMPersistHelper'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/com/dotnet.xml
+++ b/reference/com/dotnet.xml
@@ -60,9 +60,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dotnet')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='dotnet'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dotnet')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='dotnet'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/com/variant.xml
+++ b/reference/com/variant.xml
@@ -29,9 +29,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.variant')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='variant'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.variant')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='variant'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/curl/curlfile.xml
+++ b/reference/curl/curlfile.xml
@@ -53,12 +53,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.curlfile')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='CURLFile'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.curlfile')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='CURLFile'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.curlfile')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='CURLFile'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.curlfile')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='CURLFile'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/curl/curlstringfile.xml
+++ b/reference/curl/curlstringfile.xml
@@ -49,9 +49,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.curlstringfile')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='CURLStringFile'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.curlstringfile')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='CURLStringFile'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/curl/functions/curl-multi-errno.xml
+++ b/reference/curl/functions/curl-multi-errno.xml
@@ -8,7 +8,7 @@
   <refpurpose>直近のマルチハンドルに対するエラー番号を返す</refpurpose>
  </refnamediv>
 
- <refsect1 role="description"><!-- {{{ -->
+ <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
    <type>int</type><methodname>curl_multi_errno</methodname>
@@ -17,21 +17,21 @@
   <para>
    直近のマルチハンドルに対するエラー番号を含んだ数値を返します。
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
 
- <refsect1 role="parameters"><!-- {{{ -->
+ <refsect1 role="parameters">
   &reftitle.parameters;
   <variablelist>
     &curl.mh.description;
   </variablelist>
- </refsect1><!-- }}} -->
+ </refsect1>
 
- <refsect1 role="returnvalues"><!-- {{{ -->
+ <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
    直近のマルチハンドルに対するエラー番号を含んだ数値を返します。
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
 
  <refsect1 role="changelog">
   &reftitle.changelog;
@@ -56,12 +56,12 @@
   </informaltable>
  </refsect1>
 
- <refsect1 role="seealso"><!-- {{{ -->
+ <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
    <member><function>curl_errno</function></member>
   </simplelist>
- </refsect1><!-- }}} -->
+ </refsect1>
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/curl/functions/curl-share-errno.xml
+++ b/reference/curl/functions/curl-share-errno.xml
@@ -8,7 +8,7 @@
   <refpurpose>直近の共有ハンドルに対するエラー番号を返す</refpurpose>
  </refnamediv>
 
- <refsect1 role="description"><!-- {{{ -->
+ <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
    <type>int</type><methodname>curl_share_errno</methodname>
@@ -17,21 +17,21 @@
   <para>
    直近の共有ハンドルに対するエラー番号を含んだ数値を返します。
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
 
- <refsect1 role="parameters"><!-- {{{ -->
+ <refsect1 role="parameters">
   &reftitle.parameters;
   <variablelist>
    &curl.sh.description;
   </variablelist>
- </refsect1><!-- }}} -->
+ </refsect1>
 
- <refsect1 role="returnvalues"><!-- {{{ -->
+ <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
    直近の共有ハンドルに対するエラー番号を含んだ数値を返します。
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
 
  <refsect1 role="changelog">
   &reftitle.changelog;
@@ -56,12 +56,12 @@
   </informaltable>
  </refsect1>
 
- <refsect1 role="seealso"><!-- {{{ -->
+ <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
    <member><function>curl_errno</function></member>
   </simplelist>
- </refsect1><!-- }}} -->
+ </refsect1>
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/curl/functions/curl-share-strerror.xml
+++ b/reference/curl/functions/curl-share-strerror.xml
@@ -8,7 +8,7 @@
   <refpurpose>与えられたエラーコードを説明する文字列を返す</refpurpose>
  </refnamediv>
 
- <refsect1 role="description"><!-- {{{ -->
+ <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
    <type class="union"><type>string</type><type>null</type></type><methodname>curl_share_strerror</methodname>
@@ -17,9 +17,9 @@
   <para>
    与えられたエラーコードを説明する、テキストのエラーメッセージを返します。
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
 
- <refsect1 role="parameters"><!-- {{{ -->
+ <refsect1 role="parameters">
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
@@ -31,23 +31,23 @@
     </listitem>
    </varlistentry>
   </variablelist>
- </refsect1><!-- }}} -->
+ </refsect1>
 
- <refsect1 role="returnvalues"><!-- {{{ -->
+ <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
    エラーの説明を返します。
    不正なエラーコードの場合は、&null; を返します。
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
 
- <refsect1 role="seealso"><!-- {{{ -->
+ <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
    <member><function>curl_share_errno</function></member>
    <member><function>curl_strerror</function></member>
   </simplelist>
- </refsect1><!-- }}} -->
+ </refsect1>
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/datetime/dateerror.xml
+++ b/reference/datetime/dateerror.xml
@@ -38,17 +38,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/datetime/dateexception.xml
+++ b/reference/datetime/dateexception.xml
@@ -42,17 +42,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/datetime/dateinterval.xml
+++ b/reference/datetime/dateinterval.xml
@@ -9,7 +9,6 @@
 
  <partintro>
 
-<!-- {{{ DateInterval intro -->
   <section xml:id="dateinterval.intro">
    &reftitle.intro;
    <para>
@@ -39,12 +38,10 @@
     <link linkend="language.operators.comparison.incomparable">比較できません</link>。
    </para>
   </section>
-<!-- }}} -->
 
   <section xml:id="dateinterval.synopsis">
    &reftitle.classsynopsis;
 
-<!-- {{{ Synopsis -->
    <classsynopsis class="class">
     <ooclass>
      <classname>DateInterval</classname>
@@ -108,14 +105,9 @@
     </fieldsynopsis>
     
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dateinterval')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DateInterval'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dateinterval')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DateInterval'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dateinterval')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DateInterval'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dateinterval')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DateInterval'])"/>
    </classsynopsis>
-<!-- }}} -->
 
   </section>
   
@@ -233,7 +225,7 @@
    </variablelist>
   </section>
 
-  <section role="changelog" xml:id="dateinterval.changelog"><!-- {{{ -->
+  <section role="changelog" xml:id="dateinterval.changelog">
    &reftitle.changelog;
    <para>
     <informaltable>
@@ -281,7 +273,7 @@
      </tgroup>
     </informaltable>
    </para>
-  </section><!-- }}} -->
+  </section>
 
  </partintro>
 

--- a/reference/datetime/dateinvalidoperationexception.xml
+++ b/reference/datetime/dateinvalidoperationexception.xml
@@ -39,17 +39,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/datetime/dateinvalidtimezoneexception.xml
+++ b/reference/datetime/dateinvalidtimezoneexception.xml
@@ -31,17 +31,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/datetime/datemalformedintervalstringexception.xml
+++ b/reference/datetime/datemalformedintervalstringexception.xml
@@ -31,17 +31,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/datetime/datemalformedperiodstringexception.xml
+++ b/reference/datetime/datemalformedperiodstringexception.xml
@@ -31,17 +31,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/datetime/datemalformedstringexception.xml
+++ b/reference/datetime/datemalformedstringexception.xml
@@ -38,17 +38,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/datetime/dateobjecterror.xml
+++ b/reference/datetime/dateobjecterror.xml
@@ -36,17 +36,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/datetime/dateperiod.xml
+++ b/reference/datetime/dateperiod.xml
@@ -93,12 +93,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dateperiod')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DatePeriod'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dateperiod')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DatePeriod'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dateperiod')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DatePeriod'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dateperiod')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DatePeriod'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/datetime/daterangeerror.xml
+++ b/reference/datetime/daterangeerror.xml
@@ -36,17 +36,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/datetime/datetime.xml
+++ b/reference/datetime/datetime.xml
@@ -9,7 +9,6 @@
 
  <partintro>
 
-<!-- {{{ DateTime intro -->
   <section xml:id="datetime.intro">
    &reftitle.intro;
    <para>
@@ -33,12 +32,10 @@
     </para>
    </warning>
   </section>
-<!-- }}} -->
 
   <section xml:id="datetime.synopsis">
    &reftitle.classsynopsis;
 
-<!-- {{{ Synopsis -->
    <classsynopsis class="class">
     <ooclass>
      <classname>DateTime</classname>
@@ -50,26 +47,17 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.datetimeinterface')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.datetimeinterface')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.datetime')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DateTime'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.datetime')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DateTime'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.datetimeinterface')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DateTime'])">
-    <xi:fallback/>
-   </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.datetime')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DateTime'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.datetime')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DateTime'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.datetimeinterface')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DateTime'])"/>
   </classsynopsis>
-<!-- }}} -->
 
   </section>
 
- <section role="changelog" xml:id="datetime.changelog"><!-- {{{ -->
+ <section role="changelog" xml:id="datetime.changelog">
   &reftitle.changelog;
   <para>
    <informaltable>
@@ -107,7 +95,7 @@
     </tgroup>
    </informaltable>
   </para>
- </section><!-- }}} -->
+ </section>
 
 
  </partintro>

--- a/reference/datetime/datetimeimmutable.xml
+++ b/reference/datetime/datetimeimmutable.xml
@@ -9,7 +9,6 @@
 
  <partintro>
 
-<!-- {{{ DateTimeImmutable intro -->
   <section xml:id="datetimeimmutable.intro">
    &reftitle.intro;
    <para>
@@ -23,12 +22,10 @@
     状態を変更して新しいオブジェクトを返すメソッドが呼び出された時を除きます。
    </para>
   </section>
-<!-- }}} -->
 
   <section xml:id="datetimeimmutable.synopsis">
    &reftitle.classsynopsis;
 
-<!-- {{{ Synopsis -->
    <classsynopsis class="class">
     <ooclass>
      <classname>DateTimeImmutable</classname>
@@ -40,26 +37,17 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.datetimeinterface')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.datetimeinterface')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.datetimeimmutable')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DateTimeImmutable'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.datetimeimmutable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DateTimeImmutable'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.datetimeinterface')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DateTimeImmutable'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.datetimeimmutable')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DateTimeImmutable'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.datetimeimmutable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DateTimeImmutable'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.datetimeinterface')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DateTimeImmutable'])"/>
    </classsynopsis>
-<!-- }}} -->
 
   </section>
 
- <section role="changelog" xml:id="datetimeimmutable.changelog"><!-- {{{ -->
+ <section role="changelog" xml:id="datetimeimmutable.changelog">
   &reftitle.changelog;
   <para>
    <informaltable>
@@ -90,7 +78,7 @@
     </tgroup>
    </informaltable>
   </para>
- </section><!-- }}} -->
+ </section>
  </partintro>
 
  &reference.datetime.entities.datetimeimmutable;

--- a/reference/datetime/datetimeinterface.xml
+++ b/reference/datetime/datetimeinterface.xml
@@ -9,7 +9,6 @@
 
  <partintro>
 
-<!-- {{{ DateTimeInterface intro -->
   <section xml:id="datetimeinterface.intro">
    &reftitle.intro;
    <para>
@@ -26,12 +25,10 @@
     このインターフェイスに定義されています。
    </para>
   </section>
-<!-- }}} -->
 
   <section xml:id="datetimeinterface.synopsis">
    &reftitle.interfacesynopsis;
 
-<!-- {{{ Synopsis -->
    <classsynopsis class="interface">
     <oointerface>
      <interfacename>DateTimeInterface</interfacename>
@@ -138,15 +135,11 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.datetimeinterface')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DateTimeInterface'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.datetimeinterface')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DateTimeInterface'])"/>
    </classsynopsis>
-<!-- }}} -->
 
   </section>
 
-<!-- {{{ DateTimeInterface constants -->
   <section xml:id="datetimeinterface.constants.types">
    &reftitle.constants;
    <variablelist>
@@ -352,9 +345,8 @@
 
    </variablelist>
   </section>
-<!-- }}} -->
 
-  <section role="changelog" xml:id="datetimeinterface.changelog"><!-- {{{ -->
+  <section role="changelog" xml:id="datetimeinterface.changelog">
    &reftitle.changelog;
    <para>
     <informaltable>
@@ -396,7 +388,7 @@
      </tgroup>
     </informaltable>
    </para>
-  </section><!-- }}} -->
+  </section>
 
  </partintro>
 

--- a/reference/datetime/datetimezone.xml
+++ b/reference/datetime/datetimezone.xml
@@ -113,12 +113,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.datetimezone')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DateTimeZone'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.datetimezone')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DateTimeZone'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.datetimezone')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DateTimeZone'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.datetimezone')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DateTimeZone'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/datetime/formats.xml
+++ b/reference/datetime/formats.xml
@@ -302,9 +302,7 @@ object(DateTimeImmutable)#1 (3) {
    </tgroup>
   </table>
  </sect1>
- <!--}}}-->
 
- <!--Date Formats: {{{-->
  <sect1 annotations="chunk:false" xml:id="datetime.formats.date">
   <title>日付の書式</title>
   
@@ -610,9 +608,7 @@ object(DateTimeImmutable)#1 (3) {
    </para>
   </caution>
  </sect1>
- <!--}}}-->
 
- <!--Compound Formats: {{{-->
  <sect1 annotations="chunk:false" xml:id="datetime.formats.compound">
   <title>複合的な書式</title>
 
@@ -894,9 +890,7 @@ object(DateTimeImmutable)#1 (3) {
    </para>
   </note>
  </sect1>
- <!--}}}-->
 
- <!--Relative Formats: {{{-->
  <sect1 annotations="chunk:false" xml:id="datetime.formats.relative">
   <title>相対的な書式</title>
   <para>
@@ -1262,7 +1256,6 @@ object(DateTimeImmutable)#1 (3) {
    </para>
   </sect2>
  </sect1>
- <!--}}}-->
 
 </chapter>
 

--- a/reference/dir/directory.xml
+++ b/reference/dir/directory.xml
@@ -44,9 +44,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.directory')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Directory'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.directory')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Directory'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/dom/dom/attr/isid.xml
+++ b/reference/dom/dom/attr/isid.xml
@@ -28,9 +28,7 @@
  </refsect1>
 
  <refsect1 role="returnvalues">
-  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domattr.isid')/db:refsect1[@role='returnvalues']/*)">
-   <xi:fallback/>
-  </xi:include>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domattr.isid')/db:refsect1[@role='returnvalues']/*)"/>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/dom/dom/dom-attr.xml
+++ b/reference/dom/dom/dom-attr.xml
@@ -32,9 +32,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
@@ -80,20 +78,14 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-attr')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Attr'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-attr')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Attr'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])"/>-->
    </classsynopsis>
   </section>
 

--- a/reference/dom/dom/dom-cdatasection.xml
+++ b/reference/dom/dom/dom-cdatasection.xml
@@ -34,32 +34,18 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-text')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-characterdata')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-text')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-characterdata')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-text')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Text'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-characterdata')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\CharacterData'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-text')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Text'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-characterdata')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\CharacterData'])"/>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])"/>-->
    </classsynopsis>
 
   </section>

--- a/reference/dom/dom/dom-characterdata.xml
+++ b/reference/dom/dom/dom-characterdata.xml
@@ -7,9 +7,7 @@
 
  <partintro>
   <section xml:id="dom-characterdata.intro">
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.intro')/*)">
-    <xi:fallback/>
-   </xi:include>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.intro')/*)"/>
    <simpara>
     このクラスは、<classname>DOMCharacterData</classname> と同等ですが、
     モダンかつ仕様に準拠しています。
@@ -34,9 +32,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
@@ -64,20 +60,14 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-characterdata')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\CharacterData'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-characterdata')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\CharacterData'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])"/>-->
    </classsynopsis>
   </section>
 
@@ -85,24 +75,16 @@
    &reftitle.properties;
    <variablelist>
     <varlistentry xml:id="dom-characterdata.props.previouselementsibling">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.props.previouselementsibling')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.props.previouselementsibling')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-characterdata.props.nextelementsibling">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.props.nextelementsibling')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.props.nextelementsibling')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-characterdata.props.data">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.props.data')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.props.data')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-characterdata.props.length">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.props.length')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.props.length')/*)"/>
     </varlistentry>
    </variablelist>
   </section>

--- a/reference/dom/dom/dom-childnode.xml
+++ b/reference/dom/dom/dom-childnode.xml
@@ -24,9 +24,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-childnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\ChildNode'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-childnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\ChildNode'])"/>
    </classsynopsis>
   </section>
 

--- a/reference/dom/dom/dom-comment.xml
+++ b/reference/dom/dom/dom-comment.xml
@@ -8,9 +8,7 @@
  <partintro>
 
   <section xml:id="dom-comment.intro">
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcomment.intro')/*)">
-    <xi:fallback/>
-   </xi:include>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcomment.intro')/*)"/>
    <simpara>
     このクラスは、<classname>DOMComment</classname> と同等ですが、
     モダンかつ仕様に準拠しています。
@@ -31,26 +29,16 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-characterdata')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-characterdata')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-characterdata')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\CharacterData'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-characterdata')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\CharacterData'])"/>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])"/>-->
    </classsynopsis>
   </section>
 

--- a/reference/dom/dom/dom-document.xml
+++ b/reference/dom/dom/dom-document.xml
@@ -8,9 +8,7 @@
  <partintro>
 
   <section xml:id="dom-document.intro">
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.intro')/*)">
-    <xi:fallback/>
-   </xi:include>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.intro')/*)"/>
    <simpara>
     このクラスは、<classname>DOMDocument</classname> と同等ですが、
     モダンかつ仕様に準拠しています。
@@ -39,9 +37,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
@@ -129,21 +125,15 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-document')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Document'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-document')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Document'])"/>-->
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])"/>-->
    </classsynopsis>
   </section>
 
@@ -151,14 +141,10 @@
    &reftitle.properties;
    <variablelist>
     <varlistentry xml:id="dom-document.props.implementation">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.props.implementation')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.props.implementation')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-document.props.doctype">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.props.doctype')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.props.doctype')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-document.props.url">
      <term><varname>URL</varname></term>
@@ -188,9 +174,7 @@
      </listitem>
     </varlistentry>
     <varlistentry xml:id="dom-document.props.documenturi">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.props.documenturi')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.props.documenturi')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-document.props.documentelement">
      <term><varname>documentElement</varname></term>
@@ -202,24 +186,16 @@
      </listitem>
     </varlistentry>
     <varlistentry xml:id="dom-document.props.firstelementchild">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.props.firstelementchild')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.props.firstelementchild')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-document.props.lastelementchild">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.props.lastelementchild')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.props.lastelementchild')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-document.props.childelementcount">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.props.childelementcount')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.props.childelementcount')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-document.props.children">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('dom-parentnode.props.children')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('dom-parentnode.props.children')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-document.props.body">
      <term><varname>body</varname></term>

--- a/reference/dom/dom/dom-documentfragment.xml
+++ b/reference/dom/dom/dom-documentfragment.xml
@@ -38,9 +38,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
@@ -69,21 +67,15 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-documentfragment')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\DocumentFragment'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-documentfragment')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\DocumentFragment'])"/>-->
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])"/>-->
    </classsynopsis>
   </section>
 
@@ -91,24 +83,16 @@
    &reftitle.properties;
    <variablelist>
     <varlistentry xml:id="dom-documentfragment.props.firstelementchild">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocumentfragment.props.firstelementchild')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocumentfragment.props.firstelementchild')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-documentfragment.props.lastelementchild">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocumentfragment.props.lastelementchild')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocumentfragment.props.lastelementchild')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-documentfragment.props.childelementcount">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocumentfragment.props.childelementcount')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocumentfragment.props.childelementcount')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-documentfragment.props.children">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('dom-parentnode.props.children')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('dom-parentnode.props.children')/*)"/>
     </varlistentry>
    </variablelist>
   </section>

--- a/reference/dom/dom/dom-documenttype.xml
+++ b/reference/dom/dom/dom-documenttype.xml
@@ -39,9 +39,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
@@ -82,21 +80,15 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-documenttype')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\DocumentType'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-documenttype')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\DocumentType'])"/>-->
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])"/>-->
    </classsynopsis>
   </section>
 
@@ -104,19 +96,13 @@
    &reftitle.properties;
    <variablelist>
     <varlistentry xml:id="dom-documenttype.props.publicid">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocumenttype.props.publicid')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocumenttype.props.publicid')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-documenttype.props.systemid">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocumenttype.props.systemid')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocumenttype.props.systemid')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-documenttype.props.name">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocumenttype.props.name')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocumenttype.props.name')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-documenttype.props.entities">
      <term><varname>entities</varname></term>
@@ -138,9 +124,7 @@
      </listitem>
     </varlistentry>
     <varlistentry xml:id="dom-documenttype.props.internalsubset">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocumenttype.props.internalsubset')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocumenttype.props.internalsubset')/*)"/>
     </varlistentry>
    </variablelist>
   </section>

--- a/reference/dom/dom/dom-dtdnamednodemap.xml
+++ b/reference/dom/dom/dom-dtdnamednodemap.xml
@@ -42,9 +42,7 @@
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-dtdnamednodemap')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\DtdNamedNodeMap'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-dtdnamednodemap')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\DtdNamedNodeMap'])"/>-->
    </classsynopsis>
   </section>
 

--- a/reference/dom/dom/dom-element.xml
+++ b/reference/dom/dom/dom-element.xml
@@ -41,9 +41,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
@@ -145,21 +143,15 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-element')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Element'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-element')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Element'])"/>-->
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])"/>-->
    </classsynopsis>
   </section>
 
@@ -191,9 +183,7 @@
      </listitem>
     </varlistentry>
     <varlistentry xml:id="dom-element.props.classname">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domelement.props.classname')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domelement.props.classname')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-element.props.classlist">
      <term><varname>classList</varname></term>
@@ -214,39 +204,25 @@
      </listitem>
     </varlistentry>
     <varlistentry xml:id="dom-element.props.id">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domelement.props.id')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domelement.props.id')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-element.props.firstelementchild">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domelement.props.firstelementchild')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domelement.props.firstelementchild')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-element.props.lastelementchild">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domelement.props.lastelementchild')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domelement.props.lastelementchild')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-element.props.childelementcount">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domelement.props.childelementcount')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domelement.props.childelementcount')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-element.props.previouselementsibling">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domelement.props.previouselementsibling')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domelement.props.previouselementsibling')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-element.props.nextelementsibling">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domelement.props.nextelementsibling')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domelement.props.nextelementsibling')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-element.props.children">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('dom-parentnode.props.children')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('dom-parentnode.props.children')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-element.props.innerhtml">
      <term><varname>innerHTML</varname></term>

--- a/reference/dom/dom/dom-entity.xml
+++ b/reference/dom/dom/dom-entity.xml
@@ -8,9 +8,7 @@
 
  <partintro>
   <section xml:id="dom-entity.intro">
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domentity.intro')/*)">
-    <xi:fallback/>
-   </xi:include>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domentity.intro')/*)"/>
    <simpara>
     このクラスは、<classname>DOMEntity</classname> と同等ですが、
     モダンかつ仕様に準拠しています。
@@ -30,9 +28,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
@@ -55,15 +51,11 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])"/>-->
    </classsynopsis>
   </section>
 
@@ -71,19 +63,13 @@
    &reftitle.properties;
    <variablelist>
     <varlistentry xml:id="dom-entity.props.publicid">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domentity.props.publicid')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domentity.props.publicid')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-entity.props.systemid">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domentity.props.systemid')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domentity.props.systemid')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-entity.props.notationname">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domentity.props.notationname')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domentity.props.notationname')/*)"/>
     </varlistentry>
    </variablelist>
   </section>

--- a/reference/dom/dom/dom-entityreference.xml
+++ b/reference/dom/dom/dom-entityreference.xml
@@ -29,20 +29,14 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])"/>-->
    </classsynopsis>
   </section>
 

--- a/reference/dom/dom/dom-htmlcollection.xml
+++ b/reference/dom/dom/dom-htmlcollection.xml
@@ -41,9 +41,7 @@
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-htmlcollection')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\HTMLCollection'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-htmlcollection')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\HTMLCollection'])"/>-->
    </classsynopsis>
   </section>
 

--- a/reference/dom/dom/dom-htmldocument.xml
+++ b/reference/dom/dom/dom-htmldocument.xml
@@ -29,31 +29,19 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-document')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-document')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-htmldocument')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\HTMLDocument'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-htmldocument')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\HTMLDocument'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-document')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Document'])">
-     <xi:fallback/>
-    </xi:include>-->
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Document'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-document')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Document'])"/>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Document'])"/>-->
    </classsynopsis>
   </section>
 

--- a/reference/dom/dom/dom-htmlelement.xml
+++ b/reference/dom/dom/dom-htmlelement.xml
@@ -28,26 +28,16 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-element')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-element')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-element')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Element'])">
-     <xi:fallback/>
-    </xi:include>-->
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-element')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Element'])"/>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])"/>-->
    </classsynopsis>
   </section>
 

--- a/reference/dom/dom/dom-implementation.xml
+++ b/reference/dom/dom/dom-implementation.xml
@@ -10,9 +10,7 @@
   <section xml:id="dom-implementation.intro">
    &reftitle.intro;
    <simpara>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domimplementation.intro.brief')/text())">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domimplementation.intro.brief')/text())"/>
    </simpara>
    <simpara>
     このクラスは、<classname>DOMImplementation</classname> と同等ですが、
@@ -29,9 +27,7 @@
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-implementation')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Implementation'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-implementation')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Implementation'])"/>-->
    </classsynopsis>
 
   </section>

--- a/reference/dom/dom/dom-namednodemap.xml
+++ b/reference/dom/dom/dom-namednodemap.xml
@@ -41,9 +41,7 @@
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-namednodemap')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\NamedNodeMap'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-namednodemap')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\NamedNodeMap'])"/>-->
    </classsynopsis>
   </section>
 

--- a/reference/dom/dom/dom-namespaceinfo.xml
+++ b/reference/dom/dom/dom-namespaceinfo.xml
@@ -42,9 +42,7 @@
     </fieldsynopsis>
 
     <!--<classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-namespaceinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Dom\\NamespaceInfo'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-namespaceinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Dom\\NamespaceInfo'])"/>-->
    </classsynopsis>
   </section>
 

--- a/reference/dom/dom/dom-node.xml
+++ b/reference/dom/dom/dom-node.xml
@@ -152,9 +152,7 @@
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])"/>-->
    </classsynopsis>
 
   </section>
@@ -163,34 +161,22 @@
    &reftitle.constants;
    <variablelist>
     <varlistentry xml:id="dom-node.constants.document-position-disconnected">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.constants.document-position-disconnected')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.constants.document-position-disconnected')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-node.constants.document-position-preceding">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.constants.document-position-preceding')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.constants.document-position-preceding')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-node.constants.document-position-following">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.constants.document-position-following')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.constants.document-position-following')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-node.constants.document-position-contains">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.constants.document-position-contains')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.constants.document-position-contains')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-node.constants.document-position-contained-by">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.constants.document-position-contained-by')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.constants.document-position-contained-by')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-node.constants.document-position-implementation-specific">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.constants.document-position-implementation-specific')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.constants.document-position-implementation-specific')/*)"/>
     </varlistentry>
    </variablelist>
   </section>
@@ -199,9 +185,7 @@
    &reftitle.properties;
    <variablelist>
     <varlistentry xml:id="dom-node.props.nodetype">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.props.nodetype')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.props.nodetype')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-node.props.nodename">
      <term><varname>nodeName</varname></term>
@@ -216,14 +200,10 @@
      </listitem>
     </varlistentry>
     <varlistentry xml:id="dom-node.props.baseuri">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.props.baseuri')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.props.baseuri')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-node.props.isconnected">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.props.isconnected')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.props.isconnected')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-node.props.ownerdocument">
      <term><varname>ownerDocument</varname></term>
@@ -235,14 +215,10 @@
      </listitem>
     </varlistentry>
     <varlistentry xml:id="dom-node.props.parentnode">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.props.parentnode')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.props.parentnode')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-node.props.parentelement">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.props.parentelement')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.props.parentelement')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-node.props.childnodes">
      <term><varname>childNodes</varname></term>
@@ -254,24 +230,16 @@
      </listitem>
     </varlistentry>
     <varlistentry xml:id="dom-node.props.firstchild">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.props.firstchild')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.props.firstchild')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-node.props.lastchild">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.props.lastchild')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.props.lastchild')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-node.props.previoussibling">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.props.previoussibling')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.props.previoussibling')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-node.props.nextsibling">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.props.nextsibling')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.props.nextsibling')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-node.props.nodevalue">
      <term><varname>nodeValue</varname></term>
@@ -282,9 +250,7 @@
      </listitem>
     </varlistentry>
     <varlistentry xml:id="dom-node.props.textcontent">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.props.textcontent')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.props.textcontent')/*)"/>
     </varlistentry>
    </variablelist>
   </section>

--- a/reference/dom/dom/dom-nodelist.xml
+++ b/reference/dom/dom/dom-nodelist.xml
@@ -8,9 +8,7 @@
  <partintro>
 
   <section xml:id="dom-nodelist.intro">
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnodelist.intro')/*)">
-    <xi:fallback/>
-   </xi:include>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnodelist.intro')/*)"/>
    <simpara>
     このクラスは、<classname>DOMNodeList</classname> と同等ですが、
     モダンかつ仕様に準拠しています。
@@ -43,9 +41,7 @@
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-nodelist')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\NodeList'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-nodelist')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\NodeList'])"/>-->
    </classsynopsis>
   </section>
 
@@ -53,9 +49,7 @@
    &reftitle.properties;
    <variablelist>
     <varlistentry xml:id="dom-nodelist.props.length">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnodelist.props.length')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnodelist.props.length')/*)"/>
     </varlistentry>
    </variablelist>
   </section>

--- a/reference/dom/dom/dom-notation.xml
+++ b/reference/dom/dom/dom-notation.xml
@@ -20,9 +20,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
@@ -39,15 +37,11 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])"/>-->
    </classsynopsis>
   </section>
 
@@ -55,14 +49,10 @@
    &reftitle.properties;
    <variablelist>
     <varlistentry xml:id="dom-notation.props.publicid">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnotation.props.publicid')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnotation.props.publicid')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-notation.props.systemid">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnotation.props.systemid')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnotation.props.systemid')/*)"/>
     </varlistentry>
    </variablelist>
   </section>

--- a/reference/dom/dom/dom-parentnode.xml
+++ b/reference/dom/dom/dom-parentnode.xml
@@ -32,9 +32,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-parentnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\ParentNode'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-parentnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\ParentNode'])"/>
    </classsynopsis>
 
   </section>

--- a/reference/dom/dom/dom-processinginstruction.xml
+++ b/reference/dom/dom/dom-processinginstruction.xml
@@ -8,9 +8,7 @@
  <partintro>
 
   <section xml:id="dom-processinginstruction.intro">
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domprocessinginstruction.intro')/*)">
-    <xi:fallback/>
-   </xi:include>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domprocessinginstruction.intro')/*)"/>
    <simpara>
     このクラスは、<classname>DOMProcessingInstruction</classname> と同等ですが、
     モダンかつ仕様に準拠しています。
@@ -31,9 +29,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
@@ -44,21 +40,13 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-characterdata')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-characterdata')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-characterdata')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\CharacterData'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-characterdata')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\CharacterData'])"/>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])"/>-->
    </classsynopsis>
   </section>
 
@@ -66,9 +54,7 @@
    &reftitle.properties;
    <variablelist>
     <varlistentry xml:id="dom-processinginstruction.props.target">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domprocessinginstruction.props.target')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domprocessinginstruction.props.target')/*)"/>
     </varlistentry>
    </variablelist>
   </section>

--- a/reference/dom/dom/dom-text.xml
+++ b/reference/dom/dom/dom-text.xml
@@ -33,9 +33,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
@@ -46,26 +44,16 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-characterdata')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-characterdata')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-text')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Text'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-text')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Text'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-characterdata')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\CharacterData'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-characterdata')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\CharacterData'])"/>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])"/>-->
    </classsynopsis>
   </section>
 
@@ -73,9 +61,7 @@
    &reftitle.properties;
    <variablelist>
     <varlistentry xml:id="dom-text.props.wholetext">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domtext.props.wholetext')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domtext.props.wholetext')/*)"/>
     </varlistentry>
    </variablelist>
   </section>

--- a/reference/dom/dom/dom-tokenlist.xml
+++ b/reference/dom/dom/dom-tokenlist.xml
@@ -46,9 +46,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-tokenlist')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\TokenList'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-tokenlist')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\TokenList'])"/>
    </classsynopsis>
   </section>
 

--- a/reference/dom/dom/dom-xmldocument.xml
+++ b/reference/dom/dom/dom-xmldocument.xml
@@ -29,9 +29,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
@@ -57,27 +55,17 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-document')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-document')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-xmldocument')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\XMLDocument'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-xmldocument')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\XMLDocument'])"/>-->
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-document')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Document'])">
-     <xi:fallback/>
-    </xi:include>-->
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Document'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-document')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Document'])"/>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Document'])"/>-->
    </classsynopsis>
   </section>
 
@@ -93,19 +81,13 @@
    </note>
    <variablelist>
     <varlistentry xml:id="dom-xmldocument.props.xmlencoding">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.props.xmlencoding')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.props.xmlencoding')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-xmldocument.props.xmlstandalone">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.props.xmlstandalone')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.props.xmlstandalone')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-xmldocument.props.xmlversion">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.props.xmlversion')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.props.xmlversion')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-xmldocument.props.formatoutput">
      <term><varname>formatOutput</varname></term>

--- a/reference/dom/dom/dom-xpath.xml
+++ b/reference/dom/dom/dom-xpath.xml
@@ -8,9 +8,7 @@
  <partintro>
 
   <section xml:id="dom-xpath.intro">
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domxpath.intro')/*)">
-    <xi:fallback/>
-   </xi:include>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domxpath.intro')/*)"/>
    <simpara>
     このクラスは、<classname>DOMXPath</classname> と同等ですが、
     モダンかつ仕様に準拠しています。
@@ -41,12 +39,8 @@
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-xpath')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Dom\\XPath'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-xpath')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\XPath'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-xpath')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Dom\\XPath'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-xpath')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\XPath'])"/>-->
    </classsynopsis>
   </section>
 
@@ -54,14 +48,10 @@
    &reftitle.properties;
    <variablelist>
     <varlistentry xml:id="dom-xpath.props.document">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domxpath.props.document')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domxpath.props.document')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-xpath.props.registernodenamespaces">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domxpath.props.registernodenamespaces')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domxpath.props.registernodenamespaces')/*)"/>
     </varlistentry>
    </variablelist>
   </section>

--- a/reference/dom/domattr.xml
+++ b/reference/dom/domattr.xml
@@ -33,9 +33,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
@@ -69,22 +67,14 @@
     </fieldsynopsis>
  
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domattr')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DOMAttr'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domattr')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMAttr'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domattr')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DOMAttr'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domattr')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMAttr'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/dom/domcdatasection.xml
+++ b/reference/dom/domcdatasection.xml
@@ -35,36 +35,20 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domtext')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domcharacterdata')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domtext')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domcharacterdata')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domcdatasection')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DOMCdataSection'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domcdatasection')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DOMCdataSection'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domtext')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMText'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domcharacterdata')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMCharacterData'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domtext')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMText'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domcharacterdata')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMCharacterData'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/dom/domcharacterdata.xml
+++ b/reference/dom/domcharacterdata.xml
@@ -38,9 +38,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
@@ -69,19 +67,13 @@
 
  
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domcharacterdata')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMCharacterData'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domcharacterdata')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMCharacterData'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/dom/domchildnode.xml
+++ b/reference/dom/domchildnode.xml
@@ -17,9 +17,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domchildnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMChildNode'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domchildnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMChildNode'])"/>
    </classsynopsis>
    <!-- }}} -->
 

--- a/reference/dom/domcomment.xml
+++ b/reference/dom/domcomment.xml
@@ -33,30 +33,18 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domcharacterdata')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domcharacterdata')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domcomment')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DOMComment'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domcomment')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DOMComment'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domcharacterdata')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMCharacterData'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domcharacterdata')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMCharacterData'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/dom/domdocument.xml
+++ b/reference/dom/domdocument.xml
@@ -38,9 +38,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
@@ -164,22 +162,14 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
  
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domdocument')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DOMDocument'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domdocument')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMDocument'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domdocument')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DOMDocument'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domdocument')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMDocument'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/dom/domdocument/getelementsbytagname.xml
+++ b/reference/dom/domdocument/getelementsbytagname.xml
@@ -39,10 +39,10 @@
    オブジェクトを返します。
   </para>
  </refsect1>
- <refsect1 role="examples"><!-- {{{ -->
+ <refsect1 role="examples">
   &reftitle.examples;
   <para>
-   <example xml:id="domdocument.getelementsbytagname.example.basic"><!-- {{{ -->
+   <example xml:id="domdocument.getelementsbytagname.example.basic">
     <title>基本的な使用例</title>
     <programlisting role="php">
 <![CDATA[
@@ -73,9 +73,9 @@ Design Patterns: Elements of Reusable Software Design
 Clean Code
 ]]>
     </screen>
-   </example><!-- }}} -->
+   </example>
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/dom/domdocumentfragment.xml
+++ b/reference/dom/domdocumentfragment.xml
@@ -38,9 +38,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
@@ -63,22 +61,14 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domdocumentfragment')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DOMDocumentFragment'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domdocumentfragment')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMDocumentFragment'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domdocumentfragment')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DOMDocumentFragment'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domdocumentfragment')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMDocumentFragment'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])"/>
    </classsynopsis>
   </section>
 

--- a/reference/dom/domdocumenttype.xml
+++ b/reference/dom/domdocumenttype.xml
@@ -34,9 +34,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
@@ -77,14 +75,10 @@
     </fieldsynopsis>
  
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/dom/domelement.xml
+++ b/reference/dom/domelement.xml
@@ -43,9 +43,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
@@ -102,22 +100,14 @@
     </fieldsynopsis>
  
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domelement')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DOMElement'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domelement')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMElement'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domelement')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DOMElement'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domelement')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMElement'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/dom/domentity.xml
+++ b/reference/dom/domentity.xml
@@ -33,9 +33,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
@@ -76,14 +74,10 @@
     </fieldsynopsis>
    
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/dom/domentityreference.xml
+++ b/reference/dom/domentityreference.xml
@@ -41,24 +41,16 @@ Remove me once you perform substitutions
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domentityreference')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DOMEntityReference'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domentityreference')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DOMEntityReference'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/dom/domexception.xml
+++ b/reference/dom/domexception.xml
@@ -55,17 +55,11 @@ FIXME: Remove me once you perform substitutions
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/dom/domimplementation.xml
+++ b/reference/dom/domimplementation.xml
@@ -34,9 +34,7 @@ Remove me once you perform substitutions
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domimplementation')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMImplementation'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domimplementation')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMImplementation'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/dom/domnamednodemap.xml
+++ b/reference/dom/domnamednodemap.xml
@@ -51,9 +51,7 @@ Remove me once you perform substitutions
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnamednodemap')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNamedNodeMap'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnamednodemap')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNamedNodeMap'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/dom/domnamespacenode.xml
+++ b/reference/dom/domnamespacenode.xml
@@ -88,9 +88,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnamespacenode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNameSpaceNode'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnamespacenode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNameSpaceNode'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/dom/domnode.xml
+++ b/reference/dom/domnode.xml
@@ -178,9 +178,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/dom/domnodelist.xml
+++ b/reference/dom/domnodelist.xml
@@ -24,7 +24,6 @@ Remove me once you perform substitutions
   <section xml:id="domnodelist.synopsis">
    &reftitle.classsynopsis;
  
-<!-- {{{ Synopsis -->
    <classsynopsis class="class">
     <ooclass>
      <classname>DOMNodeList</classname>
@@ -48,15 +47,11 @@ Remove me once you perform substitutions
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnodelist')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNodeList'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnodelist')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNodeList'])"/>
    </classsynopsis>
-<!-- }}} -->
  
   </section>
  
-<!-- {{{ DOMNodeList properties -->
   <section xml:id="domnodelist.props">
    &reftitle.properties;
    <variablelist>
@@ -71,9 +66,8 @@ Remove me once you perform substitutions
     </varlistentry>
    </variablelist>
   </section>
-<!-- }}} -->
   
-  <section role="changelog" xml:id="domnodelist.changelog"><!-- {{{ -->
+  <section role="changelog" xml:id="domnodelist.changelog">
    &reftitle.changelog;
    <para>
     <informaltable>
@@ -105,7 +99,7 @@ Remove me once you perform substitutions
      </tgroup>
     </informaltable>
    </para>
-  </section><!-- }}} -->
+  </section>
 
   <section role="notes">
    &reftitle.notes;
@@ -116,7 +110,6 @@ Remove me once you perform substitutions
    </note>
   </section>
 
- <!-- {{{ See also -->
   <section role="seealso">
    &reftitle.seealso;
    <para>

--- a/reference/dom/domnotation.xml
+++ b/reference/dom/domnotation.xml
@@ -43,9 +43,7 @@ Remove me once you perform substitutions
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
@@ -62,14 +60,10 @@ Remove me once you perform substitutions
     </fieldsynopsis>
  
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/dom/domparentnode.xml
+++ b/reference/dom/domparentnode.xml
@@ -17,9 +17,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domparentnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMParentNode'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domparentnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMParentNode'])"/>
    </classsynopsis>
    <!-- }}} -->
 

--- a/reference/dom/domprocessinginstruction.xml
+++ b/reference/dom/domprocessinginstruction.xml
@@ -31,9 +31,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
@@ -49,19 +47,13 @@
     </fieldsynopsis>
  
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domprocessinginstruction')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DOMProcessingInstruction'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domprocessinginstruction')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DOMProcessingInstruction'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/dom/domtext.xml
+++ b/reference/dom/domtext.xml
@@ -35,9 +35,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
@@ -48,28 +46,16 @@
     </fieldsynopsis>
  
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domcharacterdata')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domcharacterdata')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domtext')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DOMText'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domtext')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMText'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domtext')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DOMText'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domtext')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMText'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domcharacterdata')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMCharacterData'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domcharacterdata')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMCharacterData'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/dom/domxpath.xml
+++ b/reference/dom/domxpath.xml
@@ -46,12 +46,8 @@ Remove me once you perform substitutions
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domxpath')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DOMXPath'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domxpath')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMXPath'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domxpath')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DOMXPath'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domxpath')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMXPath'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/dom/functions/dom-ns-import-simplexml.xml
+++ b/reference/dom/functions/dom-ns-import-simplexml.xml
@@ -25,9 +25,7 @@
  </refsect1>
 
  <refsect1 role="parameters">
-  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.dom-import-simplexml')/db:refsect1[@role='parameters']/*)">
-   <xi:fallback/>
-  </xi:include>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.dom-import-simplexml')/db:refsect1[@role='parameters']/*)"/>
  </refsect1>
 
  <refsect1 role="returnvalues">

--- a/reference/eio/book.xml
+++ b/reference/eio/book.xml
@@ -5,7 +5,6 @@
  <?phpdoc extension-membership="pecl" ?>
  <title>Eio</title>
  <titleabbrev>Eio</titleabbrev>
-<!--{{{ preface -->
  <preface xml:id="intro.eio">
   &reftitle.intro;
   <simpara>
@@ -161,7 +160,6 @@ event_base_loop($base);
 
   </para>
  </preface>
-<!--}}}-->
  &reference.eio.setup;
  &reference.eio.constants;
  &reference.eio.examples;

--- a/reference/eio/constants.xml
+++ b/reference/eio/constants.xml
@@ -7,7 +7,6 @@
 
  <para>リクエストの優先度
   <variablelist>
-<!--{{{ EIO_PRI_* -->
    <varlistentry xml:id="constant.eio-pri-min">
     <term>
      <constant>EIO_PRI_MIN</constant>
@@ -41,7 +40,6 @@
      </simpara>
     </listitem>
    </varlistentry>
-   <!--}}}-->
   </variablelist>
  </para>
 
@@ -87,7 +85,6 @@
   <function>eio_readdir</function> で使うフラグ
   <variablelist>
 
-<!--{{{ EIO_READDIR_* -->
    <varlistentry xml:id="constant.eio-readdir-dents">
     <term>
      <constant>EIO_READDIR_DENTS</constant>
@@ -142,9 +139,7 @@
      </simpara>
     </listitem>
    </varlistentry>
-<!--}}}-->
 
-<!--{{{ EIO_DT_* -->
    <varlistentry xml:id="constant.eio-dt-unknown">
     <term>
      <constant>EIO_DT_UNKNOWN</constant>
@@ -321,7 +316,6 @@
     </listitem>
    </varlistentry>
 
-<!--}}}-->
 
   </variablelist>
  </para>
@@ -329,7 +323,6 @@
   <function>eio_open</function> の <parameter>flags</parameter> 引数用のアクセスモード
   <variablelist>
 
-<!--{{{ EIO_O_*-->
    <varlistentry xml:id="constant.eio-o-rdonly">
     <term>
      <constant>EIO_O_RDONLY</constant>
@@ -420,7 +413,6 @@
      </simpara>
     </listitem>
    </varlistentry>
-<!--}}}-->
 
   </variablelist>
  </para>
@@ -428,7 +420,6 @@
   <function>eio_open</function> の <parameter>mode</parameter> 引数用のフラグ
   <variablelist>
 
-<!--{{{ EIO_S_I*-->
    <varlistentry xml:id="constant.eio-s-irusr">
     <term>
      <constant>EIO_S_IRUSR</constant>
@@ -569,7 +560,6 @@
      </simpara>
     </listitem>
    </varlistentry>
-<!--}}}-->
 
 
   </variablelist>
@@ -578,7 +568,6 @@
   <function>eio_sync_file_range</function> のフラグ
   <variablelist>
 
-<!--{{{ EIO_SYNC_FILE_*-->
    <varlistentry xml:id="constant.eio-sync-file-range-wait-before">
     <term>
      <constant>EIO_SYNC_FILE_RANGE_WAIT_BEFORE</constant>
@@ -609,7 +598,6 @@
      </simpara>
     </listitem>
    </varlistentry>
-<!--}}}-->
 
 
   </variablelist>

--- a/reference/eio/functions/eio-readdir.xml
+++ b/reference/eio/functions/eio-readdir.xml
@@ -79,7 +79,6 @@
 
   <variablelist>
 
-   <!--{{{ EIO_READDIR_* -->
    <varlistentry>
     <term>
      <constant>EIO_READDIR_DENTS</constant>
@@ -135,14 +134,12 @@
      </simpara>
     </listitem>
    </varlistentry>
-<!--}}}-->
 
   </variablelist>
 
   <para>ノード型
    <variablelist>
 
-<!--{{{ EIO_DT_* -->
     <varlistentry>
      <term>
       <constant>EIO_DT_UNKNOWN</constant>
@@ -319,7 +316,6 @@
      </listitem>
     </varlistentry>
 
- <!--}}}-->
 
    </variablelist>
   </para>

--- a/reference/eio/setup.xml
+++ b/reference/eio/setup.xml
@@ -14,16 +14,13 @@
 
  <!--{{{ Installation -->
  &reference.eio.configure;
-   <!--}}}-->
 
-  <!--{{{ Resources -->
    <section xml:id="eio.resources">
     &reftitle.resources;
     <simpara>
     この拡張モジュールでは二種類のリソース型を使います。リクエストとリクエストグループです。
     </simpara>
    </section>
-    <!--}}}-->
 
 </chapter>
 <!-- Keep this comment at the end of the file

--- a/reference/enchant/functions/enchant-broker-describe.xml
+++ b/reference/enchant/functions/enchant-broker-describe.xml
@@ -113,17 +113,6 @@ Array
 
 
 
- <!-- Use when adding See Also links
- <refsect1 role="seealso">
-  &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function></function></member>
-    <member>Or <link linkend="somethingelse">something else</link></member>
-   </simplelist>
-  </para>
- </refsect1>
- -->
 
 
 </refentry>

--- a/reference/ev/ev.xml
+++ b/reference/ev/ev.xml
@@ -5,32 +5,26 @@
  <title>Ev クラス</title>
  <titleabbrev>Ev</titleabbrev>
  <partintro>
-<!-- {{{ Ev intro -->
   <section xml:id="ev.intro">
    &reftitle.intro;
    <simpara>
     Ev は静的クラスで、デフォルトのループへのアクセスや各種共通操作へのアクセスを提供します。
    </simpara>
   </section>
-<!-- }}} -->
   <section xml:id="ev.synopsis">
    &reftitle.classsynopsis;
 
-<!-- {{{ Synopsis -->
    <classsynopsis>
     <ooclass>
      <classname>Ev</classname>
     </ooclass>
-<!-- {{{ Class synopsis -->
     <classsynopsisinfo>
      <ooclass>
       <modifier>final</modifier>
       <classname>Ev</classname>
      </ooclass>
     </classsynopsisinfo>
-<!-- }}} -->
     <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
-<!--{{{-->
     <fieldsynopsis>
      <modifier>const</modifier>
      <type>int</type>
@@ -235,19 +229,15 @@
      <varname linkend="ev.constants.backend-mask">Ev::BACKEND_MASK</varname>
      <initializer>65535</initializer>
     </fieldsynopsis>
-<!--}}}-->
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ev')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])"/>
    </classsynopsis>
-<!-- }}} -->
   </section>
-<!-- {{{ Ev constants -->
   <section xml:id="ev.constants">
    &reftitle.constants;
 
   <para xml:id="ev.constants.loop-flags">
     ループを作るときに渡すフラグ
-<!--{{{-->
     <variablelist>
      <varlistentry xml:id="ev.constants.flag-auto">
       <term>
@@ -349,13 +339,11 @@
      </varlistentry>
     </variablelist>
    </para>
-<!--}}}-->
    <para xml:id="ev.constants.run-flags">
     <methodname>Ev::run</methodname>
     あるいは
     <methodname>EvLoop::run</methodname>
     に渡すフラグ
-<!--{{{-->
     <variablelist>
      <varlistentry xml:id="ev.constants.run-nowait">
       <term>
@@ -389,13 +377,11 @@
      </varlistentry>
     </variablelist>
    </para>
-<!--}}}-->
    <para xml:id="ev.constants.break-flags">
     <methodname>Ev::stop</methodname>
     あるいは
     <methodname>EvLoop::stop</methodname>
     に渡すフラグ
-<!--{{{-->
     <variablelist>
      <varlistentry xml:id="ev.constants.break-cancel">
       <term>
@@ -437,10 +423,8 @@
      </varlistentry>
     </variablelist>
    </para>
-<!--}}}-->
    <para xml:id="ev.constants.watcher-pri">
     ウォッチャーの優先度
-<!--{{{-->
     <variablelist>
      <varlistentry xml:id="ev.constants.minpri">
       <term>
@@ -464,10 +448,8 @@
      </varlistentry>
     </variablelist>
    </para>
-<!--}}}-->
    <para xml:id="ev.constants.watcher-revents">
     受信したイベントのビットマスク
-<!--{{{-->
     <variablelist>
      <varlistentry xml:id="ev.constants.read">
       <term>
@@ -641,10 +623,8 @@
      </varlistentry>
     </variablelist>
    </para>
-<!--}}}-->
    <para xml:id="ev.constants.watcher-backends">
     バックエンドのフラグ
-<!--{{{-->
     <variablelist>
      <varlistentry xml:id="ev.constants.backend-select">
       <term>
@@ -747,7 +727,6 @@
      </varlistentry>
     </variablelist>
    </para>
-<!--}}}-->
    <note xmlns="http://docbook.org/ns/docbook">
     <simpara>
      デフォルトのループの場合は、モジュールの初期化時に
@@ -774,7 +753,6 @@
     </simpara>
    </note>
   </section>
-<!-- }}} -->
  </partintro>
 
  &reference.ev.entities.ev;

--- a/reference/ffi/ffi.ctype.xml
+++ b/reference/ffi/ffi.ctype.xml
@@ -261,9 +261,7 @@
      </fieldsynopsis>
 
      <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ffi-ctype')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FFI\\CType'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ffi-ctype')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FFI\\CType'])"/>
     </classsynopsis>
    </packagesynopsis>
 <!-- }}} -->

--- a/reference/ffi/ffi.exception.xml
+++ b/reference/ffi/ffi.exception.xml
@@ -35,17 +35,11 @@
      </ooclass>
 
      <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
      <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])">
-      <xi:fallback/>
-     </xi:include>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])"/>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])"/>
     </classsynopsis>
    </packagesynopsis>
 <!-- }}} -->

--- a/reference/ffi/ffi.parserexception.xml
+++ b/reference/ffi/ffi.parserexception.xml
@@ -36,17 +36,11 @@
      </ooclass>
 
      <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
      <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])">
-      <xi:fallback/>
-     </xi:include>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])"/>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])"/>
     </classsynopsis>
    </packagesynopsis>
 <!-- }}} -->

--- a/reference/ffi/ffi.xml
+++ b/reference/ffi/ffi.xml
@@ -56,9 +56,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ffi')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FFI'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ffi')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FFI'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/ffi/ffi/cdef.xml
+++ b/reference/ffi/ffi/cdef.xml
@@ -64,7 +64,7 @@
   </simpara>
  </refsect1>
 
- <refsect1 role="changelog"><!-- {{{ -->
+ <refsect1 role="changelog">
   &reftitle.changelog;
   <informaltable>
    <tgroup cols="2">
@@ -91,7 +91,7 @@
     </tbody>
    </tgroup>
   </informaltable>
- </refsect1><!-- }}} -->
+ </refsect1>
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/fileinfo/finfo.xml
+++ b/reference/fileinfo/finfo.xml
@@ -27,12 +27,8 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.finfo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='finfo'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.finfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='finfo'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.finfo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='finfo'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.finfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='finfo'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/filesystem/functions/fputcsv.xml
+++ b/reference/filesystem/functions/fputcsv.xml
@@ -45,15 +45,9 @@
       </para>
      </listitem>
     </varlistentry>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='separator']]]/.)">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='enclosure']]]/.)">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='escape']]]/.)">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='separator']]]/.)"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='enclosure']]]/.)"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='escape']]]/.)"/>
     <varlistentry>
      <term><parameter>eol</parameter></term>
      <listitem>
@@ -81,9 +75,7 @@
   </para>
  </refsect1>
 
- <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='errors']/.)">
-  <xi:fallback/>
- </xi:include>
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='errors']/.)"/>
 
  <refsect1 role="changelog">
   &reftitle.changelog;
@@ -97,9 +89,7 @@
       </row>
      </thead>
      <tbody>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='changelog']//db:row[db:entry[text()='8.4.0']]/.)">
-       <xi:fallback/>
-      </xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='changelog']//db:row[db:entry[text()='8.4.0']]/.)"/>
       <row>
        <entry>8.1.0</entry>
        <entry>

--- a/reference/filter/filter.filterexception.xml
+++ b/reference/filter/filter.filterexception.xml
@@ -30,17 +30,11 @@
      </ooclass>
 
      <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
      <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-      <xi:fallback/>
-     </xi:include>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
     </classsynopsis>
    </packagesynopsis>
   </section>

--- a/reference/filter/filter.filterfailedexception.xml
+++ b/reference/filter/filter.filterfailedexception.xml
@@ -31,17 +31,11 @@
      </ooclass>
 
      <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
      <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-      <xi:fallback/>
-     </xi:include>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
     </classsynopsis>
    </packagesynopsis>
   </section>

--- a/reference/filter/functions/filter-input-array.xml
+++ b/reference/filter/functions/filter-input-array.xml
@@ -43,12 +43,8 @@
      </warning>
     </listitem>
    </varlistentry>
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.filter-var-array')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='options']]]/.)">
-    <xi:fallback/>
-   </xi:include>
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.filter-var-array')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='add_empty']]]/.)">
-    <xi:fallback/>
-   </xi:include>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.filter-var-array')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='options']]]/.)"/>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.filter-var-array')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='add_empty']]]/.)"/>
   </variablelist>
  </refsect1>
 

--- a/reference/filter/functions/filter-input.xml
+++ b/reference/filter/functions/filter-input.xml
@@ -48,12 +48,8 @@
      </simpara>
     </listitem>
    </varlistentry>
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.filter-var')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='filter']]]/.)">
-    <xi:fallback/>
-   </xi:include>
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.filter-var')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='options']]]/.)">
-    <xi:fallback/>
-   </xi:include>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.filter-var')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='filter']]]/.)"/>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.filter-var')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='options']]]/.)"/>
   </variablelist>
  </refsect1>
 

--- a/reference/gender/gender.xml
+++ b/reference/gender/gender.xml
@@ -406,12 +406,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gender')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gender')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gender')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gender')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/gmagick/gmagick.xml
+++ b/reference/gmagick/gmagick.xml
@@ -32,12 +32,8 @@
     </classsynopsisinfo>
 <!-- }}} -->
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gmagick')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gmagick')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gmagick')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gmagick')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/gmagick/gmagickpixel.xml
+++ b/reference/gmagick/gmagickpixel.xml
@@ -33,12 +33,8 @@
 <!-- }}} -->
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gmagickpixel')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gmagickpixel')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gmagickpixel')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gmagickpixel')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/gmp/functions/gmp-random-seed.xml
+++ b/reference/gmp/functions/gmp-random-seed.xml
@@ -41,13 +41,13 @@
   </para>
  </refsect1>
 
- <refsect1 role="errors"><!-- {{{ -->
+ <refsect1 role="errors">
   &reftitle.errors;
   <para>
    <parameter>seed</parameter> が無効な場合は、
    <classname>ValueError</classname> がスローされます。
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
 
  <refsect1 role="changelog">
   &reftitle.changelog;

--- a/reference/gmp/gmp.xml
+++ b/reference/gmp/gmp.xml
@@ -34,12 +34,8 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gmp')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='GMP'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gmp')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='GMP'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gmp')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='GMP'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gmp')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='GMP'])"/>
    </classsynopsis>
   </section>
 

--- a/reference/hash/functions/hash-algos.xml
+++ b/reference/hash/functions/hash-algos.xml
@@ -28,7 +28,7 @@
   </para>
  </refsect1>
 
- <refsect1 role="changelog"><!-- {{{ -->
+ <refsect1 role="changelog">
   &reftitle.changelog;
   <para>
    <informaltable>
@@ -63,7 +63,7 @@
     </tgroup>
    </informaltable>
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
  
  <refsect1 role="examples">
   &reftitle.examples;
@@ -153,13 +153,13 @@ Array
   </para>
  </refsect1>
 
- <refsect1 role="seealso"><!-- {{{ -->
+ <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
    <member><function>hash</function></member>
    <member><function>hash_hmac_algos</function></member>
   </simplelist>
- </refsect1><!-- }}} -->
+ </refsect1>
 
 </refentry>
 

--- a/reference/hash/functions/hash-hmac-algos.xml
+++ b/reference/hash/functions/hash-hmac-algos.xml
@@ -8,31 +8,31 @@
   <refpurpose>hash_hmac に合うハッシュアルゴリズムの一覧を返す</refpurpose>
  </refnamediv>
 
- <refsect1 role="description"><!-- {{{ -->
+ <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
    <type>array</type><methodname>hash_hmac_algos</methodname>
    <void />
   </methodsynopsis>
- </refsect1><!-- }}} -->
+ </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
   &no.function.parameters;
  </refsect1>
 
- <refsect1 role="returnvalues"><!-- {{{ -->
+ <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
    数値インデックスをキーとし、
    <function>hash_hmac</function> に合う、
    サポートされたハッシュアルゴリズムの一覧を値とした配列を返します。
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
 
- <refsect1 role="examples"><!-- {{{ -->
+ <refsect1 role="examples">
   &reftitle.examples;
-  <example xml:id="hash-hmac-algos.example.basic"><!-- {{{ -->
+  <example xml:id="hash-hmac-algos.example.basic">
    <title><function>hash_hmac_algos</function> の例</title>
    <programlisting role="php">
 <![CDATA[
@@ -92,10 +92,10 @@ Array
 )
 ]]>
    </screen>
-  </example><!-- }}} -->
- </refsect1><!-- }}} -->
+  </example>
+ </refsect1>
 
- <refsect1 role="notes"><!-- {{{ -->
+ <refsect1 role="notes">
   &reftitle.notes;
   <note>
    <para>
@@ -105,15 +105,15 @@ Array
     <function>hash_algos</function> を呼び出すことでした。
    </para>
   </note>
- </refsect1><!-- }}} -->
+ </refsect1>
 
- <refsect1 role="seealso"><!-- {{{ -->
+ <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
    <member><function>hash_hmac</function></member>
    <member><function>hash_algos</function></member>
   </simplelist>
- </refsect1><!-- }}} -->
+ </refsect1>
 
 </refentry>
 

--- a/reference/hash/functions/hash-pbkdf2.xml
+++ b/reference/hash/functions/hash-pbkdf2.xml
@@ -102,14 +102,14 @@
   </para>
  </refsect1>
 
- <refsect1 role="returnvalues"><!-- {{{ -->
+ <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
    小文字の16進数を含む文字列が返されます。<parameter>binary</parameter> が &true; の場合、導出鍵の生のバイナリ表現が返されます。
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
 
- <refsect1 role="errors"><!-- {{{ -->
+ <refsect1 role="errors">
   &reftitle.errors;
   <para>
     アルゴリズムが未知である場合、
@@ -120,7 +120,7 @@
    (<constant>INT_MAX</constant><literal> - 4</literal> よりも大きい) に、
    <classname>ValueError</classname> がスローされます。
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
 
  <refsect1 role="changelog">
   &reftitle.changelog;

--- a/reference/hash/hashcontext.xml
+++ b/reference/hash/hashcontext.xml
@@ -28,12 +28,8 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.hashcontext')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='HashContext'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.hashcontext')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='HashContext'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.hashcontext')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='HashContext'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.hashcontext')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='HashContext'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/ibm_db2/functions/db2-client-info.xml
+++ b/reference/ibm_db2/functions/db2-client-info.xml
@@ -153,38 +153,7 @@
   </simpara>
  </refsect1>
 
- <!-- Use when ERRORS exist
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   When does this function throw E_* level errors, or exceptions?
-  </para>
- </refsect1>
- -->
 
- <!-- Use when a CHANGELOG exists
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>Enter the PHP version of change here</entry>
-       <entry>Description of change</entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
- -->
 
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/ibm_db2/functions/db2-column-privileges.xml
+++ b/reference/ibm_db2/functions/db2-column-privileges.xml
@@ -128,36 +128,6 @@
   </para>
  </refsect1>
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>db2_column_privileges</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/ibm_db2/functions/db2-columns.xml
+++ b/reference/ibm_db2/functions/db2-columns.xml
@@ -189,36 +189,6 @@
   </para>
  </refsect1>
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>db2_columns</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/ibm_db2/functions/db2-commit.xml
+++ b/reference/ibm_db2/functions/db2-commit.xml
@@ -45,36 +45,6 @@
   </simpara>
  </refsect1>
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>db2_commit</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/ibm_db2/functions/db2-cursor-type.xml
+++ b/reference/ibm_db2/functions/db2-cursor-type.xml
@@ -44,36 +44,6 @@
   </simpara>
  </refsect1>
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>db2_cursor_type</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/ibm_db2/functions/db2-field-display-size.xml
+++ b/reference/ibm_db2/functions/db2-field-display-size.xml
@@ -52,36 +52,6 @@
   </simpara>
  </refsect1>
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>db2_field_display_size</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/ibm_db2/functions/db2-field-name.xml
+++ b/reference/ibm_db2/functions/db2-field-name.xml
@@ -52,36 +52,6 @@
   </simpara>
  </refsect1>
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>db2_field_name</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/ibm_db2/functions/db2-field-num.xml
+++ b/reference/ibm_db2/functions/db2-field-num.xml
@@ -52,36 +52,6 @@
   </simpara>
  </refsect1>
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>db2_field_num</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/ibm_db2/functions/db2-field-precision.xml
+++ b/reference/ibm_db2/functions/db2-field-precision.xml
@@ -52,36 +52,6 @@
   </simpara>
  </refsect1>
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>db2_field_precision</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/ibm_db2/functions/db2-field-scale.xml
+++ b/reference/ibm_db2/functions/db2-field-scale.xml
@@ -52,36 +52,6 @@
   </simpara>
  </refsect1>
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>db2_field_scale</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/ibm_db2/functions/db2-field-type.xml
+++ b/reference/ibm_db2/functions/db2-field-type.xml
@@ -52,36 +52,6 @@
   </simpara>
  </refsect1>
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>db2_field_type</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/ibm_db2/functions/db2-field-width.xml
+++ b/reference/ibm_db2/functions/db2-field-width.xml
@@ -55,36 +55,6 @@
   </simpara>
  </refsect1>
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>db2_field_width</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/ibm_db2/functions/db2-foreign-keys.xml
+++ b/reference/ibm_db2/functions/db2-foreign-keys.xml
@@ -159,36 +159,6 @@
   </para>
  </refsect1>
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>db2_foreign_keys</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/ibm_db2/functions/db2-free-result.xml
+++ b/reference/ibm_db2/functions/db2-free-result.xml
@@ -43,36 +43,6 @@
   </simpara>
  </refsect1>
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>db2_free_result</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/ibm_db2/functions/db2-free-stmt.xml
+++ b/reference/ibm_db2/functions/db2-free-stmt.xml
@@ -44,36 +44,6 @@
   </simpara>
  </refsect1>
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>db2_free_stmt</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
 
  <refsect1 role="seealso">

--- a/reference/ibm_db2/functions/db2-next-result.xml
+++ b/reference/ibm_db2/functions/db2-next-result.xml
@@ -147,17 +147,6 @@ array(1) {
  </refsect1>
 
 
- <!-- Use when adding See Also links
- <refsect1 role="seealso">
-  &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function></function></member>
-    <member>Or <link linkend="somethingelse">something else</link></member>
-   </simplelist>
-  </para>
- </refsect1>
- -->
 
 
 </refentry>

--- a/reference/ibm_db2/functions/db2-num-rows.xml
+++ b/reference/ibm_db2/functions/db2-num-rows.xml
@@ -69,49 +69,8 @@
   </simpara>
  </refsect1>
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>db2_num_rows</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
 
- <!-- Use when adding See Also links
- <refsect1 role="seealso">
-  &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function></function></member>
-    <member>Or <link linkend="somethingelse">something else</link></member>
-   </simplelist>
-  </para>
- </refsect1>
- -->
 
 
 </refentry>

--- a/reference/ibm_db2/functions/db2-primary-keys.xml
+++ b/reference/ibm_db2/functions/db2-primary-keys.xml
@@ -112,36 +112,6 @@
   </para>
  </refsect1>
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>db2_primary_keys</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/ibm_db2/functions/db2-procedure-columns.xml
+++ b/reference/ibm_db2/functions/db2-procedure-columns.xml
@@ -228,36 +228,6 @@
   </para>
  </refsect1>
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>db2_procedure_columns</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/ibm_db2/functions/db2-procedures.xml
+++ b/reference/ibm_db2/functions/db2-procedures.xml
@@ -125,36 +125,6 @@
   </para>
  </refsect1>
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>db2_procedures</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/ibm_db2/functions/db2-server-info.xml
+++ b/reference/ibm_db2/functions/db2-server-info.xml
@@ -299,39 +299,8 @@
   </simpara>
  </refsect1>
 
- <!-- Use when ERRORS exist
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   When does this function throw E_* level errors, or exceptions?
-  </para>
- </refsect1>
- -->
 
 
- <!-- Use when a CHANGELOG exists
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>Enter the PHP version of change here</entry>
-       <entry>Description of change</entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
- -->
 
 
  <refsect1 role="examples">

--- a/reference/ibm_db2/functions/db2-special-columns.xml
+++ b/reference/ibm_db2/functions/db2-special-columns.xml
@@ -195,36 +195,6 @@
   </para>
  </refsect1>
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>db2_special_columns</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/ibm_db2/functions/db2-statistics.xml
+++ b/reference/ibm_db2/functions/db2-statistics.xml
@@ -246,36 +246,6 @@
   </para>
  </refsect1>
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>db2_statistics</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/ibm_db2/functions/db2-stmt-error.xml
+++ b/reference/ibm_db2/functions/db2-stmt-error.xml
@@ -54,36 +54,6 @@
   </simpara>
  </refsect1>
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>db2_stmt_error</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/ibm_db2/functions/db2-stmt-errormsg.xml
+++ b/reference/ibm_db2/functions/db2-stmt-errormsg.xml
@@ -48,36 +48,6 @@
   </simpara>
  </refsect1>
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>db2_stmt_errormsg</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/ibm_db2/functions/db2-table-privileges.xml
+++ b/reference/ibm_db2/functions/db2-table-privileges.xml
@@ -124,36 +124,6 @@
   </para>
  </refsect1>
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>db2_table_privileges</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/ibm_db2/functions/db2-tables.xml
+++ b/reference/ibm_db2/functions/db2-tables.xml
@@ -121,36 +121,6 @@
   </para>
  </refsect1>
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>db2_tables</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/imagick/imagick.xml
+++ b/reference/imagick/imagick.xml
@@ -15,12 +15,8 @@
       <interfacename>Iterator</interfacename>
      </oointerface>
     </classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.imagick')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.imagick')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.imagick')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.imagick')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
    </classsynopsis>
   </section>
 

--- a/reference/imagick/imagick/setfont.xml
+++ b/reference/imagick/imagick/setfont.xml
@@ -48,38 +48,7 @@
   </para>
  </refsect1>
 
- <!-- Use when ERRORS exist
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   When does this function throw E_* level errors, or exceptions?
-  </para>
- </refsect1>
- -->
 
- <!-- Use when a CHANGELOG exists
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>Enter the PHP version of change here</entry>
-       <entry>Description of change</entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
- -->
 
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/imap/functions/imap-mutf7-to-utf8.xml
+++ b/reference/imap/functions/imap-mutf7-to-utf8.xml
@@ -8,7 +8,7 @@
   <refpurpose>修正UTF-7文字列をUTF-8にデコードする</refpurpose>
  </refnamediv>
 
- <refsect1 role="description"><!-- {{{ -->
+ <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
    <type class="union"><type>string</type><type>false</type></type><methodname>imap_mutf7_to_utf8</methodname>
@@ -22,9 +22,9 @@
     この関数は libcclient が utf8_to_mutf7() をエクスポートした場合にのみ利用できます。
    </para>
   </note>
- </refsect1><!-- }}} -->
+ </refsect1>
 
- <refsect1 role="parameters"><!-- {{{ -->
+ <refsect1 role="parameters">
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
@@ -36,22 +36,22 @@
     </listitem>
    </varlistentry>
   </variablelist>
- </refsect1><!-- }}} -->
+ </refsect1>
 
- <refsect1 role="returnvalues"><!-- {{{ -->
+ <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
    <parameter>string</parameter> を UTF-8 に変換したものを返します。
    &return.falseforfailure;.
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
 
- <refsect1 role="seealso"><!-- {{{ -->
+ <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
    <member><function>imap_utf8_to_mutf7</function></member>
   </simplelist>
- </refsect1><!-- }}} -->
+ </refsect1>
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/imap/functions/imap-utf8-to-mutf7.xml
+++ b/reference/imap/functions/imap-utf8-to-mutf7.xml
@@ -8,7 +8,7 @@
   <refpurpose>UTF-8 文字列を修正UTF-7にエンコードする</refpurpose>
  </refnamediv>
 
- <refsect1 role="description"><!-- {{{ -->
+ <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
    <type class="union"><type>string</type><type>false</type></type><methodname>imap_utf8_to_mutf7</methodname>
@@ -22,9 +22,9 @@
     この関数は libcclient が utf8_to_mutf7() をエクスポートした場合にのみ利用できます。
    </para>
   </note>
- </refsect1><!-- }}} -->
+ </refsect1>
 
- <refsect1 role="parameters"><!-- {{{ -->
+ <refsect1 role="parameters">
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
@@ -36,22 +36,22 @@
     </listitem>
    </varlistentry>
   </variablelist>
- </refsect1><!-- }}} -->
+ </refsect1>
 
- <refsect1 role="returnvalues"><!-- {{{ -->
+ <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
    <parameter>string</parameter> を修正UTF-7に変換したものを返します。
    &return.falseforfailure;.
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
 
- <refsect1 role="seealso"><!-- {{{ -->
+ <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
    <member><function>imap_mutf7_to_utf8</function></member>
   </simplelist>
- </refsect1><!-- }}} -->
+ </refsect1>
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/info/functions/gc-collect-cycles.xml
+++ b/reference/info/functions/gc-collect-cycles.xml
@@ -30,14 +30,6 @@
   </para>
  </refsect1>
 
- <!-- Use when ERRORS exist
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   When does this function throw E_* level errors, or exceptions?
-  </para>
- </refsect1>
- -->
 
  <refsect1 role="changelog">
   &reftitle.changelog;
@@ -62,36 +54,6 @@
   </informaltable>
  </refsect1>
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>gc_collect_cycles</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/info/functions/gc-disable.xml
+++ b/reference/info/functions/gc-disable.xml
@@ -31,69 +31,8 @@
   </para>
  </refsect1>
 
- <!-- Use when ERRORS exist
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   When does this function throw E_* level errors, or exceptions?
-  </para>
- </refsect1>
- -->
 
- <!-- Use when a CHANGELOG exists
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>Enter the PHP version of change here</entry>
-       <entry>Description of change</entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>gc_disable</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/info/functions/gc-enable.xml
+++ b/reference/info/functions/gc-enable.xml
@@ -31,69 +31,8 @@
   </para>
  </refsect1>
 
- <!-- Use when ERRORS exist
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   When does this function throw E_* level errors, or exceptions?
-  </para>
- </refsect1>
- -->
 
- <!-- Use when a CHANGELOG exists
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>Enter the PHP version of change here</entry>
-       <entry>Description of change</entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>gc_enable</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/info/functions/gc-enabled.xml
+++ b/reference/info/functions/gc-enabled.xml
@@ -30,38 +30,7 @@
   </para>
  </refsect1>
 
- <!-- Use when ERRORS exist
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   When does this function throw E_* level errors, or exceptions?
-  </para>
- </refsect1>
- -->
 
- <!-- Use when a CHANGELOG exists
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>Enter the PHP version of change here</entry>
-       <entry>Description of change</entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
- -->
 
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/info/functions/gc-mem-caches.xml
+++ b/reference/info/functions/gc-mem-caches.xml
@@ -32,69 +32,8 @@
   </para>
  </refsect1>
 
- <!-- Use when ERRORS exist
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   When does this function throw E_* level errors, or exceptions?
-  </para>
- </refsect1>
- -->
 
- <!-- Use when a CHANGELOG exists
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>Enter the PHP version of change here</entry>
-       <entry>Description of change</entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>gc_collect_cycles</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/intl/collator.xml
+++ b/reference/intl/collator.xml
@@ -172,12 +172,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.collator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Collator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.collator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Collator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.collator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Collator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.collator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Collator'])"/>
    </classsynopsis>
    <!-- }}} -->
 

--- a/reference/intl/dateformatter.xml
+++ b/reference/intl/dateformatter.xml
@@ -108,12 +108,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intldateformatter')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='IntlDateFormatter'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intldateformatter')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlDateFormatter'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intldateformatter')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='IntlDateFormatter'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intldateformatter')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlDateFormatter'])"/>
    </classsynopsis>
    <!-- }}} -->
 

--- a/reference/intl/intlbreakiterator.xml
+++ b/reference/intl/intlbreakiterator.xml
@@ -170,12 +170,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlbreakiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='IntlBreakIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlbreakiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlBreakIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlbreakiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='IntlBreakIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlbreakiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlBreakIterator'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/intl/intlcalendar.xml
+++ b/reference/intl/intlcalendar.xml
@@ -264,12 +264,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlcalendar')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='IntlCalendar'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlcalendar')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlCalendar'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlcalendar')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='IntlCalendar'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlcalendar')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlCalendar'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/intl/intlchar.xml
+++ b/reference/intl/intlchar.xml
@@ -4031,9 +4031,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlchar')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlChar'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlchar')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlChar'])"/>
    </classsynopsis>
 
    <section xml:id="intlchar.constants">

--- a/reference/intl/intlcodepointbreakiterator.xml
+++ b/reference/intl/intlcodepointbreakiterator.xml
@@ -33,19 +33,13 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlbreakiterator')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlbreakiterator')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlcodepointbreakiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlCodePointBreakIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlcodepointbreakiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlCodePointBreakIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlbreakiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlBreakIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlbreakiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlBreakIterator'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/intl/intldatepatterngenerator.xml
+++ b/reference/intl/intldatepatterngenerator.xml
@@ -28,12 +28,8 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intldatepatterngenerator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='IntlDatePatternGenerator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intldatepatterngenerator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlDatePatternGenerator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intldatepatterngenerator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='IntlDatePatternGenerator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intldatepatterngenerator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlDatePatternGenerator'])"/>
    </classsynopsis>
    <!-- }}} -->
 

--- a/reference/intl/intlexception.xml
+++ b/reference/intl/intlexception.xml
@@ -35,17 +35,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/intl/intlgregoriancalendar.xml
+++ b/reference/intl/intlgregoriancalendar.xml
@@ -32,22 +32,14 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlcalendar')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlcalendar')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlgregoriancalendar')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='IntlGregorianCalendar'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlgregoriancalendar')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlGregorianCalendar'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlgregoriancalendar')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='IntlGregorianCalendar'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlgregoriancalendar')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlGregorianCalendar'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlcalendar')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlCalendar'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlcalendar')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlCalendar'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/intl/intliterator.xml
+++ b/reference/intl/intliterator.xml
@@ -52,9 +52,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intliterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intliterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlIterator'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/intl/intllistformatter.xml
+++ b/reference/intl/intllistformatter.xml
@@ -65,12 +65,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intllistformatter')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='IntlListFormatter'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intllistformatter')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlListFormatter'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intllistformatter')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='IntlListFormatter'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intllistformatter')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlListFormatter'])"/>
    </classsynopsis>
    <!-- }}} -->
 

--- a/reference/intl/intlpartsiterator.xml
+++ b/reference/intl/intlpartsiterator.xml
@@ -64,14 +64,10 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlpartsiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlPartsIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlpartsiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlPartsIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intliterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intliterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlIterator'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/intl/intlrulebasedbreakiterator.xml
+++ b/reference/intl/intlrulebasedbreakiterator.xml
@@ -41,22 +41,14 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlbreakiterator')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlbreakiterator')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlrulebasedbreakiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='IntlRuleBasedBreakIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlrulebasedbreakiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlRuleBasedBreakIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlrulebasedbreakiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='IntlRuleBasedBreakIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlrulebasedbreakiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlRuleBasedBreakIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlbreakiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlBreakIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlbreakiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlBreakIterator'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/intl/intltimezone.xml
+++ b/reference/intl/intltimezone.xml
@@ -95,12 +95,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intltimezone')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='IntlTimeZone'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intltimezone')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlTimeZone'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intltimezone')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='IntlTimeZone'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intltimezone')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlTimeZone'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/intl/locale.xml
+++ b/reference/intl/locale.xml
@@ -121,9 +121,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.locale')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Locale'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.locale')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Locale'])"/>
    </classsynopsis>
    <!-- }}} -->
 

--- a/reference/intl/messageformatter.xml
+++ b/reference/intl/messageformatter.xml
@@ -59,12 +59,8 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.messageformatter')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='MessageFormatter'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.messageformatter')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='MessageFormatter'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.messageformatter')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='MessageFormatter'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.messageformatter')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='MessageFormatter'])"/>
    </classsynopsis>
    <!-- }}} -->
 

--- a/reference/intl/normalizer.xml
+++ b/reference/intl/normalizer.xml
@@ -111,9 +111,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.normalizer')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Normalizer'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.normalizer')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Normalizer'])"/>
    </classsynopsis>
    <!-- }}} -->
 

--- a/reference/intl/numberformatter.xml
+++ b/reference/intl/numberformatter.xml
@@ -561,12 +561,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.numberformatter')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='NumberFormatter'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.numberformatter')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='NumberFormatter'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.numberformatter')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='NumberFormatter'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.numberformatter')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='NumberFormatter'])"/>
    </classsynopsis>
    <!-- }}} -->
 

--- a/reference/intl/resourcebundle.xml
+++ b/reference/intl/resourcebundle.xml
@@ -59,12 +59,8 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.resourcebundle')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ResourceBundle'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.resourcebundle')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ResourceBundle'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.resourcebundle')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ResourceBundle'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.resourcebundle')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ResourceBundle'])"/>
    </classsynopsis>
    <!-- }}} -->
 

--- a/reference/intl/spoofchecker.xml
+++ b/reference/intl/spoofchecker.xml
@@ -154,12 +154,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.spoofchecker')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Spoofchecker'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.spoofchecker')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Spoofchecker'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.spoofchecker')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Spoofchecker'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.spoofchecker')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Spoofchecker'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/intl/transliterator.xml
+++ b/reference/intl/transliterator.xml
@@ -48,12 +48,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.transliterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Transliterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.transliterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Transliterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.transliterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Transliterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.transliterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Transliterator'])"/>
    </classsynopsis>
    <!-- }}} -->
 

--- a/reference/intl/uconverter.xml
+++ b/reference/intl/uconverter.xml
@@ -275,12 +275,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.uconverter')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='UConverter'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.uconverter')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='UConverter'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.uconverter')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='UConverter'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.uconverter')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='UConverter'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/json/jsonexception.xml
+++ b/reference/json/jsonexception.xml
@@ -36,17 +36,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/json/jsonserializable.xml
+++ b/reference/json/jsonserializable.xml
@@ -29,9 +29,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.jsonserializable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='JsonSerializable'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.jsonserializable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='JsonSerializable'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/libxml/functions/libxml-disable-entity-loader.xml
+++ b/reference/libxml/functions/libxml-disable-entity-loader.xml
@@ -84,44 +84,7 @@
   </informaltable>
  </refsect1>
 
-<!--
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   When does this function issue E_* level errors, and/or throw exceptions.
-  </para>
- </refsect1>
--->
 
-<!--
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title><function>libxml_disable_entity_loader</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or what
-     goes on in the example should be here.
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-
-/* ... */
-
-?>
-]]>
-    </programlisting>
-    &example.outputs.similar;
-    <screen>
-<![CDATA[
-...
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
--->
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/mbstring/functions/mb-stripos.xml
+++ b/reference/mbstring/functions/mb-stripos.xml
@@ -112,36 +112,6 @@
   </informaltable>
  </refsect1>
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>mb_stripos</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/mbstring/functions/mb-stristr.xml
+++ b/reference/mbstring/functions/mb-stristr.xml
@@ -78,14 +78,6 @@
   </para>
  </refsect1>
 
- <!-- Use when ERRORS exist
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   When does this function throw E_* level errors, or exceptions?
-  </para>
- </refsect1>
- -->
 
  <refsect1 role="changelog">
   &reftitle.changelog;
@@ -105,36 +97,6 @@
   </informaltable>
  </refsect1>
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>mb_stristr</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/mbstring/functions/mb-strrichr.xml
+++ b/reference/mbstring/functions/mb-strrichr.xml
@@ -78,14 +78,6 @@
   </para>
  </refsect1>
 
- <!-- Use when ERRORS exist
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   When does this function throw E_* level errors, or exceptions?
-  </para>
- </refsect1>
- -->
 
  <refsect1 role="changelog">
   &reftitle.changelog;
@@ -105,36 +97,6 @@
   </informaltable>
  </refsect1>
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>mb_strrichr</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
 
  <refsect1 role="seealso">

--- a/reference/mbstring/functions/mb-strripos.xml
+++ b/reference/mbstring/functions/mb-strripos.xml
@@ -109,36 +109,6 @@
   </informaltable>
  </refsect1>
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>mb_strripos</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/mbstring/functions/mb-strstr.xml
+++ b/reference/mbstring/functions/mb-strstr.xml
@@ -73,14 +73,6 @@
   </para>
  </refsect1>
 
- <!-- Use when ERRORS exist
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   When does this function throw E_* level errors, or exceptions?
-  </para>
- </refsect1>
- -->
 
  <refsect1 role="changelog">
   &reftitle.changelog;
@@ -100,36 +92,6 @@
   </informaltable>
  </refsect1>
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>mb_strstr</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/memcached/memcached.xml
+++ b/reference/memcached/memcached.xml
@@ -33,12 +33,8 @@
     </classsynopsisinfo>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.memcached')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Memcached'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.memcached')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Memcached'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.memcached')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Memcached'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.memcached')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Memcached'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/misc/functions/pack.xml
+++ b/reference/misc/functions/pack.xml
@@ -197,7 +197,7 @@
   </para>
  </refsect1>
 
- <refsect1 role="changelog"><!-- {{{ -->
+ <refsect1 role="changelog">
   &reftitle.changelog;
   <para>
    <informaltable>
@@ -231,7 +231,7 @@
     </tgroup>
    </informaltable>
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/misc/functions/sapi-windows-cp-conv.xml
+++ b/reference/misc/functions/sapi-windows-cp-conv.xml
@@ -7,7 +7,7 @@
   <refpurpose>文字列のコードページを別のものに変換する</refpurpose>
  </refnamediv>
 
- <refsect1 role="description"><!-- {{{ -->
+ <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
    <type class="union"><type>string</type><type>null</type></type><methodname>sapi_windows_cp_conv</methodname>
@@ -18,9 +18,9 @@
   <para>
    文字列のコードページを別のものに変換します。
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
 
- <refsect1 role="parameters"><!-- {{{ -->
+ <refsect1 role="parameters">
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
@@ -50,17 +50,17 @@
     </listitem>
    </varlistentry>
   </variablelist>
- </refsect1><!-- }}} -->
+ </refsect1>
 
- <refsect1 role="returnvalues"><!-- {{{ -->
+ <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
    <parameter>out_codepage</parameter> に変換された <parameter>subject</parameter> 文字列。
    失敗した場合は &null; を返します。
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
 
- <refsect1 role="errors"><!-- {{{ -->
+ <refsect1 role="errors">
   &reftitle.errors;
   <para>
    この関数は、不正なコードページが与えられたり、
@@ -68,15 +68,15 @@
    <parameter>in_codepage</parameter> でなかった場合は、
    E_WARNINGレベルの警告を発生させます。
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
 
- <refsect1 role="seealso"><!-- {{{ -->
+ <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
    <member><function>sapi_windows_cp_get</function></member>
    <member><function>iconv</function></member>
   </simplelist>
- </refsect1><!-- }}} -->
+ </refsect1>
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/misc/functions/sapi-windows-cp-get.xml
+++ b/reference/misc/functions/sapi-windows-cp-get.xml
@@ -8,7 +8,7 @@
   <refpurpose>現在のコードページを取得する</refpurpose>
  </refnamediv>
 
- <refsect1 role="description"><!-- {{{ -->
+ <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
    <type>int</type><methodname>sapi_windows_cp_get</methodname>
@@ -17,9 +17,9 @@
   <para>
    現在のコードページを取得します。
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
 
- <refsect1 role="parameters"><!-- {{{ -->
+ <refsect1 role="parameters">
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
@@ -32,9 +32,9 @@
     </listitem>
    </varlistentry>
   </variablelist>
- </refsect1><!-- }}} -->
+ </refsect1>
 
- <refsect1 role="returnvalues"><!-- {{{ -->
+ <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
    コードページの識別子を返します。
@@ -44,14 +44,14 @@
    オペレーティングシステムの、現在の <acronym>OEM</acronym>  コードページを返します。
    それ以外の場合、現在のプロセスのコードページを返します。
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
 
- <refsect1 role="seealso"><!-- {{{ -->
+ <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
    <member><function>sapi_windows_cp_set</function></member>
   </simplelist>
- </refsect1><!-- }}} -->
+ </refsect1>
 
 </refentry>
 

--- a/reference/misc/functions/sapi-windows-cp-is-utf8.xml
+++ b/reference/misc/functions/sapi-windows-cp-is-utf8.xml
@@ -8,7 +8,7 @@
   <refpurpose>コードページがUTF-8と互換性があるかを返す</refpurpose>
  </refnamediv>
 
- <refsect1 role="description"><!-- {{{ -->
+ <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>sapi_windows_cp_is_utf8</methodname>
@@ -17,26 +17,26 @@
   <para>
    現在のプロセスのコードページが UTF-8 と互換性があるかを返します。
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
 
- <refsect1 role="parameters"><!-- {{{ -->
+ <refsect1 role="parameters">
   &reftitle.parameters;
   &no.function.parameters;
- </refsect1><!-- }}} -->
+ </refsect1>
 
- <refsect1 role="returnvalues"><!-- {{{ -->
+ <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
    現在のプロセスのコードページが UTF-8 と互換性があるかを返します。
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
 
- <refsect1 role="seealso"><!-- {{{ -->
+ <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
    <member><function>sapi_windows_cp_get</function></member>
   </simplelist>
- </refsect1><!-- }}} -->
+ </refsect1>
 
 </refentry>
 

--- a/reference/misc/functions/sapi-windows-cp-set.xml
+++ b/reference/misc/functions/sapi-windows-cp-set.xml
@@ -7,7 +7,7 @@
   <refpurpose>現在のプロセスのコードページを設定する</refpurpose>
  </refnamediv>
 
- <refsect1 role="description"><!-- {{{ -->
+ <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>sapi_windows_cp_set</methodname>
@@ -16,9 +16,9 @@
   <para>
    現在のプロセスのコードページを設定します。
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
 
- <refsect1 role="parameters"><!-- {{{ -->
+ <refsect1 role="parameters">
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
@@ -30,21 +30,21 @@
     </listitem>
    </varlistentry>
   </variablelist>
- </refsect1><!-- }}} -->
+ </refsect1>
 
- <refsect1 role="returnvalues"><!-- {{{ -->
+ <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
    &return.success;
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
 
- <refsect1 role="seealso"><!-- {{{ -->
+ <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
    <member><function>sapi_windows_cp_get</function></member>
   </simplelist>
- </refsect1><!-- }}} -->
+ </refsect1>
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/misc/functions/sapi-windows-vt100-support.xml
+++ b/reference/misc/functions/sapi-windows-vt100-support.xml
@@ -7,7 +7,7 @@
   <refpurpose>Windows コンソールの出力バッファに関連付けられたストリームのVT100サポート状況を取得/設定する</refpurpose>
  </refnamediv>
  
- <refsect1 role="description"><!-- {{{ -->
+ <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>sapi_windows_vt100_support</methodname>
@@ -40,9 +40,9 @@
     よって、古いWindowsバージョンでは VT100の機能は有効にならないかもしれません。
    </simpara>
   </warning>
- </refsect1><!-- }}} -->
+ </refsect1>
  
- <refsect1 role="parameters"><!-- {{{ -->
+ <refsect1 role="parameters">
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
@@ -64,9 +64,9 @@
     </listitem>
    </varlistentry>
   </variablelist>
- </refsect1><!-- }}} -->
+ </refsect1>
  
- <refsect1 role="returnvalues"><!-- {{{ -->
+ <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
    <parameter>enable</parameter> が省略されるか、&null; の場合、
@@ -77,7 +77,7 @@
    <parameter>enable</parameter> に <type>bool</type> を指定すると、
    &return.success;
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
 
  <refsect1 role="changelog">
   &reftitle.changelog;
@@ -101,7 +101,7 @@
   </informaltable>
  </refsect1>
 
- <refsect1 role="examples"><!-- {{{ -->
+ <refsect1 role="examples">
   &reftitle.examples;
   <example>
    <title><function>sapi_windows_vt100_support</function> でデフォルトの状態を出力する</title>

--- a/reference/misc/functions/unpack.xml
+++ b/reference/misc/functions/unpack.xml
@@ -83,7 +83,7 @@
   </para>
  </refsect1>
 
- <refsect1 role="changelog"><!-- {{{ -->
+ <refsect1 role="changelog">
   &reftitle.changelog;
   <para>
    <informaltable>
@@ -112,7 +112,7 @@
     </tgroup>
    </informaltable>
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/mysqli/mysqli.xml
+++ b/reference/mysqli/mysqli.xml
@@ -137,12 +137,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mysqli')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='mysqli'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mysqli')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='mysqli'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mysqli')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='mysqli'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mysqli')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='mysqli'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/mysqli/mysqli_result.xml
+++ b/reference/mysqli/mysqli_result.xml
@@ -62,12 +62,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mysqli-result')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='mysqli_result'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mysqli-result')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='mysqli_result'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mysqli-result')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='mysqli_result'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mysqli-result')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='mysqli_result'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/mysqli/mysqli_result/fetch-field-direct.xml
+++ b/reference/mysqli/mysqli_result/fetch-field-direct.xml
@@ -53,9 +53,7 @@
    <parameter>index</parameter> のフィールドの情報が取得できない場合は
    &false; を返します。
   </para>
-  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqli-result.fetch-fields')/db:refsect1[@role='returnvalues']/db:table)">
-   <xi:fallback/>
-  </xi:include>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqli-result.fetch-fields')/db:refsect1[@role='returnvalues']/db:table)"/>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mysqli/mysqli_result/fetch-field.xml
+++ b/reference/mysqli/mysqli_result/fetch-field.xml
@@ -44,9 +44,7 @@
    フィールド定義情報を含むオブジェクトを返します。もし
    フィールドの情報が取得できない場合は、&false; を返します。
   </para>
-  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqli-result.fetch-fields')/db:refsect1[@role='returnvalues']/db:table)">
-   <xi:fallback/>
-  </xi:include>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqli-result.fetch-fields')/db:refsect1[@role='returnvalues']/db:table)"/>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mysqli/mysqli_sql_exception.xml
+++ b/reference/mysqli/mysqli_sql_exception.xml
@@ -37,22 +37,14 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mysqli-sql-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='mysqli_sql_exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mysqli-sql-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='mysqli_sql_exception'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
   </section>
 

--- a/reference/mysqli/mysqli_stmt.xml
+++ b/reference/mysqli/mysqli_stmt.xml
@@ -88,12 +88,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mysqli-stmt')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='mysqli_stmt'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mysqli-stmt')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='mysqli_stmt'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mysqli-stmt')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='mysqli_stmt'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mysqli-stmt')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='mysqli_stmt'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/mysqli/mysqli_warning.xml
+++ b/reference/mysqli/mysqli_warning.xml
@@ -45,12 +45,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mysqli-warning')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='mysqli_warning'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mysqli-warning')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='mysqli_warning'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mysqli-warning')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='mysqli_warning'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mysqli-warning')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='mysqli_warning'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/mysqlnd/stats.xml
+++ b/reference/mysqlnd/stats.xml
@@ -170,9 +170,7 @@
       EOF のサイズはサーバーのバージョンによって異なる場合があります。
       また、EOF はエラーメッセージを転送することもあります。
      </simpara>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.bytes-received-ok-packet')/db:listitem/db:note)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.bytes-received-ok-packet')/db:listitem/db:note)"/>
     </listitem>
    </varlistentry>
 
@@ -199,9 +197,7 @@
       （<literal>LOAD LOCAL INFILE</literal>、<literal>INSERT</literal>、
       <literal>UPDATE</literal>、<literal>SELECT</literal>、エラーメッセージ）によって異なります。
      </simpara>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.bytes-received-ok-packet')/db:listitem/db:note)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.bytes-received-ok-packet')/db:listitem/db:note)"/>
     </listitem>
    </varlistentry>
 
@@ -224,9 +220,7 @@
       COM_LIST_FIELDS の場合、パケットにはエラーまたは EOF パケットが
       含まれることもあります。
      </simpara>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.bytes-received-ok-packet')/db:listitem/db:note)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.bytes-received-ok-packet')/db:listitem/db:note)"/>
     </listitem>
    </varlistentry>
 
@@ -252,9 +246,7 @@
       を <literal>bytes_received_rset_row_packet</literal>
       から差し引くことで、エラーおよび EOF パケットの数を算出できます。
      </simpara>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.bytes-received-ok-packet')/db:listitem/db:note)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.bytes-received-ok-packet')/db:listitem/db:note)"/>
     </listitem>
    </varlistentry>
 
@@ -276,9 +268,7 @@
       パケットにはエラーが含まれることもあります。
       パケットのサイズは MySQL のバージョンによって異なります。
      </simpara>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.bytes-received-ok-packet')/db:listitem/db:note)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.bytes-received-ok-packet')/db:listitem/db:note)"/>
     </listitem>
    </varlistentry>
 
@@ -300,9 +290,7 @@
       合計サイズ（バイト単位）。
       パケットにはエラーまたは EOF が含まれることもあります。
      </simpara>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.bytes-received-ok-packet')/db:listitem/db:note)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.bytes-received-ok-packet')/db:listitem/db:note)"/>
     </listitem>
    </varlistentry>
 
@@ -435,9 +423,7 @@ $res->close();
       結果セットのヘッダパケットの読み取り時にエラーが発生した場合、
       この統計情報は増加しません。
      </simpara>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.result-set-queries')/db:listitem/db:note)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.result-set-queries')/db:listitem/db:note)"/>
     </listitem>
    </varlistentry>
 
@@ -467,9 +453,7 @@ $res->close();
       結果セットを生成したが適切なインデックスを使用しなかったクエリの数。
       （mysqld の起動オプション <literal>--log-slow-queries</literal> も参照してください。）
      </simpara>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.no-index-used')/db:listitem/db:note)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.no-index-used')/db:listitem/db:note)"/>
     </listitem>
    </varlistentry>
 
@@ -605,9 +589,7 @@ $res->close();
       未読のデータが暗黙的にフラッシュされたものの数。
      </simpara>
 
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.flushed-normal-sets')/db:listitem/db:note)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.flushed-normal-sets')/db:listitem/db:note)"/>
     </listitem>
    </varlistentry>
 

--- a/reference/oauth/oauth.xml
+++ b/reference/oauth/oauth.xml
@@ -47,12 +47,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.oauth')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.oauth')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.oauth')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.oauth')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/oci8/ocicollection.xml
+++ b/reference/oci8/ocicollection.xml
@@ -34,9 +34,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ocicollection')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='OCICollection'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ocicollection')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='OCICollection'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/oci8/ocilob.xml
+++ b/reference/oci8/ocilob.xml
@@ -34,9 +34,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ocilob')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='OCILob'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ocilob')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='OCILob'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/outcontrol/user-level-output-buffers.xml
+++ b/reference/outcontrol/user-level-output-buffers.xml
@@ -20,7 +20,7 @@
    実用的な用語で説明すると、出力とは以下に示す、
    長さがゼロでないデータのことです:
    <itemizedlist>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('outputcontrol.what-is-output')/*)"><xi:fallback/></xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('outputcontrol.what-is-output')/*)"/>
    </itemizedlist>
   </para>
   <note>

--- a/reference/pdo/pdo.xml
+++ b/reference/pdo/pdo.xml
@@ -478,12 +478,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PDO'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PDO'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PDO'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PDO'])"/>
    </classsynopsis>
   </section>
 

--- a/reference/pdo/pdo/connect.xml
+++ b/reference/pdo/pdo/connect.xml
@@ -24,9 +24,7 @@
   </simpara>
  </refsect1>
 
- <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo.construct')/db:refsect1[@role='parameters']/.)">
-  <xi:fallback/>
- </xi:include>
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo.construct')/db:refsect1[@role='parameters']/.)"/>
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
@@ -37,9 +35,7 @@
   </simpara>
  </refsect1>
 
- <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo.construct')/db:refsect1[@role='errors']/.)">
-  <xi:fallback/>
- </xi:include>
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo.construct')/db:refsect1[@role='errors']/.)"/>
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/pdo/pdo/quote.xml
+++ b/reference/pdo/pdo/quote.xml
@@ -87,14 +87,6 @@
   </para>
  </refsect1>
 
- <!-- Use when ERRORS exist
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   When does this function throw E_* level errors, or exceptions?
-  </para>
- </refsect1>
- -->
 
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/pdo/pdoexception.xml
+++ b/reference/pdo/pdoexception.xml
@@ -8,7 +8,6 @@
  
  <partintro>
  
-<!-- {{{ PDOException intro -->
   <section xml:id="pdoexception.intro">
    &reftitle.intro;
    <para>
@@ -19,12 +18,10 @@
     を参照ください。
    </para>
   </section>
-<!-- }}} -->
  
   <section xml:id="pdoexception.synopsis">
    &reftitle.classsynopsis;
  
-<!-- {{{ Synopsis -->
    <classsynopsis class="class">
     <ooexception>
      <exceptionname>PDOException</exceptionname>
@@ -49,27 +46,19 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;'] and (not(@xml:id) or @xml:id != 'class.exception..code')]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;'] and (not(@xml:id) or @xml:id != 'class.exception..code')]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
-<!-- }}} -->
  
   </section>
  
-<!-- {{{ PDOException properties -->
   <section xml:id="pdoexception.props">
    &reftitle.properties;
    <variablelist>
-    <varlistentry xml:id="pdoexception.props.errorinfo"><!-- {{{ -->
+    <varlistentry xml:id="pdoexception.props.errorinfo">
      <term><varname>errorInfo</varname></term>
      <listitem>
       <para>
@@ -77,8 +66,8 @@
        <methodname>PDOStatement::errorInfo</methodname> に対応します。
       </para>
      </listitem>
-    </varlistentry><!-- }}} -->
-    <varlistentry xml:id="pdoexception.props.code"><!-- {{{ -->
+    </varlistentry>
+    <varlistentry xml:id="pdoexception.props.code">
      <term><varname>code</varname></term>
      <listitem>
       <para>
@@ -86,10 +75,9 @@
        <methodname>Exception::getCode</methodname> でアクセスします。
       </para>
      </listitem>
-    </varlistentry><!-- }}} -->
+    </varlistentry>
    </variablelist>
   </section>
-<!-- }}} -->
  
  </partintro>
  

--- a/reference/pdo/pdostatement.xml
+++ b/reference/pdo/pdostatement.xml
@@ -39,9 +39,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdostatement')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PDOStatement'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdostatement')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PDOStatement'])"/>
    </classsynopsis>
 <!-- }}} -->
   </section>

--- a/reference/pdo/pdostatement/getcolumnmeta.xml
+++ b/reference/pdo/pdostatement/getcolumnmeta.xml
@@ -114,14 +114,6 @@
   </para>
  </refsect1>
 
- <!-- Use when ERRORS exist
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   When does this function throw E_* level errors, or exceptions?
-  </para>
- </refsect1>
- -->
 
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/pdo/pdostatement/setfetchmode.xml
+++ b/reference/pdo/pdostatement/setfetchmode.xml
@@ -144,17 +144,6 @@ pear    green   150
   </para>
  </refsect1>
 
- <!-- Use when adding See Also links
- <refsect1 role="seealso">
-  &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><methodname></methodname></member>
-    <member>Or <link linkend="somethingelse">something else</link></member>
-   </simplelist>
-  </para>
- </refsect1>
- -->
 
 
 </refentry>

--- a/reference/pdo_dblib/pdo-dblib.xml
+++ b/reference/pdo_dblib/pdo-dblib.xml
@@ -34,9 +34,7 @@
      </ooclass>
 
      <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
      <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
      <fieldsynopsis>
@@ -83,12 +81,8 @@
      </fieldsynopsis>
 
      <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PDO'])">
-      <xi:fallback/>
-     </xi:include>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PDO'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PDO'])"/>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PDO'])"/>
     </classsynopsis>
    </packagesynopsis>
    <!-- }}} -->

--- a/reference/pdo_firebird/pdo-firebird.xml
+++ b/reference/pdo_firebird/pdo-firebird.xml
@@ -34,9 +34,7 @@
      </ooclass>
 
      <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
      <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
      <fieldsynopsis>
@@ -89,17 +87,11 @@
      </fieldsynopsis>
 
      <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo-firebird')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Pdo\\Firebird'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo-firebird')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Pdo\\Firebird'])"/>
 
      <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PDO'])">
-      <xi:fallback/>
-     </xi:include>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PDO'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PDO'])"/>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PDO'])"/>
     </classsynopsis>
    </packagesynopsis>
    <!-- }}} -->

--- a/reference/pdo_mysql/pdo-mysql.xml
+++ b/reference/pdo_mysql/pdo-mysql.xml
@@ -53,9 +53,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
@@ -174,17 +172,11 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo-mysql')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Pdo\\Mysql'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo-mysql')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Pdo\\Mysql'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PDO'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PDO'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PDO'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PDO'])"/>
    </classsynopsis>
    <!-- }}} -->
 
@@ -242,9 +234,7 @@ foreach ($unbufferedResult as $row) {
        LOCAL DATA 文によるファイルのロードを、
        ここで指定したディレクトリのみに制限します。
       </simpara>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-mysql.constants.attr-local-infile')//db:note/.)">
-       <xi:fallback/>
-      </xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-mysql.constants.attr-local-infile')//db:note/.)"/>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="pdo-mysql.constants.attr-init-command">
@@ -254,9 +244,7 @@ foreach ($unbufferedResult as $row) {
        MySQL サーバーへの接続時に実行するコマンドを指定します。
        再接続の際には自動的に再実行されます。
       </simpara>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-mysql.constants.attr-local-infile')//db:note/.)">
-       <xi:fallback/>
-      </xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-mysql.constants.attr-local-infile')//db:note/.)"/>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="pdo-mysql.constants.attr-read-default-file">
@@ -313,9 +301,7 @@ foreach ($unbufferedResult as $row) {
        変更された行数ではなく、
        見つかった (マッチした) 行数を返します。
       </simpara>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-mysql.constants.attr-local-infile')//db:note/.)">
-       <xi:fallback/>
-      </xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-mysql.constants.attr-local-infile')//db:note/.)"/>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="pdo-mysql.constants.attr-ignore-space">
@@ -325,9 +311,7 @@ foreach ($unbufferedResult as $row) {
        関数名の後に続く空白を許可します。
        すべての関数名が予約語になります。
       </simpara>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-mysql.constants.attr-local-infile')//db:note/.)">
-       <xi:fallback/>
-      </xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-mysql.constants.attr-local-infile')//db:note/.)"/>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="pdo-mysql.constants.attr-max-buffer-size">
@@ -351,9 +335,7 @@ foreach ($unbufferedResult as $row) {
        <methodname>PDO::prepare</methodname>や
        <methodname>PDO::query</methodname> でのマルチクエリの実行を無効にします。
       </simpara>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-mysql.constants.attr-local-infile')//db:note/.)">
-       <xi:fallback/>
-      </xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-mysql.constants.attr-local-infile')//db:note/.)"/>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="pdo-mysql.constants.attr-server-public-key">
@@ -362,9 +344,7 @@ foreach ($unbufferedResult as $row) {
       <simpara>
        SHA-256 ベースの認証で使用する <acronym>RSA</acronym> 公開鍵ファイル。
       </simpara>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-mysql.constants.attr-local-infile')//db:note/.)">
-       <xi:fallback/>
-      </xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-mysql.constants.attr-local-infile')//db:note/.)"/>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="pdo-mysql.constants.attr-ssl-key">
@@ -373,9 +353,7 @@ foreach ($unbufferedResult as $row) {
       <simpara>
        <acronym>SSL</acronym> キーのファイルパス。
       </simpara>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-mysql.constants.attr-local-infile')//db:note/.)">
-       <xi:fallback/>
-      </xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-mysql.constants.attr-local-infile')//db:note/.)"/>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="pdo-mysql.constants.attr-ssl-cert">
@@ -384,9 +362,7 @@ foreach ($unbufferedResult as $row) {
       <simpara>
        <acronym>SSL</acronym> 証明書のファイルパス。
       </simpara>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-mysql.constants.attr-local-infile')//db:note/.)">
-       <xi:fallback/>
-      </xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-mysql.constants.attr-local-infile')//db:note/.)"/>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="pdo-mysql.constants.attr-ssl-ca">
@@ -395,9 +371,7 @@ foreach ($unbufferedResult as $row) {
       <simpara>
        <acronym>SSL</acronym> 認証局のファイルパス。
       </simpara>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-mysql.constants.attr-local-infile')//db:note/.)">
-       <xi:fallback/>
-      </xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-mysql.constants.attr-local-infile')//db:note/.)"/>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="pdo-mysql.constants.attr-ssl-capath">
@@ -408,9 +382,7 @@ foreach ($unbufferedResult as $row) {
        <acronym>SSL</acronym> <acronym>CA</acronym> 証明書が入ったディレクトリパス。
        証明書は、<acronym>PEM</acronym> フォーマットで格納されています。
       </simpara>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-mysql.constants.attr-local-infile')//db:note/.)">
-       <xi:fallback/>
-      </xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-mysql.constants.attr-local-infile')//db:note/.)"/>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="pdo-mysql.constants.attr-ssl-cipher">
@@ -421,9 +393,7 @@ foreach ($unbufferedResult as $row) {
        OpenSSL で有効なフォーマットで指定します。
        例: <literal>DHE-RSA-AES256-SHA:AES128-SHA</literal>
       </simpara>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-mysql.constants.attr-local-infile')//db:note/.)">
-       <xi:fallback/>
-      </xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-mysql.constants.attr-local-infile')//db:note/.)"/>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="pdo-mysql.constants.attr-ssl-verify-server-cert">
@@ -437,9 +407,7 @@ foreach ($unbufferedResult as $row) {
         このオプションは、mysqlnd でのみ利用可能です。
        </simpara>
       </note>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-mysql.constants.attr-local-infile')//db:note/.)">
-       <xi:fallback/>
-      </xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-mysql.constants.attr-local-infile')//db:note/.)"/>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/pdo_odbc/pdo-odbc.xml
+++ b/reference/pdo_odbc/pdo-odbc.xml
@@ -35,9 +35,7 @@
      </ooclass>
 
      <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
      <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
      <fieldsynopsis>
@@ -72,12 +70,8 @@
      </fieldsynopsis>
 
      <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PDO'])">
-      <xi:fallback/>
-     </xi:include>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PDO'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PDO'])"/>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PDO'])"/>
     </classsynopsis>
    </packagesynopsis>
    <!-- }}} -->

--- a/reference/pdo_pgsql/pdo-pgsql.xml
+++ b/reference/pdo_pgsql/pdo-pgsql.xml
@@ -67,9 +67,7 @@
      </ooclass>
 
      <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
      <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
      <fieldsynopsis>
@@ -116,17 +114,11 @@
      </fieldsynopsis>
 
      <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo-pgsql')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Pdo\\Pgsql'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo-pgsql')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Pdo\\Pgsql'])"/>
 
      <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PDO'])">
-      <xi:fallback/>
-     </xi:include>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PDO'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PDO'])"/>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PDO'])"/>
     </classsynopsis>
    </packagesynopsis>
    <!-- }}} -->

--- a/reference/pdo_pgsql/pdo/pgsql/copyfromfile.xml
+++ b/reference/pdo_pgsql/pdo/pgsql/copyfromfile.xml
@@ -28,9 +28,7 @@
  <refsect1 role="parameters">
   &reftitle.parameters;
   <variablelist>
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-pgsql.copyfromarray')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='tableName']]]/.)">
-    <xi:fallback><varlistentry><term></term><listitem><simpara></simpara></listitem></varlistentry></xi:fallback>
-   </xi:include>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-pgsql.copyfromarray')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='tableName']]]/.)"/>
    <varlistentry>
     <term><parameter>filename</parameter></term>
     <listitem>
@@ -39,15 +37,9 @@
      </simpara>
     </listitem>
    </varlistentry>
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-pgsql.copyfromarray')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='separator']]]/.)">
-    <xi:fallback><varlistentry><term></term><listitem><simpara></simpara></listitem></varlistentry></xi:fallback>
-   </xi:include>
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-pgsql.copyfromarray')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='nullAs']]]/.)">
-    <xi:fallback><varlistentry><term></term><listitem><simpara></simpara></listitem></varlistentry></xi:fallback>
-   </xi:include>
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-pgsql.copyfromarray')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='fields']]]/.)">
-    <xi:fallback><varlistentry><term></term><listitem><simpara></simpara></listitem></varlistentry></xi:fallback>
-   </xi:include>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-pgsql.copyfromarray')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='separator']]]/.)"/>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-pgsql.copyfromarray')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='nullAs']]]/.)"/>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-pgsql.copyfromarray')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='fields']]]/.)"/>
   </variablelist>
  </refsect1>
 

--- a/reference/pdo_pgsql/pdo/pgsql/copytoarray.xml
+++ b/reference/pdo_pgsql/pdo/pgsql/copytoarray.xml
@@ -25,15 +25,9 @@
  <refsect1 role="parameters">
   &reftitle.parameters;
   <variablelist>
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-pgsql.copyfromarray')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='tableName']]]/.)">
-    <xi:fallback><varlistentry><term></term><listitem><simpara></simpara></listitem></varlistentry></xi:fallback>
-   </xi:include>
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-pgsql.copyfromarray')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='separator']]]/.)">
-    <xi:fallback><varlistentry><term></term><listitem><simpara></simpara></listitem></varlistentry></xi:fallback>
-   </xi:include>
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-pgsql.copyfromarray')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='nullAs']]]/.)">
-    <xi:fallback><varlistentry><term></term><listitem><simpara></simpara></listitem></varlistentry></xi:fallback>
-   </xi:include>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-pgsql.copyfromarray')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='tableName']]]/.)"/>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-pgsql.copyfromarray')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='separator']]]/.)"/>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-pgsql.copyfromarray')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='nullAs']]]/.)"/>
    <varlistentry>
     <term><parameter>fields</parameter></term>
     <listitem>

--- a/reference/pdo_pgsql/pdo/pgsql/copytofile.xml
+++ b/reference/pdo_pgsql/pdo/pgsql/copytofile.xml
@@ -28,9 +28,7 @@
  <refsect1 role="parameters">
   &reftitle.parameters;
   <variablelist>
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-pgsql.copyfromarray')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='tableName']]]/.)">
-    <xi:fallback><varlistentry><term></term><listitem><simpara></simpara></listitem></varlistentry></xi:fallback>
-   </xi:include>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-pgsql.copyfromarray')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='tableName']]]/.)"/>
    <varlistentry>
     <term><parameter>filename</parameter></term>
     <listitem>
@@ -39,12 +37,8 @@
      </simpara>
     </listitem>
    </varlistentry>
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-pgsql.copyfromarray')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='separator']]]/.)">
-    <xi:fallback><varlistentry><term></term><listitem><simpara></simpara></listitem></varlistentry></xi:fallback>
-   </xi:include>
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-pgsql.copyfromarray')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='nullAs']]]/.)">
-    <xi:fallback><varlistentry><term></term><listitem><simpara></simpara></listitem></varlistentry></xi:fallback>
-   </xi:include>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-pgsql.copyfromarray')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='separator']]]/.)"/>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-pgsql.copyfromarray')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='nullAs']]]/.)"/>
    <varlistentry>
     <term><parameter>fields</parameter></term>
     <listitem>

--- a/reference/pdo_pgsql/pdo/pgsql/lobopen.xml
+++ b/reference/pdo_pgsql/pdo/pgsql/lobopen.xml
@@ -22,9 +22,7 @@
    <function>fgets</function> などの通常のファイルシステム関数を使用して、
    ストリームの内容を操作することができます。
   </simpara>
-  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-pgsql.lobcreate')/db:refsect1[@role='description']/db:note/.)">
-   <xi:fallback/>
-  </xi:include>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-pgsql.lobcreate')/db:refsect1[@role='description']/db:note/.)"/>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/pdo_pgsql/pdo/pgsql/lobunlink.xml
+++ b/reference/pdo_pgsql/pdo/pgsql/lobunlink.xml
@@ -17,9 +17,7 @@
   <simpara>
    OID が指すラージオブジェクトをデータベースから削除します。
   </simpara>
-  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-pgsql.lobcreate')/db:refsect1[@role='description']/db:note/.)">
-   <xi:fallback/>
-  </xi:include>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-pgsql.lobcreate')/db:refsect1[@role='description']/db:note/.)"/>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/pdo_sqlite/pdo-sqlite.xml
+++ b/reference/pdo_sqlite/pdo-sqlite.xml
@@ -53,9 +53,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
@@ -102,17 +100,11 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo-sqlite')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Pdo\\Sqlite'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo-sqlite')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Pdo\\Sqlite'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PDO'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PDO'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PDO'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PDO'])"/>
    </classsynopsis>
    <!-- }}} -->
 

--- a/reference/phar/Phar.xml
+++ b/reference/phar/Phar.xml
@@ -41,9 +41,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filesystemiterator')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filesystemiterator')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
@@ -128,29 +126,15 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.phar')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Phar'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.phar')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Phar'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.phar')/db:refentry/db:refsect1[@role='description']/descendant::db:destructorsynopsis[@role='Phar'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.phar')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Phar'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.phar')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Phar'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.phar')/db:refentry/db:refsect1[@role='description']/descendant::db:destructorsynopsis[@role='Phar'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivedirectoryiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveDirectoryIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filesystemiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilesystemIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.directoryiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DirectoryIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileInfo'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivedirectoryiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveDirectoryIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filesystemiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilesystemIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.directoryiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DirectoryIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileInfo'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/phar/PharData.xml
+++ b/reference/phar/PharData.xml
@@ -47,34 +47,18 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filesystemiterator')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filesystemiterator')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.phardata')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PharData'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.phardata')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PharData'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.phardata')/db:refentry/db:refsect1[@role='description']/descendant::db:destructorsynopsis[@role='PharData'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.phardata')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PharData'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.phardata')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PharData'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.phardata')/db:refentry/db:refsect1[@role='description']/descendant::db:destructorsynopsis[@role='PharData'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivedirectoryiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveDirectoryIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filesystemiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilesystemIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.directoryiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DirectoryIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileInfo'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivedirectoryiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveDirectoryIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filesystemiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilesystemIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.directoryiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DirectoryIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileInfo'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/phar/PharException.xml
+++ b/reference/phar/PharException.xml
@@ -33,17 +33,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/phar/PharFileInfo.xml
+++ b/reference/phar/PharFileInfo.xml
@@ -34,20 +34,12 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pharfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PharFileInfo'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pharfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PharFileInfo'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pharfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:destructorsynopsis[@role='PharFileInfo'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pharfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PharFileInfo'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pharfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PharFileInfo'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pharfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:destructorsynopsis[@role='PharFileInfo'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileInfo'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileInfo'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/random/random.brokenrandomengineerror.xml
+++ b/reference/random/random.brokenrandomengineerror.xml
@@ -35,17 +35,11 @@
      </ooclass>
 
      <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
      <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])">
-      <xi:fallback/>
-     </xi:include>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])"/>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])"/>
     </classsynopsis>
    </packagesynopsis>
 <!-- }}} -->

--- a/reference/random/random.cryptosafeengine.xml
+++ b/reference/random/random.cryptosafeengine.xml
@@ -35,9 +35,7 @@
      </oointerface>
 
      <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Random\\Engine'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Random\\Engine'])"/>
     </classsynopsis>
    </packagesynopsis>
 <!-- }}} -->

--- a/reference/random/random.engine.mt19937.xml
+++ b/reference/random/random.engine.mt19937.xml
@@ -35,12 +35,8 @@
      </oointerface>
 
      <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine-mt19937')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Random\\Engine\\Mt19937'])">
-      <xi:fallback/>
-     </xi:include>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine-mt19937')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Random\\Engine\\Mt19937'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine-mt19937')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Random\\Engine\\Mt19937'])"/>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine-mt19937')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Random\\Engine\\Mt19937'])"/>
     </classsynopsis>
    </packagesynopsis>
 <!-- }}} -->

--- a/reference/random/random.engine.pcgoneseq128xslrr64.xml
+++ b/reference/random/random.engine.pcgoneseq128xslrr64.xml
@@ -36,12 +36,8 @@
      </oointerface>
 
      <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine-pcgoneseq128xslrr64')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Random\\Engine\\PcgOneseq128XslRr64'])">
-      <xi:fallback/>
-     </xi:include>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine-pcgoneseq128xslrr64')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Random\\Engine\\PcgOneseq128XslRr64'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine-pcgoneseq128xslrr64')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Random\\Engine\\PcgOneseq128XslRr64'])"/>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine-pcgoneseq128xslrr64')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Random\\Engine\\PcgOneseq128XslRr64'])"/>
     </classsynopsis>
    </packagesynopsis>
 <!-- }}} -->

--- a/reference/random/random.engine.secure.xml
+++ b/reference/random/random.engine.secure.xml
@@ -45,9 +45,7 @@
      </oointerface>
 
      <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine-secure')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Random\\Engine\\Secure'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine-secure')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Random\\Engine\\Secure'])"/>
     </classsynopsis>
    </packagesynopsis>
 <!-- }}} -->

--- a/reference/random/random.engine.xml
+++ b/reference/random/random.engine.xml
@@ -51,9 +51,7 @@
      </oointerface>
 
      <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Random\\Engine'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Random\\Engine'])"/>
     </classsynopsis>
    </packagesynopsis>
 <!-- }}} -->

--- a/reference/random/random.engine.xoshiro256starstar.xml
+++ b/reference/random/random.engine.xoshiro256starstar.xml
@@ -35,12 +35,8 @@
      </oointerface>
 
      <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine-xoshiro256starstar')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Random\\Engine\\Xoshiro256StarStar'])">
-      <xi:fallback/>
-     </xi:include>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine-xoshiro256starstar')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Random\\Engine\\Xoshiro256StarStar'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine-xoshiro256starstar')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Random\\Engine\\Xoshiro256StarStar'])"/>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine-xoshiro256starstar')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Random\\Engine\\Xoshiro256StarStar'])"/>
     </classsynopsis>
    </packagesynopsis>
 <!-- }}} -->

--- a/reference/random/random.randomerror.xml
+++ b/reference/random/random.randomerror.xml
@@ -34,17 +34,11 @@
      </ooclass>
 
      <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
      <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])">
-      <xi:fallback/>
-     </xi:include>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])"/>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])"/>
     </classsynopsis>
    </packagesynopsis>
 <!-- }}} -->

--- a/reference/random/random.randomexception.xml
+++ b/reference/random/random.randomexception.xml
@@ -34,17 +34,11 @@
      </ooclass>
 
      <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
      <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-      <xi:fallback/>
-     </xi:include>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
     </classsynopsis>
    </packagesynopsis>
 <!-- }}} -->

--- a/reference/random/random.randomizer.xml
+++ b/reference/random/random.randomizer.xml
@@ -39,12 +39,8 @@
      </fieldsynopsis>
 
      <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-randomizer')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Random\\Randomizer'])">
-      <xi:fallback/>
-     </xi:include>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-randomizer')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Random\\Randomizer'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-randomizer')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Random\\Randomizer'])"/>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-randomizer')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Random\\Randomizer'])"/>
     </classsynopsis>
    </packagesynopsis>
 <!-- }}} -->

--- a/reference/reflection/reflection.xml
+++ b/reference/reflection/reflection.xml
@@ -27,9 +27,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflection')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Reflection'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflection')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Reflection'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/reflection/reflectionattribute.xml
+++ b/reference/reflection/reflectionattribute.xml
@@ -49,12 +49,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionattribute')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionAttribute'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionattribute')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionAttribute'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionattribute')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionAttribute'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionattribute')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionAttribute'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/reflection/reflectionclass.xml
+++ b/reference/reflection/reflectionclass.xml
@@ -78,12 +78,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclass')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionClass'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclass')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionClass'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclass')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionClass'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclass')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionClass'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/reflection/reflectionclass/newlazyproxy.xml
+++ b/reference/reflection/reflectionclass/newlazyproxy.xml
@@ -69,9 +69,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('reflectionclass.newlazyghost.parameters.options')/*)">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('reflectionclass.newlazyghost.parameters.options')/*)"/>
    </varlistentry>
   </variablelist>
  </refsect1>
@@ -87,9 +85,7 @@
   </simpara>
  </refsect1>
 
- <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('reflectionclass.newlazyghost')/db:refsect1[@role='errors'])">
-  <xi:fallback/>
- </xi:include>
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('reflectionclass.newlazyghost')/db:refsect1[@role='errors'])"/>
 
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/reflection/reflectionclass/resetaslazyproxy.xml
+++ b/reference/reflection/reflectionclass/resetaslazyproxy.xml
@@ -51,9 +51,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('reflectionclass.resetaslazyghost.parameters.options')/*)">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('reflectionclass.resetaslazyghost.parameters.options')/*)"/>
    </varlistentry>
   </variablelist>
  </refsect1>
@@ -65,9 +63,7 @@
   </simpara>
  </refsect1>
  
- <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('reflectionclass.resetaslazyghost')/db:refsect1[@role='errors'])">
-  <xi:fallback/>
- </xi:include>
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('reflectionclass.resetaslazyghost')/db:refsect1[@role='errors'])"/>
  
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/reflection/reflectionclassconstant.xml
+++ b/reference/reflection/reflectionclassconstant.xml
@@ -70,12 +70,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclassconstant')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionClassConstant'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclassconstant')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionClassConstant'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclassconstant')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionClassConstant'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclassconstant')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionClassConstant'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/reflection/reflectionconstant.xml
+++ b/reference/reflection/reflectionconstant.xml
@@ -34,12 +34,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionconstant')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionConstant'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionconstant')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionConstant'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionconstant')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionConstant'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionconstant')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionConstant'])"/>
    </classsynopsis>
 
   </section>

--- a/reference/reflection/reflectionenum.xml
+++ b/reference/reflection/reflectionenum.xml
@@ -32,27 +32,17 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclass')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclass')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclass')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclass')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionenum')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionEnum'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionenum')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionEnum'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionenum')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionEnum'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionenum')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionEnum'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclass')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionClass'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclass')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionClass'])"/>
    </classsynopsis>
    <!-- }}} -->
 

--- a/reference/reflection/reflectionenumbackedcase.xml
+++ b/reference/reflection/reflectionenumbackedcase.xml
@@ -33,30 +33,18 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclassconstant')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclassconstant')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclassconstant')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclassconstant')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionenumbackedcase')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionEnumBackedCase'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionenumbackedcase')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionEnumBackedCase'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionenumbackedcase')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionEnumBackedCase'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionenumbackedcase')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionEnumBackedCase'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionenumunitcase')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionEnumUnitCase'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclassconstant')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionClassConstant'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionenumunitcase')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionEnumUnitCase'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclassconstant')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionClassConstant'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/reflection/reflectionenumunitcase.xml
+++ b/reference/reflection/reflectionenumunitcase.xml
@@ -33,27 +33,17 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclassconstant')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclassconstant')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclassconstant')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclassconstant')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionenumunitcase')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionEnumUnitCase'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionenumunitcase')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionEnumUnitCase'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionenumunitcase')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionEnumUnitCase'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionenumunitcase')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionEnumUnitCase'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclassconstant')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionClassConstant'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclassconstant')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionClassConstant'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/reflection/reflectionexception.xml
+++ b/reference/reflection/reflectionexception.xml
@@ -32,17 +32,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/reflection/reflectionextension.xml
+++ b/reference/reflection/reflectionextension.xml
@@ -40,12 +40,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionextension')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionExtension'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionextension')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionExtension'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionextension')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionExtension'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionextension')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionExtension'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/reflection/reflectionfiber.xml
+++ b/reference/reflection/reflectionfiber.xml
@@ -27,12 +27,8 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionfiber')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionFiber'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionfiber')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionFiber'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionfiber')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionFiber'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionfiber')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionFiber'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/reflection/reflectionfunction.xml
+++ b/reference/reflection/reflectionfunction.xml
@@ -41,22 +41,14 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionfunctionabstract')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionfunctionabstract')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionfunction')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionFunction'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionfunction')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionFunction'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionfunction')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionFunction'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionfunction')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionFunction'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionfunctionabstract')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionFunctionAbstract'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionfunctionabstract')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionFunctionAbstract'])"/>
    </classsynopsis>
 <!-- }}} -->
   </section>

--- a/reference/reflection/reflectionfunctionabstract.xml
+++ b/reference/reflection/reflectionfunctionabstract.xml
@@ -41,9 +41,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionfunctionabstract')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionFunctionAbstract'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionfunctionabstract')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionFunctionAbstract'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/reflection/reflectionfunctionabstract/getclosurescopeclass.xml
+++ b/reference/reflection/reflectionfunctionabstract/getclosurescopeclass.xml
@@ -35,9 +35,7 @@
   </simpara>
  </refsect1>
 
- <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('reflectionfunctionabstract.getclosurecalledclass')/db:refsect1[@role='examples']/.)">
-  <xi:fallback/>
- </xi:include>
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('reflectionfunctionabstract.getclosurecalledclass')/db:refsect1[@role='examples']/.)"/>
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/reflection/reflectionfunctionabstract/getclosurethis.xml
+++ b/reference/reflection/reflectionfunctionabstract/getclosurethis.xml
@@ -35,9 +35,7 @@
   </para>
  </refsect1>
 
- <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('reflectionfunctionabstract.getclosurecalledclass')/db:refsect1[@role='examples']/.)">
-  <xi:fallback/>
- </xi:include>
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('reflectionfunctionabstract.getclosurecalledclass')/db:refsect1[@role='examples']/.)"/>
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/reflection/reflectiongenerator.xml
+++ b/reference/reflection/reflectiongenerator.xml
@@ -28,12 +28,8 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectiongenerator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionGenerator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectiongenerator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionGenerator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectiongenerator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionGenerator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectiongenerator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionGenerator'])"/>
    </classsynopsis>
 <!-- }}} -->
   </section>

--- a/reference/reflection/reflectionintersectiontype.xml
+++ b/reference/reflection/reflectionintersectiontype.xml
@@ -32,14 +32,10 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionintersectiontype')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionIntersectionType'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionintersectiontype')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionIntersectionType'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectiontype')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionType'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectiontype')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionType'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/reflection/reflectionmethod.xml
+++ b/reference/reflection/reflectionmethod.xml
@@ -78,22 +78,14 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionfunctionabstract')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionfunctionabstract')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionmethod')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionMethod'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionmethod')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionMethod'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionmethod')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionMethod'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionmethod')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionMethod'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionfunctionabstract')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionFunctionAbstract'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionfunctionabstract')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionFunctionAbstract'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/reflection/reflectionnamedtype.xml
+++ b/reference/reflection/reflectionnamedtype.xml
@@ -32,14 +32,10 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionnamedtype')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionNamedType'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionnamedtype')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionNamedType'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectiontype')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionType'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectiontype')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionType'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/reflection/reflectionobject.xml
+++ b/reference/reflection/reflectionobject.xml
@@ -33,24 +33,16 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclass')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclass')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclass')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclass')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionobject')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionObject'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionobject')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionObject'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclass')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionClass'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclass')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionClass'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/reflection/reflectionparameter.xml
+++ b/reference/reflection/reflectionparameter.xml
@@ -48,12 +48,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionparameter')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionParameter'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionparameter')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionParameter'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionparameter')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionParameter'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionparameter')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionParameter'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/reflection/reflectionproperty.xml
+++ b/reference/reflection/reflectionproperty.xml
@@ -108,12 +108,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionproperty')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionProperty'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionproperty')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionProperty'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionproperty')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionProperty'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionproperty')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionProperty'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/reflection/reflectionreference.xml
+++ b/reference/reflection/reflectionreference.xml
@@ -28,12 +28,8 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionreference')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionReference'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionreference')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionReference'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionreference')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionReference'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionreference')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionReference'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/reflection/reflectiontype.xml
+++ b/reference/reflection/reflectiontype.xml
@@ -8,7 +8,6 @@
 
  <partintro>
 
-<!-- {{{ ReflectionType intro -->
   <section xml:id="reflectiontype.intro">
    &reftitle.intro;
    <para>
@@ -23,12 +22,10 @@
     </simplelist>
    </para>
   </section>
-<!-- }}} -->
 
   <section xml:id="reflectiontype.synopsis">
    &reftitle.classsynopsis;
 
-<!-- {{{ Synopsis -->
    <classsynopsis class="class">
     <ooclass>
      <modifier>abstract</modifier>
@@ -41,14 +38,11 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectiontype')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionType'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectiontype')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionType'])"/>
    </classsynopsis>
-<!-- }}} -->
   </section>
 
-  <section role="changelog" xml:id="reflectiontype.changelog"><!-- {{{ -->
+  <section role="changelog" xml:id="reflectiontype.changelog">
   &reftitle.changelog;
   <para>
    <informaltable>
@@ -72,7 +66,7 @@
     </tgroup>
    </informaltable>
   </para>
- </section><!-- }}} -->
+ </section>
 
  </partintro>
 

--- a/reference/reflection/reflectionuniontype.xml
+++ b/reference/reflection/reflectionuniontype.xml
@@ -32,14 +32,10 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionuniontype')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionUnionType'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionuniontype')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionUnionType'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectiontype')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionType'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectiontype')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionType'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/reflection/reflectionzendextension.xml
+++ b/reference/reflection/reflectionzendextension.xml
@@ -40,12 +40,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionzendextension')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionZendExtension'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionzendextension')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionZendExtension'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionzendextension')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionZendExtension'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionzendextension')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionZendExtension'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/reflection/reflector.xml
+++ b/reference/reflection/reflector.xml
@@ -33,9 +33,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.stringable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Stringable'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.stringable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Stringable'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/rrd/rrdcreator.xml
+++ b/reference/rrd/rrdcreator.xml
@@ -32,12 +32,8 @@
 <!-- }}} -->
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.rrdcreator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.rrdcreator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.rrdcreator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.rrdcreator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/rrd/rrdgraph.xml
+++ b/reference/rrd/rrdgraph.xml
@@ -33,12 +33,8 @@
 <!-- }}} -->
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.rrdgraph')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.rrdgraph')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.rrdgraph')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.rrdgraph')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/rrd/rrdupdater.xml
+++ b/reference/rrd/rrdupdater.xml
@@ -33,12 +33,8 @@
 <!-- }}} -->
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.rrdupdater')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.rrdupdater')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.rrdupdater')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.rrdupdater')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/session/sessionhandler.xml
+++ b/reference/session/sessionhandler.xml
@@ -76,9 +76,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sessionhandler')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SessionHandler'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sessionhandler')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SessionHandler'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/session/sessionhandlerinterface.xml
+++ b/reference/session/sessionhandlerinterface.xml
@@ -36,9 +36,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sessionhandlerinterface')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SessionHandlerInterface'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sessionhandlerinterface')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SessionHandlerInterface'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/session/sessionidinterface.xml
+++ b/reference/session/sessionidinterface.xml
@@ -35,9 +35,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sessionidinterface')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SessionIdInterface'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sessionidinterface')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SessionIdInterface'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/session/sessionupdatetimestamphandlerinterface.xml
+++ b/reference/session/sessionupdatetimestamphandlerinterface.xml
@@ -35,9 +35,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sessionupdatetimestamphandlerinterface')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SessionUpdateTimestampHandlerInterface'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sessionupdatetimestamphandlerinterface')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SessionUpdateTimestampHandlerInterface'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/simplexml/examples.xml
+++ b/reference/simplexml/examples.xml
@@ -507,7 +507,7 @@ Failed loading XML
     </screen>
    </example>
   </para>
-  <section role="seealso"><!-- {{{ -->
+  <section role="seealso">
    &reftitle.seealso;
    <para>
     <simplelist>

--- a/reference/simplexml/simplexmlelement.xml
+++ b/reference/simplexml/simplexmlelement.xml
@@ -39,12 +39,8 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.simplexmlelement')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SimpleXMLElement'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.simplexmlelement')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SimpleXMLElement'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.simplexmlelement')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SimpleXMLElement'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.simplexmlelement')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SimpleXMLElement'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/simplexml/simplexmliterator.xml
+++ b/reference/simplexml/simplexmliterator.xml
@@ -31,12 +31,8 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.simplexmlelement')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SimpleXMLElement'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.simplexmlelement')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SimpleXMLElement'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.simplexmlelement')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SimpleXMLElement'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.simplexmlelement')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SimpleXMLElement'])"/>
    </classsynopsis>
 
   </section>

--- a/reference/snmp/snmp.xml
+++ b/reference/snmp/snmp.xml
@@ -144,12 +144,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.snmp')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SNMP'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.snmp')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SNMP'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.snmp')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SNMP'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.snmp')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SNMP'])"/>
    </classsynopsis>
   </section>
 

--- a/reference/snmp/snmpexception.xml
+++ b/reference/snmp/snmpexception.xml
@@ -7,7 +7,6 @@
 
  <partintro>
 
-<!-- {{{ SNMPException intro -->
   <section xml:id="snmpexception.intro">
    &reftitle.intro;
    <simpara>
@@ -18,12 +17,10 @@
     を参照ください。
    </simpara>
   </section>
-<!-- }}} -->
 
   <section xml:id="snmpexception.synopsis">
    &reftitle.classsynopsis;
 
-<!-- {{{ Synopsis -->
    <classsynopsis class="class">
     <ooexception>
      <exceptionname>SNMPException</exceptionname>
@@ -35,37 +32,28 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
-<!-- }}} -->
 
   </section>
 
-<!-- {{{ SNMPException properties -->
   <section xml:id="snmpexception.props">
    &reftitle.properties;
    <variablelist>
-    <varlistentry xml:id="snmpexception.props.code"><!-- {{{ -->
+    <varlistentry xml:id="snmpexception.props.code">
      <term><varname>code</varname></term>
      <listitem>
       <simpara>
        <literal>SNMP</literal> ライブラリのエラーコード。<function>Exception::getCode</function> でアクセスします。
       </simpara>
      </listitem>
-    </varlistentry><!-- }}} -->
+    </varlistentry>
    </variablelist>
   </section>
-<!-- }}} -->
 
  </partintro>
 

--- a/reference/soap/soapclient.xml
+++ b/reference/soap/soapclient.xml
@@ -245,12 +245,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.soapclient')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SoapClient'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.soapclient')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SoapClient'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.soapclient')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SoapClient'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.soapclient')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SoapClient'])"/>
    </classsynopsis>
 <!-- }}} -->
   </section>

--- a/reference/soap/soapfault.xml
+++ b/reference/soap/soapfault.xml
@@ -81,22 +81,14 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.soapfault')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SoapFault'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.soapfault')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SoapFault'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.soapfault')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SoapFault'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.soapfault')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SoapFault'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
   </section>

--- a/reference/soap/soapheader.xml
+++ b/reference/soap/soapheader.xml
@@ -55,9 +55,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.soapheader')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SoapHeader'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.soapheader')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SoapHeader'])"/>
    </classsynopsis>
 <!-- }}} -->
   </section>

--- a/reference/soap/soapparam.xml
+++ b/reference/soap/soapparam.xml
@@ -39,9 +39,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.soapparam')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SoapParam'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.soapparam')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SoapParam'])"/>
    </classsynopsis>
 <!-- }}} -->
   </section>

--- a/reference/soap/soapserver.xml
+++ b/reference/soap/soapserver.xml
@@ -37,12 +37,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.soapserver')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SoapServer'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.soapserver')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SoapServer'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.soapserver')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SoapServer'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.soapserver')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SoapServer'])"/>
    </classsynopsis>
 <!-- }}} -->
   </section>

--- a/reference/soap/soapvar.xml
+++ b/reference/soap/soapvar.xml
@@ -64,9 +64,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.soapvar')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SoapVar'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.soapvar')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SoapVar'])"/>
    </classsynopsis>
 <!-- }}} -->
   </section>

--- a/reference/sodium/sodiumexception.xml
+++ b/reference/sodium/sodiumexception.xml
@@ -32,17 +32,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/spl/appenditerator.xml
+++ b/reference/spl/appenditerator.xml
@@ -32,17 +32,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.appenditerator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='AppendIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.appenditerator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='AppendIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.appenditerator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='AppendIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.appenditerator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='AppendIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/spl/appenditerator/append.xml
+++ b/reference/spl/appenditerator/append.xml
@@ -41,10 +41,10 @@
   </para>
  </refsect1>
 
- <refsect1 role="examples"><!-- {{{ -->
+ <refsect1 role="examples">
   &reftitle.examples;
   <para>
-   <example xml:id="appenditerator.append.examples.basic"><!-- {{{ -->
+   <example xml:id="appenditerator.append.examples.basic">
     <title><methodname>AppendIterator::append</methodname> の例</title>
     <programlisting role="php">
 <![CDATA[
@@ -68,9 +68,9 @@ foreach ($iterator as $current) {
 abcdef
 ]]>
     </screen>
-   </example><!-- }}} -->
+   </example>
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/spl/appenditerator/construct.xml
+++ b/reference/spl/appenditerator/construct.xml
@@ -23,10 +23,10 @@
   &no.function.parameters;
  </refsect1>
 
- <refsect1 role="examples"><!-- {{{ -->
+ <refsect1 role="examples">
   &reftitle.examples;
   <para>
-   <example xml:id="appenditerator.examples.foreach"><!-- {{{ -->
+   <example xml:id="appenditerator.examples.foreach">
     <title>AppendIterator の foreach での使用例</title>
     <programlisting role="php">
 <![CDATA[
@@ -57,8 +57,8 @@ foreach ($appendIterator as $key => $item) {
 4 => Ham
 ]]>
     </screen>
-   </example><!-- }}} -->
-   <example xml:id="appenditerator.examples.api"><!-- {{{ -->
+   </example>
+   <example xml:id="appenditerator.examples.api">
     <title>AppendIterator API による AppendIterator の処理</title>
     <programlisting role="php">
 <![CDATA[
@@ -96,11 +96,11 @@ while ($appendIterator->valid()) {
 1 => 4 => Ham
 ]]>
     </screen>
-   </example><!-- }}} --> 
+   </example>
   </para>
- </refsect1><!-- }}} --> 
+ </refsect1>
  
- <refsect1 role="notes"><!-- {{{ -->
+ <refsect1 role="notes">
   &reftitle.notes;
   <caution>
    <para>
@@ -112,7 +112,7 @@ while ($appendIterator->valid()) {
     このときに元のキーの値を取得する方法はありません。
    </para>
   </caution>
- </refsect1><!-- }}} --> 
+ </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/spl/appenditerator/getiteratorindex.xml
+++ b/reference/spl/appenditerator/getiteratorindex.xml
@@ -33,10 +33,10 @@
   </para>
  </refsect1>
 
- <refsect1 role="examples"><!-- {{{ -->
+ <refsect1 role="examples">
   &reftitle.examples;
   <para>
-   <example xml:id="appenditerator.getiteratorindex.examples.basic"><!-- {{{ -->
+   <example xml:id="appenditerator.getiteratorindex.examples.basic">
     <title><methodname>AppendIterator.getIteratorIndex</methodname> の基本的な例</title>
     <programlisting role="php">
 <![CDATA[
@@ -66,9 +66,9 @@ foreach ($iterator as $key => $current) {
 
 ]]>
     </screen>
-   </example><!-- }}} -->
+   </example>
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/spl/appenditerator/key.xml
+++ b/reference/spl/appenditerator/key.xml
@@ -31,10 +31,10 @@
   </para>
  </refsect1>
 
- <refsect1 role="examples"><!-- {{{ -->
+ <refsect1 role="examples">
   &reftitle.examples;
   <para>
-   <example xml:id="appenditerator.key.examples.basic"><!-- {{{ -->
+   <example xml:id="appenditerator.key.examples.basic">
     <title><methodname>AppendIterator::key</methodname> の基本的な例</title>
     <programlisting role="php">
 <![CDATA[
@@ -80,9 +80,9 @@ c capybara
 2 lemon
 ]]>
     </screen>
-   </example><!-- }}} -->
+   </example>
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/spl/arrayiterator.xml
+++ b/reference/spl/arrayiterator.xml
@@ -66,12 +66,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ArrayIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ArrayIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ArrayIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ArrayIterator'])"/>
    </classsynopsis>
  
   </section>

--- a/reference/spl/arrayobject.xml
+++ b/reference/spl/arrayobject.xml
@@ -63,12 +63,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayobject')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ArrayObject'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayobject')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ArrayObject'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayobject')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ArrayObject'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayobject')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ArrayObject'])"/>
    </classsynopsis>
  
   </section>

--- a/reference/spl/badfunctioncallexception.xml
+++ b/reference/spl/badfunctioncallexception.xml
@@ -32,17 +32,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/spl/badmethodcallexception.xml
+++ b/reference/spl/badmethodcallexception.xml
@@ -32,17 +32,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/spl/cachingiterator.xml
+++ b/reference/spl/cachingiterator.xml
@@ -82,17 +82,11 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.cachingiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='CachingIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.cachingiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='CachingIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.cachingiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='CachingIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.cachingiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='CachingIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/spl/callbackfilteriterator.xml
+++ b/reference/spl/callbackfilteriterator.xml
@@ -32,20 +32,12 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.callbackfilteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='CallbackFilterIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.callbackfilteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='CallbackFilterIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.callbackfilteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='CallbackFilterIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.callbackfilteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='CallbackFilterIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilterIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilterIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/spl/directoryiterator.xml
+++ b/reference/spl/directoryiterator.xml
@@ -37,17 +37,11 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.directoryiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DirectoryIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.directoryiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DirectoryIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.directoryiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DirectoryIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.directoryiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DirectoryIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileInfo'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileInfo'])"/>
    </classsynopsis>
  
   </section>

--- a/reference/spl/domainexception.xml
+++ b/reference/spl/domainexception.xml
@@ -32,17 +32,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/spl/emptyiterator.xml
+++ b/reference/spl/emptyiterator.xml
@@ -32,9 +32,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.emptyiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='EmptyIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.emptyiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='EmptyIterator'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/spl/filesystemiterator.xml
+++ b/reference/spl/filesystemiterator.xml
@@ -106,20 +106,12 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filesystemiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='FilesystemIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filesystemiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilesystemIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filesystemiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='FilesystemIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filesystemiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilesystemIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.directoryiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DirectoryIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileInfo'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.directoryiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DirectoryIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileInfo'])"/>
    </classsynopsis>
    <!-- }}} -->
 

--- a/reference/spl/filteriterator.xml
+++ b/reference/spl/filteriterator.xml
@@ -35,17 +35,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='FilterIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilterIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='FilterIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilterIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])"/>
    </classsynopsis>
 
   </section>

--- a/reference/spl/functions/iterator-apply.xml
+++ b/reference/spl/functions/iterator-apply.xml
@@ -104,42 +104,6 @@ CHERRIES
   </para>
  </refsect1>
 
-<!--
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   When does this function issue E_* level errors, and/or throw exceptions.
-  </para>
- </refsect1>
-
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title><function>iterator_apply</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or what
-     goes on in the example should be here.
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-
-/* ... */
-
-?>
-]]>
-    </programlisting>
-    &example.outputs.similar;
-    <screen>
-<![CDATA[
-...
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
--->
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/spl/globiterator.xml
+++ b/reference/spl/globiterator.xml
@@ -38,28 +38,16 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filesystemiterator')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filesystemiterator')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.globiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='GlobIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.globiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='GlobIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.globiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='GlobIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.globiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='GlobIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filesystemiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilesystemIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.directoryiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DirectoryIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileInfo'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filesystemiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilesystemIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.directoryiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DirectoryIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileInfo'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/spl/infiniteiterator.xml
+++ b/reference/spl/infiniteiterator.xml
@@ -34,17 +34,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.infiniteiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='InfiniteIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.infiniteiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='InfiniteIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.infiniteiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='InfiniteIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.infiniteiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='InfiniteIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/spl/invalidargumentexception.xml
+++ b/reference/spl/invalidargumentexception.xml
@@ -32,17 +32,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/spl/iteratoriterator.xml
+++ b/reference/spl/iteratoriterator.xml
@@ -8,7 +8,6 @@
 
  <partintro>
 
-<!-- {{{ IteratorIterator intro -->
   <section xml:id="iteratoriterator.intro">
    &reftitle.intro;
    <para>
@@ -22,12 +21,10 @@
     でなければ、例外や致命的なエラーが起こり得ます。
    </para>
   </section>
-<!-- }}} -->
 
   <section xml:id="iteratoriterator.synopsis">
    &reftitle.classsynopsis;
 
-<!-- {{{ Synopsis -->
    <classsynopsis class="class">
     <ooclass>
      <classname>IteratorIterator</classname>
@@ -39,25 +36,20 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='IteratorIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='IteratorIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])"/>
    </classsynopsis>
-<!-- }}} -->
 
   </section>
  
-  <section role="notes"><!-- {{{ -->
+  <section role="notes">
    &reftitle.notes;
    <note>
     <para>
      このクラスは、内部のイテレータのメソッドへのアクセスを許可するために、マジックメソッド __call を利用します。
     </para>
    </note>
-  </section><!-- }}} -->
+  </section>
  </partintro>
 
  &reference.spl.entities.iteratoriterator;

--- a/reference/spl/lengthexception.xml
+++ b/reference/spl/lengthexception.xml
@@ -32,17 +32,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/spl/limititerator.xml
+++ b/reference/spl/limititerator.xml
@@ -32,17 +32,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.limititerator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='LimitIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.limititerator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='LimitIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.limititerator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='LimitIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.limititerator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='LimitIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])"/>
    </classsynopsis>
  
   </section>

--- a/reference/spl/logicexception.xml
+++ b/reference/spl/logicexception.xml
@@ -33,17 +33,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/spl/multipleiterator.xml
+++ b/reference/spl/multipleiterator.xml
@@ -58,12 +58,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.multipleiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='MultipleIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.multipleiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='MultipleIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.multipleiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='MultipleIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.multipleiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='MultipleIterator'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/spl/multipleiterator/construct.xml
+++ b/reference/spl/multipleiterator/construct.xml
@@ -45,10 +45,10 @@
   </para>
  </refsect1>
 
- <refsect1 role="examples"><!-- {{{ -->
+ <refsect1 role="examples">
   &reftitle.examples;
   <para>
-   <example xml:id="multipleiterator.example.basic"><!-- {{{ -->
+   <example xml:id="multipleiterator.example.basic">
     <title>MultipleIterator の反復処理</title>
     <programlisting role="php">
 <![CDATA[
@@ -152,9 +152,9 @@ Array
     [role] =>
 )]]>
     </screen>    
-   </example><!-- }}} -->
+   </example>
   </para>
- </refsect1><!-- }}} -->   
+ </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/spl/norewinditerator.xml
+++ b/reference/spl/norewinditerator.xml
@@ -33,17 +33,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.norewinditerator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='NoRewindIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.norewinditerator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='NoRewindIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.norewinditerator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='NoRewindIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.norewinditerator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='NoRewindIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])"/>
    </classsynopsis>
 
   </section>

--- a/reference/spl/outeriterator.xml
+++ b/reference/spl/outeriterator.xml
@@ -33,14 +33,10 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.outeriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='OuterIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.outeriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='OuterIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Iterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Iterator'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/spl/outofboundsexception.xml
+++ b/reference/spl/outofboundsexception.xml
@@ -33,17 +33,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/spl/outofrangeexception.xml
+++ b/reference/spl/outofrangeexception.xml
@@ -33,17 +33,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/spl/overflowexception.xml
+++ b/reference/spl/overflowexception.xml
@@ -32,17 +32,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/spl/parentiterator.xml
+++ b/reference/spl/parentiterator.xml
@@ -35,23 +35,13 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parentiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ParentIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parentiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ParentIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parentiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ParentIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parentiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ParentIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivefilteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveFilterIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilterIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivefilteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveFilterIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilterIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])"/>
    </classsynopsis>
  
   </section>

--- a/reference/spl/rangeexception.xml
+++ b/reference/spl/rangeexception.xml
@@ -35,17 +35,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/spl/recursivearrayiterator.xml
+++ b/reference/spl/recursivearrayiterator.xml
@@ -39,9 +39,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayiterator')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayiterator')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
@@ -52,17 +50,11 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivearrayiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveArrayIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivearrayiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveArrayIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ArrayIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ArrayIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ArrayIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ArrayIterator'])"/>
    </classsynopsis>
 
   </section>

--- a/reference/spl/recursivecachingiterator.xml
+++ b/reference/spl/recursivecachingiterator.xml
@@ -37,25 +37,15 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.cachingiterator')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.cachingiterator')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivecachingiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='RecursiveCachingIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivecachingiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveCachingIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivecachingiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='RecursiveCachingIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivecachingiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveCachingIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.cachingiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='CachingIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.cachingiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='CachingIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])"/>
    </classsynopsis>
  
   </section>

--- a/reference/spl/recursivecallbackfilteriterator.xml
+++ b/reference/spl/recursivecallbackfilteriterator.xml
@@ -37,23 +37,13 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivecallbackfilteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='RecursiveCallbackFilterIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivecallbackfilteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveCallbackFilterIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivecallbackfilteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='RecursiveCallbackFilterIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivecallbackfilteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveCallbackFilterIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.callbackfilteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='CallbackFilterIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilterIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.callbackfilteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='CallbackFilterIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilterIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/spl/recursivedirectoryiterator.xml
+++ b/reference/spl/recursivedirectoryiterator.xml
@@ -38,28 +38,16 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filesystemiterator')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filesystemiterator')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivedirectoryiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='RecursiveDirectoryIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivedirectoryiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveDirectoryIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivedirectoryiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='RecursiveDirectoryIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivedirectoryiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveDirectoryIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filesystemiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilesystemIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.directoryiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DirectoryIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileInfo'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filesystemiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilesystemIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.directoryiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DirectoryIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileInfo'])"/>
    </classsynopsis>
  
   </section>

--- a/reference/spl/recursivefilteriterator.xml
+++ b/reference/spl/recursivefilteriterator.xml
@@ -40,20 +40,12 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivefilteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='RecursiveFilterIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivefilteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveFilterIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivefilteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='RecursiveFilterIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivefilteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveFilterIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilterIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilterIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/spl/recursiveiterator.xml
+++ b/reference/spl/recursiveiterator.xml
@@ -33,14 +33,10 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursiveiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursiveiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Iterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Iterator'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/spl/recursiveiteratoriterator.xml
+++ b/reference/spl/recursiveiteratoriterator.xml
@@ -58,12 +58,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursiveiteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='RecursiveIteratorIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursiveiteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveIteratorIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursiveiteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='RecursiveIteratorIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursiveiteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveIteratorIterator'])"/>
    </classsynopsis>
 
   </section>

--- a/reference/spl/recursiveiteratoriterator/construct.xml
+++ b/reference/spl/recursiveiteratoriterator/construct.xml
@@ -68,10 +68,10 @@
   </para>
  </refsect1>
 
- <refsect1 role="examples"><!-- {{{ -->
+ <refsect1 role="examples">
   &reftitle.examples;
   <para>
-   <example xml:id="recursiveiteratoriterator.example.basic"><!-- {{{ -->
+   <example xml:id="recursiveiteratoriterator.example.basic">
     <title>RecursiveIteratorIterator の反復処理</title>
     <programlisting role="php">
 <![CDATA[
@@ -158,9 +158,9 @@ foreach ($iterator as $key => $leaf) {
 0 => Array
 ]]>
     </screen>
-   </example><!-- }}} -->
+   </example>
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/spl/recursiveregexiterator.xml
+++ b/reference/spl/recursiveregexiterator.xml
@@ -37,33 +37,19 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.regexiterator')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.regexiterator')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.regexiterator')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.regexiterator')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursiveregexiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='RecursiveRegexIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursiveregexiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveRegexIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursiveregexiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='RecursiveRegexIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursiveregexiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveRegexIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.regexiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RegexIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilterIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.regexiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RegexIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilterIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])"/>
    </classsynopsis>
 
   </section>

--- a/reference/spl/recursivetreeiterator.xml
+++ b/reference/spl/recursivetreeiterator.xml
@@ -33,9 +33,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursiveiteratoriterator')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursiveiteratoriterator')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
@@ -93,17 +91,11 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivetreeiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='RecursiveTreeIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivetreeiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveTreeIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivetreeiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='RecursiveTreeIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivetreeiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveTreeIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursiveiteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveIteratorIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursiveiteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveIteratorIterator'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/spl/regexiterator.xml
+++ b/reference/spl/regexiterator.xml
@@ -83,20 +83,12 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.regexiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='RegexIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.regexiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RegexIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.regexiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='RegexIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.regexiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RegexIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilterIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilterIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])"/>
    </classsynopsis>
 
   </section>

--- a/reference/spl/runtimeexception.xml
+++ b/reference/spl/runtimeexception.xml
@@ -32,17 +32,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/spl/seekableiterator.xml
+++ b/reference/spl/seekableiterator.xml
@@ -8,19 +8,16 @@
 
  <partintro>
 
-<!-- {{{ SeekableIterator intro -->
   <section xml:id="seekableiterator.intro">
    &reftitle.intro;
    <para>
     Seekable イテレータです。
    </para>
   </section>
-<!-- }}} -->
 
   <section xml:id="seekableiterator.synopsis">
    &reftitle.interfacesynopsis;
 
-<!-- {{{ Synopsis -->
    <classsynopsis class="interface">
     <oointerface>
      <interfacename>SeekableIterator</interfacename>
@@ -32,22 +29,17 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.seekableiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SeekableIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.seekableiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SeekableIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Iterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Iterator'])"/>
    </classsynopsis>
-<!-- }}} -->
 
   </section>
 
   <section xml:id="seekableiterator.examples">
    &reftitle.examples;
-   <example xml:id="seekableiterator.examples.basic"><!-- {{{ -->
+   <example xml:id="seekableiterator.examples.basic">
     <title>基本的な使用法</title>
     <para>
      この例では、<classname>SeekableIterator</classname>
@@ -128,7 +120,7 @@ second element
 invalid seek position (10)
 ]]>
     </screen>
-   </example><!-- }}} -->
+   </example>
   </section>
 
  </partintro>

--- a/reference/spl/spldoublylinkedlist.xml
+++ b/reference/spl/spldoublylinkedlist.xml
@@ -70,9 +70,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.spldoublylinkedlist')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplDoublyLinkedList'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.spldoublylinkedlist')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplDoublyLinkedList'])"/>
    </classsynopsis>
  
   </section>

--- a/reference/spl/spldoublylinkedlist/bottom.xml
+++ b/reference/spl/spldoublylinkedlist/bottom.xml
@@ -27,12 +27,12 @@
   </para>
  </refsect1>
  
- <refsect1 role="errors"><!-- {{{ -->
+ <refsect1 role="errors">
   &reftitle.errors;
    <para>
     データが空のときは <classname>RuntimeException</classname> をスローします。
    </para>
- </refsect1><!-- }}} -->
+ </refsect1>
  
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/spl/spldoublylinkedlist/offsetget.xml
+++ b/reference/spl/spldoublylinkedlist/offsetget.xml
@@ -38,14 +38,14 @@
   </para>
  </refsect1>
  
- <refsect1 role="errors"><!-- {{{ -->
+ <refsect1 role="errors">
   &reftitle.errors;
  <para>
   <parameter>index</parameter> が範囲外を指すときや
   <parameter>index</parameter> が整数として解釈できないときに
   <classname>OutOfRangeException</classname> をスローします。
  </para>
- </refsect1><!-- }}} -->
+ </refsect1>
  
  
 </refentry>

--- a/reference/spl/spldoublylinkedlist/offsetset.xml
+++ b/reference/spl/spldoublylinkedlist/offsetset.xml
@@ -53,14 +53,14 @@
   </para>
  </refsect1>
  
- <refsect1 role="errors"><!-- {{{ -->
+ <refsect1 role="errors">
   &reftitle.errors;
   <para>
    <parameter>index</parameter> が範囲外を指すときや
    <parameter>index</parameter> が整数として解釈できないときに
    <classname>OutOfRangeException</classname> をスローします。
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
  
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/spl/spldoublylinkedlist/offsetunset.xml
+++ b/reference/spl/spldoublylinkedlist/offsetunset.xml
@@ -42,14 +42,14 @@
   </para>
  </refsect1>
  
- <refsect1 role="errors"><!-- {{{ -->
+ <refsect1 role="errors">
   &reftitle.errors;
   <para>
    <parameter>index</parameter> が範囲外を指すときや
    <parameter>index</parameter> が整数として解釈できないときに
    <classname>OutOfRangeException</classname> をスローします。
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/spl/spldoublylinkedlist/pop.xml
+++ b/reference/spl/spldoublylinkedlist/pop.xml
@@ -27,12 +27,12 @@
   </para>
  </refsect1>
  
- <refsect1 role="errors"><!-- {{{ -->
+ <refsect1 role="errors">
   &reftitle.errors;
   <para>
     データが空のときは <classname>RuntimeException</classname> をスローします。
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/spl/spldoublylinkedlist/shift.xml
+++ b/reference/spl/spldoublylinkedlist/shift.xml
@@ -27,12 +27,12 @@
   </para>
  </refsect1>
  
- <refsect1 role="errors"><!-- {{{ -->
+ <refsect1 role="errors">
   &reftitle.errors;
    <para>
     データが空のときは <classname>RuntimeException</classname> をスローします。
    </para>
- </refsect1><!-- }}} -->
+ </refsect1>
  
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/spl/spldoublylinkedlist/top.xml
+++ b/reference/spl/spldoublylinkedlist/top.xml
@@ -27,12 +27,12 @@
   </para>
  </refsect1>
  
- <refsect1 role="errors"><!-- {{{ -->
+ <refsect1 role="errors">
   &reftitle.errors;
    <para>
     データが空のときは <classname>RuntimeException</classname> をスローします。
    </para>
- </refsect1><!-- }}} -->
+ </refsect1>
  
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/spl/splfileinfo.xml
+++ b/reference/spl/splfileinfo.xml
@@ -33,12 +33,8 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SplFileInfo'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileInfo'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SplFileInfo'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileInfo'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/spl/splfileobject.xml
+++ b/reference/spl/splfileobject.xml
@@ -68,17 +68,11 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileobject')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SplFileObject'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileobject')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileObject'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileobject')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SplFileObject'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileobject')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileObject'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileInfo'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileInfo'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/spl/splfileobject/fgetcsv.xml
+++ b/reference/spl/splfileobject/fgetcsv.xml
@@ -19,9 +19,7 @@
   <para>
    <acronym>CSV</acronym> フォーマットのファイルから行を取り出し読み込まれたフィールドを含む配列を返します。
   </para>
-  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='description']//db:note/.)">
-   <xi:fallback/>
-  </xi:include>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='description']//db:note/.)"/>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -86,9 +84,7 @@
   </note>
  </refsect1>
 
- <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='errors']/.)">
-  <xi:fallback/>
- </xi:include>
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='errors']/.)"/>
 
  <refsect1 role="changelog">
   &reftitle.changelog;
@@ -102,9 +98,7 @@
       </row>
      </thead>
      <tbody>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='changelog']//db:row[db:entry[text()='8.4.0']]/.)">
-       <xi:fallback/>
-      </xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='changelog']//db:row[db:entry[text()='8.4.0']]/.)"/>
       <row>
        <entry>7.4.0</entry>
        <entry>

--- a/reference/spl/splfileobject/fputcsv.xml
+++ b/reference/spl/splfileobject/fputcsv.xml
@@ -35,15 +35,9 @@
      </para>
     </listitem>
    </varlistentry>
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('splfileobject.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='separator']]]/.)">
-    <xi:fallback/>
-   </xi:include>
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('splfileobject.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='enclosure']]]/.)">
-    <xi:fallback/>
-   </xi:include>
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('splfileobject.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='escape']]]/.)">
-    <xi:fallback/>
-   </xi:include>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('splfileobject.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='separator']]]/.)"/>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('splfileobject.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='enclosure']]]/.)"/>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('splfileobject.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='escape']]]/.)"/>
    <varlistentry>
     <term><parameter>eol</parameter></term>
     <listitem>
@@ -71,9 +65,7 @@
   </para>
  </refsect1>
 
- <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='errors']/.)">
-  <xi:fallback/>
- </xi:include>
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='errors']/.)"/>
 
  <refsect1 role="changelog">
   &reftitle.changelog;
@@ -87,9 +79,7 @@
       </row>
      </thead>
      <tbody>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='changelog']//db:row[db:entry[text()='8.4.0']]/.)">
-       <xi:fallback/>
-      </xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='changelog']//db:row[db:entry[text()='8.4.0']]/.)"/>
       <row>
        <entry>8.1.0</entry>
        <entry>

--- a/reference/spl/splfileobject/setcsvcontrol.xml
+++ b/reference/spl/splfileobject/setcsvcontrol.xml
@@ -25,15 +25,9 @@
  <refsect1 role="parameters">
   &reftitle.parameters;
   <variablelist>
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='separator']]]/.)">
-    <xi:fallback><varlistentry><term></term><listitem><simpara></simpara></listitem></varlistentry></xi:fallback>
-   </xi:include>
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='enclosure']]]/.)">
-    <xi:fallback/>
-   </xi:include>
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='escape']]]/.)">
-    <xi:fallback/>
-   </xi:include>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='separator']]]/.)"/>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='enclosure']]]/.)"/>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='escape']]]/.)"/>
   </variablelist>
   &warning.csv.escape-parameter;
  </refsect1>
@@ -45,9 +39,7 @@
   </para>
  </refsect1>
 
- <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='errors']/.)">
-  <xi:fallback/>
- </xi:include>
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='errors']/.)"/>
 
  <refsect1 role="changelog">
   &reftitle.changelog;
@@ -61,9 +53,7 @@
       </row>
      </thead>
      <tbody>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='changelog']//db:row[db:entry[text()='8.4.0']]/.)">
-       <xi:fallback/>
-      </xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='changelog']//db:row[db:entry[text()='8.4.0']]/.)"/>
       <row>
        <entry>7.4.0</entry>
        <entry>

--- a/reference/spl/splfileobject/setmaxlinelen.xml
+++ b/reference/spl/splfileobject/setmaxlinelen.xml
@@ -42,13 +42,13 @@
   </para>
  </refsect1>
 
- <refsect1 role="errors"><!-- {{{ -->
+ <refsect1 role="errors">
   &reftitle.errors;
   <para>
    <parameter>maxLength</parameter> がゼロより小さい場合に
    <classname>DomainException</classname> をスローします。
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/spl/splfixedarray.xml
+++ b/reference/spl/splfixedarray.xml
@@ -47,12 +47,8 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfixedarray')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SplFixedArray'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfixedarray')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFixedArray'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfixedarray')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SplFixedArray'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfixedarray')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFixedArray'])"/>
    </classsynopsis>
  
   </section>

--- a/reference/spl/splfixedarray/offsetget.xml
+++ b/reference/spl/splfixedarray/offsetget.xml
@@ -41,14 +41,14 @@
   </para>
  </refsect1>
  
- <refsect1 role="errors"><!-- {{{ -->
+ <refsect1 role="errors">
   &reftitle.errors;
   <para>
    <parameter>index</parameter> が配列で定義されているサイズの範囲外の場合や
    <parameter>index</parameter> を数値として解釈できない場合に
    <classname>RuntimeException</classname> をスローします。
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
  
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/spl/splfixedarray/offsetset.xml
+++ b/reference/spl/splfixedarray/offsetset.xml
@@ -52,14 +52,14 @@
   </para>
  </refsect1>
  
- <refsect1 role="errors"><!-- {{{ -->
+ <refsect1 role="errors">
   &reftitle.errors;
   <para>
    <parameter>index</parameter> が配列で定義されているサイズの範囲外の場合や
    <parameter>index</parameter> を数値として解釈できない場合に
    <classname>RuntimeException</classname> をスローします。
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
  
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/spl/splfixedarray/offsetunset.xml
+++ b/reference/spl/splfixedarray/offsetunset.xml
@@ -41,14 +41,14 @@
   </para>
  </refsect1>
  
- <refsect1 role="errors"><!-- {{{ -->
+ <refsect1 role="errors">
   &reftitle.errors;
   <para>
    <parameter>index</parameter> が配列で定義されているサイズの範囲外の場合や
    <parameter>index</parameter> を数値として解釈できない場合に
    <classname>RuntimeException</classname> をスローします。
   </para>
- </refsect1><!-- }}} --> 
+ </refsect1>
  
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/spl/splheap.xml
+++ b/reference/spl/splheap.xml
@@ -36,9 +36,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splheap')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplHeap'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splheap')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplHeap'])"/>
    </classsynopsis>
  
   </section>

--- a/reference/spl/splheap/extract.xml
+++ b/reference/spl/splheap/extract.xml
@@ -27,12 +27,12 @@
   </para>
  </refsect1>
  
- <refsect1 role="errors"><!-- {{{ -->
+ <refsect1 role="errors">
   &reftitle.errors;
   <para>
    データが空のときは <classname>RuntimeException</classname> をスローします。
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/spl/splheap/top.xml
+++ b/reference/spl/splheap/top.xml
@@ -27,12 +27,12 @@
   </para>
  </refsect1>
 
- <refsect1 role="errors"><!-- {{{ -->
+ <refsect1 role="errors">
   &reftitle.errors;
   <para>
    データが空のときは <classname>RuntimeException</classname> をスローします。
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
  
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/spl/splmaxheap.xml
+++ b/reference/spl/splmaxheap.xml
@@ -31,14 +31,10 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splmaxheap')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplMaxHeap'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splmaxheap')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplMaxHeap'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splheap')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplHeap'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splheap')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplHeap'])"/>
    </classsynopsis>
  
   </section>

--- a/reference/spl/splminheap.xml
+++ b/reference/spl/splminheap.xml
@@ -31,14 +31,10 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splminheap')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplMinHeap'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splminheap')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplMinHeap'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splheap')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplHeap'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splheap')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplHeap'])"/>
    </classsynopsis>
  
   </section>

--- a/reference/spl/splobjectstorage.xml
+++ b/reference/spl/splobjectstorage.xml
@@ -46,9 +46,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splobjectstorage')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplObjectStorage'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splobjectstorage')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplObjectStorage'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/spl/splobjectstorage/offsetget.xml
+++ b/reference/spl/splobjectstorage/offsetget.xml
@@ -41,13 +41,13 @@
   </para>
  </refsect1>
  
- <refsect1 role="errors"><!-- {{{ -->
+ <refsect1 role="errors">
   &reftitle.errors;
   <para>
    <parameter>object</parameter> が見つからないときに
    <classname>UnexpectedValueException</classname> をスローします。
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
  
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/spl/splobserver.xml
+++ b/reference/spl/splobserver.xml
@@ -28,9 +28,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splobserver')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplObserver'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splobserver')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplObserver'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/spl/splpriorityqueue.xml
+++ b/reference/spl/splpriorityqueue.xml
@@ -63,9 +63,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splpriorityqueue')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplPriorityQueue'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splpriorityqueue')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplPriorityQueue'])"/>
    </classsynopsis>
  
   </section>

--- a/reference/spl/splqueue.xml
+++ b/reference/spl/splqueue.xml
@@ -33,19 +33,13 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.spldoublylinkedlist')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.spldoublylinkedlist')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splqueue')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplQueue'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splqueue')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplQueue'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.spldoublylinkedlist')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplDoublyLinkedList'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.spldoublylinkedlist')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplDoublyLinkedList'])"/>
    </classsynopsis>
   </section>
 

--- a/reference/spl/splstack.xml
+++ b/reference/spl/splstack.xml
@@ -33,14 +33,10 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.spldoublylinkedlist')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.spldoublylinkedlist')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.spldoublylinkedlist')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplDoublyLinkedList'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.spldoublylinkedlist')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplDoublyLinkedList'])"/>
    </classsynopsis>
   </section>
 

--- a/reference/spl/splsubject.xml
+++ b/reference/spl/splsubject.xml
@@ -28,9 +28,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splsubject')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplSubject'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splsubject')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplSubject'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/spl/spltempfileobject.xml
+++ b/reference/spl/spltempfileobject.xml
@@ -32,22 +32,14 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileobject')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileobject')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.spltempfileobject')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SplTempFileObject'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.spltempfileobject')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SplTempFileObject'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileobject')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileObject'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileInfo'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileobject')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileObject'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileInfo'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/spl/underflowexception.xml
+++ b/reference/spl/underflowexception.xml
@@ -32,17 +32,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/spl/unexpectedvalueexception.xml
+++ b/reference/spl/unexpectedvalueexception.xml
@@ -35,17 +35,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/sqlite3/sqlite3.xml
+++ b/reference/sqlite3/sqlite3.xml
@@ -250,12 +250,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sqlite3')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SQLite3'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sqlite3')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SQLite3'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sqlite3')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SQLite3'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sqlite3')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SQLite3'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/sqlite3/sqlite3exception.xml
+++ b/reference/sqlite3/sqlite3exception.xml
@@ -31,17 +31,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/sqlite3/sqlite3result.xml
+++ b/reference/sqlite3/sqlite3result.xml
@@ -26,12 +26,8 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sqlite3result')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SQLite3Result'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sqlite3result')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SQLite3Result'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sqlite3result')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SQLite3Result'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sqlite3result')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SQLite3Result'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/sqlite3/sqlite3stmt.xml
+++ b/reference/sqlite3/sqlite3stmt.xml
@@ -26,12 +26,8 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sqlite3stmt')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SQLite3Stmt'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sqlite3stmt')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SQLite3Stmt'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sqlite3stmt')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SQLite3Stmt'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sqlite3stmt')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SQLite3Stmt'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/ssh2/functions/ssh2-send-eof.xml
+++ b/reference/ssh2/functions/ssh2-send-eof.xml
@@ -7,7 +7,7 @@
   <refpurpose>ストリームに EOF を送信する</refpurpose>
  </refnamediv>
 
- <refsect1 role="description"><!-- {{{ -->
+ <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="procedural">
    <type>bool</type><methodname>ssh2_send_eof</methodname>
@@ -22,9 +22,9 @@
    そうすれば、追加のファイルを作ることなく、
    処理結果を読み取ることが出来ます。
   </simpara>
- </refsect1><!-- }}} -->
+ </refsect1>
 
- <refsect1 role="parameters"><!-- {{{ -->
+ <refsect1 role="parameters">
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
@@ -39,21 +39,21 @@
     </listitem>
    </varlistentry>
   </variablelist>
- </refsect1><!-- }}} -->
+ </refsect1>
 
- <refsect1 role="returnvalues"><!-- {{{ -->
+ <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
    &return.success;
   </simpara>
- </refsect1><!-- }}} -->
+ </refsect1>
 
- <refsect1 role="seealso"><!-- {{{ -->
+ <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
    <member><function>ssh2_fetch_stream</function></member>
   </simplelist>
- </refsect1><!-- }}} -->
+ </refsect1>
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/stream/php-user-filter.xml
+++ b/reference/stream/php-user-filter.xml
@@ -50,9 +50,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.php-user-filter')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='php_user_filter'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.php-user-filter')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='php_user_filter'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/stream/streamwrapper.xml
+++ b/reference/stream/streamwrapper.xml
@@ -10,7 +10,6 @@
 
  <partintro>
 
-<!-- {{{ streamWrapper intro -->
   <section xml:id="streamwrapper.intro">
    &reftitle.intro;
    <para>
@@ -34,22 +33,18 @@
     関連付けられているプロトコルへのストリーム関数からのアクセスがあった時点で初期化されます。
    </para>
   </section>
-<!-- }}} -->
 
   <section xml:id="streamwrapper.synopsis">
    &reftitle.classsynopsis;
 
-<!-- {{{ Synopsis -->
    <classsynopsis>
     <ooclass><classname>streamWrapper</classname></ooclass>
 
-<!-- {{{ Class synopsis -->
     <classsynopsisinfo>
      <ooclass>
       <classname><replaceable>streamWrapper</replaceable></classname>
      </ooclass>
     </classsynopsisinfo>
-<!-- }}} -->
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>public</modifier>
@@ -63,12 +58,10 @@
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.streamwrapper')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.streamwrapper')/db:refentry/db:refsect1[@role='description']/descendant::db:destructorsynopsis[not(@role='procedural')])" />
    </classsynopsis>
-<!-- }}} -->
 
   </section>
 
   
-<!-- {{{ streamWrapper properties -->
   <section xml:id="streamwrapper.props">
    &reftitle.properties;
    <variablelist>
@@ -93,9 +86,8 @@
     </varlistentry>
    </variablelist>
   </section>
-<!-- }}} -->
 
- <section role="seealso"><!-- {{{ -->
+ <section role="seealso">
   &reftitle.seealso;
   <para>
    <simplelist>
@@ -105,7 +97,7 @@
     <member><function>stream_wrapper_restore</function></member>
    </simplelist>
   </para>
- </section><!-- }}} -->
+ </section>
 
  </partintro>
 

--- a/reference/strings/functions/str-getcsv.xml
+++ b/reference/strings/functions/str-getcsv.xml
@@ -23,9 +23,7 @@
    <acronym>CSV</acronym> 形式の文字列入力のフィールドをパースして、
    読み込んだフィールドの内容を配列で返します。
   </para>
-  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='description']//db:note/.)">
-   <xi:fallback/>
-  </xi:include>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='description']//db:note/.)"/>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -40,15 +38,9 @@
       </para>
      </listitem>
     </varlistentry>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='separator']]]/.)">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='enclosure']]]/.)">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='escape']]]/.)">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='separator']]]/.)"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='enclosure']]]/.)"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='escape']]]/.)"/>
    </variablelist>
   </para>
   &warning.csv.escape-parameter;
@@ -61,9 +53,7 @@
   </para>
  </refsect1>
 
- <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='errors']/.)">
-  <xi:fallback/>
- </xi:include>
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='errors']/.)"/>
 
  <refsect1 role="changelog">
   &reftitle.changelog;
@@ -77,9 +67,7 @@
       </row>
      </thead>
      <tbody>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='changelog']//db:row[db:entry[text()='8.4.0']]/.)">
-       <xi:fallback/>
-      </xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='changelog']//db:row[db:entry[text()='8.4.0']]/.)"/>
       <row>
        <entry>8.4.0</entry>
        <entry>
@@ -90,9 +78,7 @@
         の動作に倣ったものとなります。
        </entry>
       </row>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='changelog']//db:row[db:entry[text()='8.3.0']]/.)">
-       <xi:fallback/>
-      </xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='changelog']//db:row[db:entry[text()='8.3.0']]/.)"/>
       <row>
        <entry>7.4.0</entry>
        <entry>

--- a/reference/svm/svmmodel.xml
+++ b/reference/svm/svmmodel.xml
@@ -34,12 +34,8 @@
 <!-- }}} -->
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.svmmodel')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.svmmodel')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.svmmodel')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.svmmodel')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/svn/functions/svn-auth-get-parameter.xml
+++ b/reference/svn/functions/svn-auth-get-parameter.xml
@@ -49,69 +49,8 @@
   &warn.experimental.func;
  </refsect1>
 
- <!-- Use when ERRORS exist
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   When does this function throw E_* level errors, or exceptions?
-  </para>
- </refsect1>
- -->
 
- <!-- Use when a CHANGELOG exists
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>Enter the PHP version of change here</entry>
-       <entry>Description of change</entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>svn_auth_get_parameter</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/svn/functions/svn-auth-set-parameter.xml
+++ b/reference/svn/functions/svn-auth-set-parameter.xml
@@ -54,38 +54,7 @@
   </simpara>
  </refsect1>
 
- <!-- Use when ERRORS exist
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   When does this function throw E_* level errors, or exceptions?
-  </para>
- </refsect1>
- -->
 
- <!-- Use when a CHANGELOG exists
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>Enter the PHP version of change here</entry>
-       <entry>Description of change</entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
- -->
 
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/svn/functions/svn-cat.xml
+++ b/reference/svn/functions/svn-cat.xml
@@ -52,38 +52,7 @@
   </simpara>
  </refsect1>
 
- <!-- Use when ERRORS exist
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   When does this function throw E_* level errors, or exceptions?
-  </para>
- </refsect1>
- -->
 
- <!-- Use when a CHANGELOG exists
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>Enter the PHP version of change here</entry>
-       <entry>Description of change</entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
- -->
 
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/svn/functions/svn-checkout.xml
+++ b/reference/svn/functions/svn-checkout.xml
@@ -71,38 +71,7 @@
   </simpara>
  </refsect1>
 
- <!-- Use when ERRORS exist
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   When does this function throw E_* level errors, or exceptions?
-  </para>
- </refsect1>
- -->
 
- <!-- Use when a CHANGELOG exists
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>Enter the PHP version of change here</entry>
-       <entry>Description of change</entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
- -->
 
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/svn/functions/svn-cleanup.xml
+++ b/reference/svn/functions/svn-cleanup.xml
@@ -43,38 +43,7 @@
   </simpara>
  </refsect1>
 
- <!-- Use when ERRORS exist
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   When does this function throw E_* level errors, or exceptions?
-  </para>
- </refsect1>
- -->
 
- <!-- Use when a CHANGELOG exists
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>Enter the PHP version of change here</entry>
-       <entry>Description of change</entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
- -->
 
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/svn/functions/svn-client-version.xml
+++ b/reference/svn/functions/svn-client-version.xml
@@ -30,38 +30,7 @@
   </simpara>
  </refsect1>
 
- <!-- Use when ERRORS exist
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   When does this function throw E_* level errors, or exceptions?
-  </para>
- </refsect1>
- -->
 
- <!-- Use when a CHANGELOG exists
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>Enter the PHP version of change here</entry>
-       <entry>Description of change</entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
- -->
 
  <refsect1 role="examples">
   &reftitle.examples;
@@ -88,17 +57,6 @@ echo svn_client_version();
   &warn.experimental.func;
  </refsect1>
 
- <!-- Use when adding See Also links
- <refsect1 role="seealso">
-  &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function></function></member>
-    <member>Or <link linkend="somethingelse">something else</link></member>
-   </simplelist>
-  </para>
- </refsect1>
- -->
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/svn/functions/svn-diff.xml
+++ b/reference/svn/functions/svn-diff.xml
@@ -97,38 +97,7 @@
   </simpara>
  </refsect1>
 
- <!-- Use when ERRORS exist
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   When does this function throw E_* level errors, or exceptions?
-  </para>
- </refsect1>
- -->
 
- <!-- Use when a CHANGELOG exists
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>Enter the PHP version of change here</entry>
-       <entry>Description of change</entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
- -->
 
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/svn/functions/svn-fs-abort-txn.xml
+++ b/reference/svn/functions/svn-fs-abort-txn.xml
@@ -45,81 +45,9 @@
   &warn.experimental.func;
  </refsect1>
 
- <!-- Use when ERRORS exist
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   When does this function throw E_* level errors, or exceptions?
-  </para>
- </refsect1>
- -->
 
- <!-- Use when a CHANGELOG exists
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>Enter the PHP version of change here</entry>
-       <entry>Description of change</entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>svn_fs_abort_txn</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when adding See Also links
- <refsect1 role="seealso">
-  &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function></function></member>
-    <member>Or <link linkend="somethingelse">something else</link></member>
-   </simplelist>
-  </para>
- </refsect1>
- -->
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/svn/functions/svn-fs-apply-text.xml
+++ b/reference/svn/functions/svn-fs-apply-text.xml
@@ -19,119 +19,14 @@
    ファイルの内容を置換するために使用するストリームを作成して返します。
   </simpara>
  </refsect1>
-<!--
- <refsect1 role="parameters">
-  &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>root</parameter></term>
-     <listitem>
-      <para>
-       Its description
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>path</parameter></term>
-     <listitem>
-      <para>
-       Its description
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
-
- </refsect1>
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   What the function returns, first on success, then on failure. See
-   also the &amp;return.success; entity
-  </para>
- </refsect1>
--->
  <refsect1 role="notes">
   &reftitle.notes;
   &warn.experimental.func;
  </refsect1>
 
- <!-- Use when ERRORS exist
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   When does this function throw E_* level errors, or exceptions?
-  </para>
- </refsect1>
- -->
 
- <!-- Use when a CHANGELOG exists
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>Enter the PHP version of change here</entry>
-       <entry>Description of change</entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>svn_fs_apply_text</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when adding See Also links
- <refsect1 role="seealso">
-  &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function></function></member>
-    <member>Or <link linkend="somethingelse">something else</link></member>
-   </simplelist>
-  </para>
- </refsect1>
- -->
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/svn/functions/svn-fs-begin-txn2.xml
+++ b/reference/svn/functions/svn-fs-begin-txn2.xml
@@ -19,119 +19,14 @@
    新しいトランザクションを作成します。
   </simpara>
  </refsect1>
-<!--
- <refsect1 role="parameters">
-  &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>repos</parameter></term>
-     <listitem>
-      <para>
-       Its description
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>rev</parameter></term>
-     <listitem>
-      <para>
-       Its description
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
-
- </refsect1>
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   What the function returns, first on success, then on failure. See
-   also the &amp;return.success; entity
-  </para>
- </refsect1>
--->
  <refsect1 role="notes">
   &reftitle.notes;
   &warn.experimental.func;
  </refsect1>
 
- <!-- Use when ERRORS exist
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   When does this function throw E_* level errors, or exceptions?
-  </para>
- </refsect1>
- -->
 
- <!-- Use when a CHANGELOG exists
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>Enter the PHP version of change here</entry>
-       <entry>Description of change</entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>svn_fs_begin_txn2</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when adding See Also links
- <refsect1 role="seealso">
-  &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function></function></member>
-    <member>Or <link linkend="somethingelse">something else</link></member>
-   </simplelist>
-  </para>
- </refsect1>
- -->
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/svn/functions/svn-fs-change-node-prop.xml
+++ b/reference/svn/functions/svn-fs-change-node-prop.xml
@@ -21,135 +21,14 @@
    成功したら true、失敗したら false を返します。
   </simpara>
  </refsect1>
-<!--
- <refsect1 role="parameters">
-  &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>root</parameter></term>
-     <listitem>
-      <para>
-       Its description
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>path</parameter></term>
-     <listitem>
-      <para>
-       Its description
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>name</parameter></term>
-     <listitem>
-      <para>
-       Its description
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>value</parameter></term>
-     <listitem>
-      <para>
-       Its description
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
-
- </refsect1>
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   What the function returns, first on success, then on failure. See
-   also the &amp;return.success; entity
-  </para>
- </refsect1>
--->
  <refsect1 role="notes">
   &reftitle.notes;
   &warn.experimental.func;
  </refsect1>
 
- <!-- Use when ERRORS exist
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   When does this function throw E_* level errors, or exceptions?
-  </para>
- </refsect1>
- -->
 
- <!-- Use when a CHANGELOG exists
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>Enter the PHP version of change here</entry>
-       <entry>Description of change</entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>svn_fs_change_node_prop</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when adding See Also links
- <refsect1 role="seealso">
-  &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function></function></member>
-    <member>Or <link linkend="somethingelse">something else</link></member>
-   </simplelist>
-  </para>
- </refsect1>
- -->
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/svn/functions/svn-fs-check-path.xml
+++ b/reference/svn/functions/svn-fs-check-path.xml
@@ -19,119 +19,14 @@
    指定したリポジトリの fsroot パスにどんなアイテムが存在するかを調べます。
   </simpara>
  </refsect1>
-<!--
- <refsect1 role="parameters">
-  &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>fsroot</parameter></term>
-     <listitem>
-      <para>
-       Its description
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>path</parameter></term>
-     <listitem>
-      <para>
-       Its description
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
-
- </refsect1>
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   What the function returns, first on success, then on failure. See
-   also the &amp;return.success; entity
-  </para>
- </refsect1>
--->
  <refsect1 role="notes">
   &reftitle.notes;
   &warn.experimental.func;
  </refsect1>
 
- <!-- Use when ERRORS exist
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   When does this function throw E_* level errors, or exceptions?
-  </para>
- </refsect1>
- -->
 
- <!-- Use when a CHANGELOG exists
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>Enter the PHP version of change here</entry>
-       <entry>Description of change</entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>svn_fs_check_path</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when adding See Also links
- <refsect1 role="seealso">
-  &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function></function></member>
-    <member>Or <link linkend="somethingelse">something else</link></member>
-   </simplelist>
-  </para>
- </refsect1>
- -->
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/svn/functions/svn-fs-contents-changed.xml
+++ b/reference/svn/functions/svn-fs-contents-changed.xml
@@ -21,135 +21,14 @@
    コンテンツが変更されている場合に true、されていない場合に false を返します。
   </simpara>
  </refsect1>
-<!--
- <refsect1 role="parameters">
-  &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>root1</parameter></term>
-     <listitem>
-      <para>
-       Its description
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>path1</parameter></term>
-     <listitem>
-      <para>
-       Its description
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>root2</parameter></term>
-     <listitem>
-      <para>
-       Its description
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>path2</parameter></term>
-     <listitem>
-      <para>
-       Its description
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
-
- </refsect1>
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   What the function returns, first on success, then on failure. See
-   also the &amp;return.success; entity
-  </para>
- </refsect1>
--->
  <refsect1 role="notes">
   &reftitle.notes;
   &warn.experimental.func;
  </refsect1>
 
- <!-- Use when ERRORS exist
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   When does this function throw E_* level errors, or exceptions?
-  </para>
- </refsect1>
- -->
 
- <!-- Use when a CHANGELOG exists
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>Enter the PHP version of change here</entry>
-       <entry>Description of change</entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>svn_fs_contents_changed</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when adding See Also links
- <refsect1 role="seealso">
-  &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function></function></member>
-    <member>Or <link linkend="somethingelse">something else</link></member>
-   </simplelist>
-  </para>
- </refsect1>
- -->
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/svn/functions/svn-fs-copy.xml
+++ b/reference/svn/functions/svn-fs-copy.xml
@@ -72,81 +72,9 @@
   &warn.experimental.func;
  </refsect1>
 
- <!-- Use when ERRORS exist
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   When does this function throw E_* level errors, or exceptions?
-  </para>
- </refsect1>
- -->
 
- <!-- Use when a CHANGELOG exists
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>Enter the PHP version of change here</entry>
-       <entry>Description of change</entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>svn_fs_copy</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when adding See Also links
- <refsect1 role="seealso">
-  &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function></function></member>
-    <member>Or <link linkend="somethingelse">something else</link></member>
-   </simplelist>
-  </para>
- </refsect1>
- -->
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/svn/functions/svn-fs-delete.xml
+++ b/reference/svn/functions/svn-fs-delete.xml
@@ -54,81 +54,9 @@
   &warn.experimental.func;
  </refsect1>
 
- <!-- Use when ERRORS exist
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   When does this function throw E_* level errors, or exceptions?
-  </para>
- </refsect1>
- -->
 
- <!-- Use when a CHANGELOG exists
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>Enter the PHP version of change here</entry>
-       <entry>Description of change</entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>svn_fs_delete</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when adding See Also links
- <refsect1 role="seealso">
-  &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function></function></member>
-    <member>Or <link linkend="somethingelse">something else</link></member>
-   </simplelist>
-  </para>
- </refsect1>
- -->
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/svn/functions/svn-fs-dir-entries.xml
+++ b/reference/svn/functions/svn-fs-dir-entries.xml
@@ -19,119 +19,14 @@
    指定したパスのディレクトリを列挙し、ディレクトリ名とファイルタイプのハッシュを返します。
   </simpara>
  </refsect1>
-<!--
- <refsect1 role="parameters">
-  &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>fsroot</parameter></term>
-     <listitem>
-      <para>
-       Its description
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>path</parameter></term>
-     <listitem>
-      <para>
-       Its description
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
-
- </refsect1>
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   What the function returns, first on success, then on failure. See
-   also the &amp;return.success; entity
-  </para>
- </refsect1>
--->
  <refsect1 role="notes">
   &reftitle.notes;
   &warn.experimental.func;
  </refsect1>
 
- <!-- Use when ERRORS exist
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   When does this function throw E_* level errors, or exceptions?
-  </para>
- </refsect1>
- -->
 
- <!-- Use when a CHANGELOG exists
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>Enter the PHP version of change here</entry>
-       <entry>Description of change</entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>svn_fs_dir_entries</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when adding See Also links
- <refsect1 role="seealso">
-  &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function></function></member>
-    <member>Or <link linkend="somethingelse">something else</link></member>
-   </simplelist>
-  </para>
- </refsect1>
- -->
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/svn/functions/svn-fs-file-contents.xml
+++ b/reference/svn/functions/svn-fs-file-contents.xml
@@ -19,119 +19,14 @@
    指定したバージョンの fs から、ファイルの中身を読み込むためのストリームを返します。
   </simpara>
  </refsect1>
-<!--
- <refsect1 role="parameters">
-  &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>fsroot</parameter></term>
-     <listitem>
-      <para>
-       Its description
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>path</parameter></term>
-     <listitem>
-      <para>
-       Its description
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
-
- </refsect1>
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   What the function returns, first on success, then on failure. See
-   also the &amp;return.success; entity
-  </para>
- </refsect1>
--->
  <refsect1 role="notes">
   &reftitle.notes;
   &warn.experimental.func;
  </refsect1>
 
- <!-- Use when ERRORS exist
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   When does this function throw E_* level errors, or exceptions?
-  </para>
- </refsect1>
- -->
 
- <!-- Use when a CHANGELOG exists
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>Enter the PHP version of change here</entry>
-       <entry>Description of change</entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>svn_fs_file_contents</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when adding See Also links
- <refsect1 role="seealso">
-  &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function></function></member>
-    <member>Or <link linkend="somethingelse">something else</link></member>
-   </simplelist>
-  </para>
- </refsect1>
- -->
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/svn/functions/svn-fs-file-length.xml
+++ b/reference/svn/functions/svn-fs-file-length.xml
@@ -19,119 +19,14 @@
    指定したバージョンの fs から、ファイルの長さを返します。
   </simpara>
  </refsect1>
-<!--
- <refsect1 role="parameters">
-  &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>fsroot</parameter></term>
-     <listitem>
-      <para>
-       Its description
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>path</parameter></term>
-     <listitem>
-      <para>
-       Its description
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
-
- </refsect1>
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   What the function returns, first on success, then on failure. See
-   also the &amp;return.success; entity
-  </para>
- </refsect1>
--->
  <refsect1 role="notes">
   &reftitle.notes;
   &warn.experimental.func;
  </refsect1>
 
- <!-- Use when ERRORS exist
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   When does this function throw E_* level errors, or exceptions?
-  </para>
- </refsect1>
- -->
 
- <!-- Use when a CHANGELOG exists
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>Enter the PHP version of change here</entry>
-       <entry>Description of change</entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>svn_fs_file_length</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when adding See Also links
- <refsect1 role="seealso">
-  &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function></function></member>
-    <member>Or <link linkend="somethingelse">something else</link></member>
-   </simplelist>
-  </para>
- </refsect1>
- -->
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/svn/functions/svn-fs-is-dir.xml
+++ b/reference/svn/functions/svn-fs-is-dir.xml
@@ -55,81 +55,9 @@
   &warn.experimental.func;
  </refsect1>
 
- <!-- Use when ERRORS exist
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   When does this function throw E_* level errors, or exceptions?
-  </para>
- </refsect1>
- -->
 
- <!-- Use when a CHANGELOG exists
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>Enter the PHP version of change here</entry>
-       <entry>Description of change</entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>svn_fs_is_dir</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when adding See Also links
- <refsect1 role="seealso">
-  &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function></function></member>
-    <member>Or <link linkend="somethingelse">something else</link></member>
-   </simplelist>
-  </para>
- </refsect1>
- -->
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/svn/functions/svn-fs-is-file.xml
+++ b/reference/svn/functions/svn-fs-is-file.xml
@@ -55,81 +55,9 @@
   &warn.experimental.func;
  </refsect1>
 
- <!-- Use when ERRORS exist
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   When does this function throw E_* level errors, or exceptions?
-  </para>
- </refsect1>
- -->
 
- <!-- Use when a CHANGELOG exists
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>Enter the PHP version of change here</entry>
-       <entry>Description of change</entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>svn_fs_is_file</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when adding See Also links
- <refsect1 role="seealso">
-  &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function></function></member>
-    <member>Or <link linkend="somethingelse">something else</link></member>
-   </simplelist>
-  </para>
- </refsect1>
- -->
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/svn/functions/svn-fs-make-dir.xml
+++ b/reference/svn/functions/svn-fs-make-dir.xml
@@ -54,81 +54,9 @@
   &warn.experimental.func;
  </refsect1>
 
- <!-- Use when ERRORS exist
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   When does this function throw E_* level errors, or exceptions?
-  </para>
- </refsect1>
- -->
 
- <!-- Use when a CHANGELOG exists
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>Enter the PHP version of change here</entry>
-       <entry>Description of change</entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>svn_fs_make_dir</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when adding See Also links
- <refsect1 role="seealso">
-  &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function></function></member>
-    <member>Or <link linkend="somethingelse">something else</link></member>
-   </simplelist>
-  </para>
- </refsect1>
- -->
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/svn/functions/svn-fs-make-file.xml
+++ b/reference/svn/functions/svn-fs-make-file.xml
@@ -54,81 +54,9 @@
   &warn.experimental.func;
  </refsect1>
 
- <!-- Use when ERRORS exist
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   When does this function throw E_* level errors, or exceptions?
-  </para>
- </refsect1>
- -->
 
- <!-- Use when a CHANGELOG exists
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>Enter the PHP version of change here</entry>
-       <entry>Description of change</entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>svn_fs_make_file</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when adding See Also links
- <refsect1 role="seealso">
-  &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function></function></member>
-    <member>Or <link linkend="somethingelse">something else</link></member>
-   </simplelist>
-  </para>
- </refsect1>
- -->
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/svn/functions/svn-fs-node-created-rev.xml
+++ b/reference/svn/functions/svn-fs-node-created-rev.xml
@@ -19,119 +19,14 @@
    fsroot 配下のパスが作成されたリビジョンを返します。
   </simpara>
  </refsect1>
-<!--
- <refsect1 role="parameters">
-  &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>fsroot</parameter></term>
-     <listitem>
-      <para>
-       Its description
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>path</parameter></term>
-     <listitem>
-      <para>
-       Its description
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
-
- </refsect1>
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   What the function returns, first on success, then on failure. See
-   also the &amp;return.success; entity
-  </para>
- </refsect1>
--->
  <refsect1 role="notes">
   &reftitle.notes;
   &warn.experimental.func;
  </refsect1>
 
- <!-- Use when ERRORS exist
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   When does this function throw E_* level errors, or exceptions?
-  </para>
- </refsect1>
- -->
 
- <!-- Use when a CHANGELOG exists
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>Enter the PHP version of change here</entry>
-       <entry>Description of change</entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>svn_fs_node_created_rev</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when adding See Also links
- <refsect1 role="seealso">
-  &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function></function></member>
-    <member>Or <link linkend="somethingelse">something else</link></member>
-   </simplelist>
-  </para>
- </refsect1>
- -->
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/svn/functions/svn-fs-node-prop.xml
+++ b/reference/svn/functions/svn-fs-node-prop.xml
@@ -20,127 +20,14 @@
    ノードのプロパティの値を返します。
   </simpara>
  </refsect1>
-<!--
- <refsect1 role="parameters">
-  &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>fsroot</parameter></term>
-     <listitem>
-      <para>
-       Its description
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>path</parameter></term>
-     <listitem>
-      <para>
-       Its description
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>propname</parameter></term>
-     <listitem>
-      <para>
-       Its description
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
-
- </refsect1>
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   What the function returns, first on success, then on failure. See
-   also the &amp;return.success; entity
-  </para>
- </refsect1>
--->
  <refsect1 role="notes">
   &reftitle.notes;
   &warn.experimental.func;
  </refsect1>
 
- <!-- Use when ERRORS exist
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   When does this function throw E_* level errors, or exceptions?
-  </para>
- </refsect1>
- -->
 
- <!-- Use when a CHANGELOG exists
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>Enter the PHP version of change here</entry>
-       <entry>Description of change</entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>svn_fs_node_prop</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when adding See Also links
- <refsect1 role="seealso">
-  &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function></function></member>
-    <member>Or <link linkend="somethingelse">something else</link></member>
-   </simplelist>
-  </para>
- </refsect1>
- -->
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/svn/functions/svn-fs-props-changed.xml
+++ b/reference/svn/functions/svn-fs-props-changed.xml
@@ -21,135 +21,14 @@
    プロパティが変更されている場合に true、それ以外の場合に false を返します。
   </simpara>
  </refsect1>
-<!--
- <refsect1 role="parameters">
-  &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>root1</parameter></term>
-     <listitem>
-      <para>
-       Its description
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>path1</parameter></term>
-     <listitem>
-      <para>
-       Its description
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>root2</parameter></term>
-     <listitem>
-      <para>
-       Its description
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>path2</parameter></term>
-     <listitem>
-      <para>
-       Its description
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
-
- </refsect1>
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   What the function returns, first on success, then on failure. See
-   also the &amp;return.success; entity
-  </para>
- </refsect1>
--->
  <refsect1 role="notes">
   &reftitle.notes;
   &warn.experimental.func;
  </refsect1>
 
- <!-- Use when ERRORS exist
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   When does this function throw E_* level errors, or exceptions?
-  </para>
- </refsect1>
- -->
 
- <!-- Use when a CHANGELOG exists
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>Enter the PHP version of change here</entry>
-       <entry>Description of change</entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>svn_fs_props_changed</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when adding See Also links
- <refsect1 role="seealso">
-  &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function></function></member>
-    <member>Or <link linkend="somethingelse">something else</link></member>
-   </simplelist>
-  </para>
- </refsect1>
- -->
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/svn/functions/svn-fs-revision-prop.xml
+++ b/reference/svn/functions/svn-fs-revision-prop.xml
@@ -20,127 +20,14 @@
    指定したプロパティの値を取得します。
   </simpara>
  </refsect1>
-<!--
- <refsect1 role="parameters">
-  &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>fs</parameter></term>
-     <listitem>
-      <para>
-       Its description
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>revnum</parameter></term>
-     <listitem>
-      <para>
-       Its description
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>propname</parameter></term>
-     <listitem>
-      <para>
-       Its description
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
-
- </refsect1>
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   What the function returns, first on success, then on failure. See
-   also the &amp;return.success; entity
-  </para>
- </refsect1>
--->
  <refsect1 role="notes">
   &reftitle.notes;
   &warn.experimental.func;
  </refsect1>
 
- <!-- Use when ERRORS exist
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   When does this function throw E_* level errors, or exceptions?
-  </para>
- </refsect1>
- -->
 
- <!-- Use when a CHANGELOG exists
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>Enter the PHP version of change here</entry>
-       <entry>Description of change</entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>svn_fs_revision_prop</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when adding See Also links
- <refsect1 role="seealso">
-  &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function></function></member>
-    <member>Or <link linkend="somethingelse">something else</link></member>
-   </simplelist>
-  </para>
- </refsect1>
- -->
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/svn/functions/svn-fs-revision-root.xml
+++ b/reference/svn/functions/svn-fs-revision-root.xml
@@ -19,119 +19,14 @@
    リポジトリのルートの指定したバージョンのハンドルを取得します。
   </simpara>
  </refsect1>
-<!--
- <refsect1 role="parameters">
-  &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>fs</parameter></term>
-     <listitem>
-      <para>
-       Its description
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>revnum</parameter></term>
-     <listitem>
-      <para>
-       Its description
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
-
- </refsect1>
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   What the function returns, first on success, then on failure. See
-   also the &amp;return.success; entity
-  </para>
- </refsect1>
--->
  <refsect1 role="notes">
   &reftitle.notes;
   &warn.experimental.func;
  </refsect1>
 
- <!-- Use when ERRORS exist
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   When does this function throw E_* level errors, or exceptions?
-  </para>
- </refsect1>
- -->
 
- <!-- Use when a CHANGELOG exists
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>Enter the PHP version of change here</entry>
-       <entry>Description of change</entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>svn_fs_revision_root</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when adding See Also links
- <refsect1 role="seealso">
-  &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function></function></member>
-    <member>Or <link linkend="somethingelse">something else</link></member>
-   </simplelist>
-  </para>
- </refsect1>
- -->
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/svn/functions/svn-fs-txn-root.xml
+++ b/reference/svn/functions/svn-fs-txn-root.xml
@@ -18,111 +18,14 @@
    トランザクションのルートを作成して返します。
   </simpara>
  </refsect1>
-<!--
- <refsect1 role="parameters">
-  &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>txn</parameter></term>
-     <listitem>
-      <para>
-       Its description
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
-
- </refsect1>
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   What the function returns, first on success, then on failure. See
-   also the &amp;return.success; entity
-  </para>
- </refsect1>
--->
  <refsect1 role="notes">
   &reftitle.notes;
   &warn.experimental.func;
  </refsect1>
 
- <!-- Use when ERRORS exist
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   When does this function throw E_* level errors, or exceptions?
-  </para>
- </refsect1>
- -->
 
- <!-- Use when a CHANGELOG exists
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>Enter the PHP version of change here</entry>
-       <entry>Description of change</entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>svn_fs_txn_root</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when adding See Also links
- <refsect1 role="seealso">
-  &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function></function></member>
-    <member>Or <link linkend="somethingelse">something else</link></member>
-   </simplelist>
-  </para>
- </refsect1>
- -->
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/svn/functions/svn-fs-youngest-rev.xml
+++ b/reference/svn/functions/svn-fs-youngest-rev.xml
@@ -18,111 +18,14 @@
    ファイルシステム内で一番若いリビジョン番号を返します。
   </simpara>
  </refsect1>
-<!--
- <refsect1 role="parameters">
-  &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>fs</parameter></term>
-     <listitem>
-      <para>
-       Its description
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
-
- </refsect1>
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   What the function returns, first on success, then on failure. See
-   also the &amp;return.success; entity
-  </para>
- </refsect1>
--->
  <refsect1 role="notes">
   &reftitle.notes;
   &warn.experimental.func;
  </refsect1>
 
- <!-- Use when ERRORS exist
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   When does this function throw E_* level errors, or exceptions?
-  </para>
- </refsect1>
- -->
 
- <!-- Use when a CHANGELOG exists
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>Enter the PHP version of change here</entry>
-       <entry>Description of change</entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>svn_fs_youngest_rev</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when adding See Also links
- <refsect1 role="seealso">
-  &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function></function></member>
-    <member>Or <link linkend="somethingelse">something else</link></member>
-   </simplelist>
-  </para>
- </refsect1>
- -->
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/svn/functions/svn-import.xml
+++ b/reference/svn/functions/svn-import.xml
@@ -62,38 +62,7 @@
   </simpara>
  </refsect1>
 
- <!-- Use when ERRORS exist
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   When does this function throw E_* level errors, or exceptions?
-  </para>
- </refsect1>
- -->
 
- <!-- Use when a CHANGELOG exists
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>Enter the PHP version of change here</entry>
-       <entry>Description of change</entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
- -->
 
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/svn/functions/svn-log.xml
+++ b/reference/svn/functions/svn-log.xml
@@ -149,38 +149,7 @@
   </simpara>
  </refsect1>
 
- <!-- Use when ERRORS exist
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   When does this function throw E_* level errors, or exceptions?
-  </para>
- </refsect1>
- -->
 
- <!-- Use when a CHANGELOG exists
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>Enter the PHP version of change here</entry>
-       <entry>Description of change</entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
- -->
 
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/svn/functions/svn-repos-create.xml
+++ b/reference/svn/functions/svn-repos-create.xml
@@ -20,127 +20,14 @@
    新しい subversion リポジトリを指定したパスに作成します。
   </simpara>
  </refsect1>
-<!--
- <refsect1 role="parameters">
-  &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>path</parameter></term>
-     <listitem>
-      <para>
-       Its description
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>config</parameter></term>
-     <listitem>
-      <para>
-       Its description
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>fsconfig</parameter></term>
-     <listitem>
-      <para>
-       Its description
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
-
- </refsect1>
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   What the function returns, first on success, then on failure. See
-   also the &amp;return.success; entity
-  </para>
- </refsect1>
--->
  <refsect1 role="notes">
   &reftitle.notes;
   &warn.experimental.func;
  </refsect1>
 
- <!-- Use when ERRORS exist
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   When does this function throw E_* level errors, or exceptions?
-  </para>
- </refsect1>
- -->
 
- <!-- Use when a CHANGELOG exists
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>Enter the PHP version of change here</entry>
-       <entry>Description of change</entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>svn_repos_create</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when adding See Also links
- <refsect1 role="seealso">
-  &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function></function></member>
-    <member>Or <link linkend="somethingelse">something else</link></member>
-   </simplelist>
-  </para>
- </refsect1>
- -->
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/svn/functions/svn-repos-fs-begin-txn-for-commit.xml
+++ b/reference/svn/functions/svn-repos-fs-begin-txn-for-commit.xml
@@ -21,135 +21,14 @@
    新しいトランザクションを作成します。
   </simpara>
  </refsect1>
-<!--
- <refsect1 role="parameters">
-  &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>repos</parameter></term>
-     <listitem>
-      <para>
-       Its description
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>rev</parameter></term>
-     <listitem>
-      <para>
-       Its description
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>author</parameter></term>
-     <listitem>
-      <para>
-       Its description
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>log_msg</parameter></term>
-     <listitem>
-      <para>
-       Its description
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
-
- </refsect1>
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   What the function returns, first on success, then on failure. See
-   also the &amp;return.success; entity
-  </para>
- </refsect1>
--->
  <refsect1 role="notes">
   &reftitle.notes;
   &warn.experimental.func;
  </refsect1>
 
- <!-- Use when ERRORS exist
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   When does this function throw E_* level errors, or exceptions?
-  </para>
- </refsect1>
- -->
 
- <!-- Use when a CHANGELOG exists
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>Enter the PHP version of change here</entry>
-       <entry>Description of change</entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>svn_repos_fs_begin_txn_for_commit</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when adding See Also links
- <refsect1 role="seealso">
-  &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function></function></member>
-    <member>Or <link linkend="somethingelse">something else</link></member>
-   </simplelist>
-  </para>
- </refsect1>
- -->
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/svn/functions/svn-repos-fs-commit-txn.xml
+++ b/reference/svn/functions/svn-repos-fs-commit-txn.xml
@@ -18,111 +18,14 @@
    トランザクションをコミットし、新しいリビジョンを返します。
   </simpara>
  </refsect1>
-<!--
- <refsect1 role="parameters">
-  &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>txn</parameter></term>
-     <listitem>
-      <para>
-       Its description
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
-
- </refsect1>
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   What the function returns, first on success, then on failure. See
-   also the &amp;return.success; entity
-  </para>
- </refsect1>
--->
  <refsect1 role="notes">
   &reftitle.notes;
   &warn.experimental.func;
  </refsect1>
 
- <!-- Use when ERRORS exist
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   When does this function throw E_* level errors, or exceptions?
-  </para>
- </refsect1>
- -->
 
- <!-- Use when a CHANGELOG exists
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>Enter the PHP version of change here</entry>
-       <entry>Description of change</entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>svn_repos_fs_commit_txn</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when adding See Also links
- <refsect1 role="seealso">
-  &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function></function></member>
-    <member>Or <link linkend="somethingelse">something else</link></member>
-   </simplelist>
-  </para>
- </refsect1>
- -->
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/svn/functions/svn-repos-fs.xml
+++ b/reference/svn/functions/svn-repos-fs.xml
@@ -18,111 +18,14 @@
    リポジトリ用に、ファイルシステム上のハンドルを取得します。
   </simpara>
  </refsect1>
-<!--
- <refsect1 role="parameters">
-  &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>repos</parameter></term>
-     <listitem>
-      <para>
-       Its description
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
-
- </refsect1>
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   What the function returns, first on success, then on failure. See
-   also the &amp;return.success; entity
-  </para>
- </refsect1>
--->
  <refsect1 role="notes">
   &reftitle.notes;
   &warn.experimental.func;
  </refsect1>
 
- <!-- Use when ERRORS exist
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   When does this function throw E_* level errors, or exceptions?
-  </para>
- </refsect1>
- -->
 
- <!-- Use when a CHANGELOG exists
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>Enter the PHP version of change here</entry>
-       <entry>Description of change</entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>svn_repos_fs</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when adding See Also links
- <refsect1 role="seealso">
-  &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function></function></member>
-    <member>Or <link linkend="somethingelse">something else</link></member>
-   </simplelist>
-  </para>
- </refsect1>
- -->
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/svn/functions/svn-repos-hotcopy.xml
+++ b/reference/svn/functions/svn-repos-hotcopy.xml
@@ -20,128 +20,15 @@
    repospath にあるリポジトリのホットコピーを作成し、destpath にコピーします。
   </simpara>
  </refsect1>
-<!--
- <refsect1 role="parameters">
-  &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>repospath</parameter></term>
-     <listitem>
-      <para>
-       Its description
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>destpath</parameter></term>
-     <listitem>
-      <para>
-       Its description
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>cleanlogs</parameter></term>
-     <listitem>
-      <para>
-       Its description
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
-
- </refsect1>
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   What the function returns, first on success, then on failure. See
-   also the &amp;return.success; entity
-  </para>
- </refsect1>
- -->
 
  <refsect1 role="notes">
   &reftitle.notes;
   &warn.experimental.func;
  </refsect1>
 
- <!-- Use when ERRORS exist
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   When does this function throw E_* level errors, or exceptions?
-  </para>
- </refsect1>
- -->
 
- <!-- Use when a CHANGELOG exists
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>Enter the PHP version of change here</entry>
-       <entry>Description of change</entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when examples exist
- <refsect1 role="examples">
-  &reftitle.examples;
-  <para>
-   <example>
-    <title>A <function>svn_repos_hotcopy</function> example</title>
-    <para>
-     Any text that describes the purpose of the example, or
-     what goes on in the example should go here (inside the
-     <example> tag, not out
-    </para>
-    <programlisting role="php">
-<![CDATA[
-<?php
-if ($anexample === true) {
-    echo 'Use the PEAR Coding Standards';
-}
-?>
-]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
-<![CDATA[
-Use the PEAR Coding Standards
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
- -->
 
- <!-- Use when adding See Also links
- <refsect1 role="seealso">
-  &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function></function></member>
-    <member>Or <link linkend="somethingelse">something else</link></member>
-   </simplelist>
-  </para>
- </refsect1>
- -->
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/tidy/tidy.xml
+++ b/reference/tidy/tidy.xml
@@ -40,12 +40,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.tidy')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='tidy'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.tidy')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='tidy'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.tidy')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='tidy'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.tidy')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='tidy'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/tidy/tidynode.xml
+++ b/reference/tidy/tidynode.xml
@@ -84,12 +84,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.tidynode')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='tidyNode'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.tidynode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='tidyNode'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.tidynode')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='tidyNode'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.tidynode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='tidyNode'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/tokenizer/phptoken.xml
+++ b/reference/tokenizer/phptoken.xml
@@ -60,12 +60,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.phptoken')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PhpToken'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.phptoken')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PhpToken'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.phptoken')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PhpToken'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.phptoken')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PhpToken'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/uri/uri.invaliduriexception.xml
+++ b/reference/uri/uri.invaliduriexception.xml
@@ -30,17 +30,11 @@
      </ooclass>
 
      <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
      <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-      <xi:fallback/>
-     </xi:include>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
     </classsynopsis>
    </packagesynopsis>
   </section>

--- a/reference/uri/uri.rfc3986.uri.xml
+++ b/reference/uri/uri.rfc3986.uri.xml
@@ -27,12 +27,8 @@
      </ooclass>
 
      <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.uri-rfc3986-uri')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Uri\\Rfc3986\\Uri'])">
-      <xi:fallback/>
-     </xi:include>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.uri-rfc3986-uri')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Uri\\Rfc3986\\Uri'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.uri-rfc3986-uri')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Uri\\Rfc3986\\Uri'])"/>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.uri-rfc3986-uri')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Uri\\Rfc3986\\Uri'])"/>
     </classsynopsis>
    </packagesynopsis>
   </section>

--- a/reference/uri/uri.urierror.xml
+++ b/reference/uri/uri.urierror.xml
@@ -30,17 +30,11 @@
      </ooclass>
 
      <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
      <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])">
-      <xi:fallback/>
-     </xi:include>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])"/>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])"/>
     </classsynopsis>
    </packagesynopsis>
   </section>

--- a/reference/uri/uri.uriexception.xml
+++ b/reference/uri/uri.uriexception.xml
@@ -31,17 +31,11 @@
      </ooclass>
 
      <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
      <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-      <xi:fallback/>
-     </xi:include>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
     </classsynopsis>
    </packagesynopsis>
   </section>

--- a/reference/uri/uri.whatwg.invalidurlexception.xml
+++ b/reference/uri/uri.whatwg.invalidurlexception.xml
@@ -40,19 +40,13 @@
      </fieldsynopsis>
 
      <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
      <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.uri-whatwg-invalidurlexception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Uri\\WhatWg\\InvalidUrlException'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.uri-whatwg-invalidurlexception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Uri\\WhatWg\\InvalidUrlException'])"/>
 
      <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
     </classsynopsis>
    </packagesynopsis>
   </section>

--- a/reference/uri/uri.whatwg.url.xml
+++ b/reference/uri/uri.whatwg.url.xml
@@ -26,12 +26,8 @@
      </ooclass>
 
      <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.uri-whatwg-url')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Uri\\WhatWg\\Url'])">
-      <xi:fallback/>
-     </xi:include>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.uri-whatwg-url')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Uri\\WhatWg\\Url'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.uri-whatwg-url')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Uri\\WhatWg\\Url'])"/>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.uri-whatwg-url')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Uri\\WhatWg\\Url'])"/>
     </classsynopsis>
    </packagesynopsis>
   </section>

--- a/reference/uri/uri.whatwg.urlvalidationerror.xml
+++ b/reference/uri/uri.whatwg.urlvalidationerror.xml
@@ -45,9 +45,7 @@
      </fieldsynopsis>
 
      <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.uri-whatwg-urlvalidationerror')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Uri\\WhatWg\\UrlValidationError'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.uri-whatwg-urlvalidationerror')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Uri\\WhatWg\\UrlValidationError'])"/>
     </classsynopsis>
    </packagesynopsis>
   </section>

--- a/reference/v8js/v8js.xml
+++ b/reference/v8js/v8js.xml
@@ -56,12 +56,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.v8js')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.v8js')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.v8js')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.v8js')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/win32service/functions/win32-create-service.xml
+++ b/reference/win32service/functions/win32-create-service.xml
@@ -353,7 +353,7 @@
   </para>
  </refsect1>
 
- <refsect1 role="changelog"><!-- {{{ -->
+ <refsect1 role="changelog">
   &reftitle.changelog;
   <para>
    <informaltable>
@@ -403,7 +403,7 @@
     </tgroup>
    </informaltable>
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/win32service/win32serviceexception.xml
+++ b/reference/win32service/win32serviceexception.xml
@@ -46,9 +46,7 @@
 <!-- }}} -->
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback />
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
 <!-- Comment this section out if the exception does not contain any methods -->
 <!--

--- a/reference/xmlreader/xmlreader.xml
+++ b/reference/xmlreader/xmlreader.xml
@@ -233,9 +233,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.xmlreader')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='XMLReader'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.xmlreader')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='XMLReader'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/xmlreader/xmlreader/fromstring.xml
+++ b/reference/xmlreader/xmlreader/fromstring.xml
@@ -21,9 +21,7 @@
  </refsect1>
 
  <refsect1 role="parameters">
-  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('xmlreader.xml')/db:refsect1[@role='parameters']/*)">
-   <xi:fallback/>
-  </xi:include>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('xmlreader.xml')/db:refsect1[@role='parameters']/*)"/>
  </refsect1>
 
  <refsect1 role="returnvalues">

--- a/reference/xmlreader/xmlreader/fromuri.xml
+++ b/reference/xmlreader/xmlreader/fromuri.xml
@@ -21,9 +21,7 @@
  </refsect1>
 
  <refsect1 role="parameters">
-  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('xmlreader.open')/db:refsect1[@role='parameters']/*)">
-   <xi:fallback/>
-  </xi:include>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('xmlreader.open')/db:refsect1[@role='parameters']/*)"/>
  </refsect1>
 
  <refsect1 role="returnvalues">

--- a/reference/xmlwriter/xmlwriter.xml
+++ b/reference/xmlwriter/xmlwriter.xml
@@ -27,9 +27,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.xmlwriter')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='XMLWriter'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.xmlwriter')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='XMLWriter'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/xmlwriter/xmlwriter/touri.xml
+++ b/reference/xmlwriter/xmlwriter/touri.xml
@@ -18,9 +18,7 @@
  </refsect1>
 
  <refsect1 role="parameters">
-  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('xmlwriter.openuri')/db:refsect1[@role='parameters']/*)">
-   <xi:fallback/>
-  </xi:include>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('xmlwriter.openuri')/db:refsect1[@role='parameters']/*)"/>
  </refsect1>
 
  <refsect1 role="returnvalues">

--- a/reference/xsl/xsltprocessor.xml
+++ b/reference/xsl/xsltprocessor.xml
@@ -52,9 +52,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.xsltprocessor')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='XSLTProcessor'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.xsltprocessor')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='XSLTProcessor'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/xsl/xsltprocessor/transformtoxml.xml
+++ b/reference/xsl/xsltprocessor/transformtoxml.xml
@@ -20,9 +20,7 @@
   </para>
  </refsect1>
  <refsect1 role="parameters">
-  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('xsltprocessor.transformtodoc')/db:refsect1[@role='parameters']/*)">
-   <xi:fallback/>
-  </xi:include>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('xsltprocessor.transformtodoc')/db:refsect1[@role='parameters']/*)"/>
  </refsect1>
 
  <xi:include xpointer="domxpath.query..errors" />

--- a/reference/zip/ziparchive.xml
+++ b/reference/zip/ziparchive.xml
@@ -732,9 +732,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ziparchive')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ZipArchive'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ziparchive')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ZipArchive'])"/>
    </classsynopsis>
 <!-- }}} -->
 


### PR DESCRIPTION
doc-en 側で `[skip-revcheck]` として行われた機械的なマークアップ整理を、まとめて適用しました。

- php/doc-en#5699 — 空の `xi:fallback` の除去（329ファイル・940箇所）
- php/doc-en#5630 — 折りたたみマーカーと、コメントアウトされたスケルトンの除去（198ファイル・822箇所）

訳文の変更はありません。いずれも解決に成功している限り出力に現れない要素なので、挙動も変わりません。

`[skip-revcheck]` が付いているため revcheck には現れず、このままだと今後これらのファイルを同期するたびに、実際の翻訳変更にこの分の差分が混ざります。先にまとめて解消しておくのが狙いです。

あわせて、同じ形の取り残しが1件あったので別コミットで除去しました。`reference/win32service/functions/win32-create-service.xml` の折りたたみマーカーで、こちらは php/doc-en#5630 ではなく php/doc-en@4d72f13eaf（2021年）で除去されていたものです。

これで ja 側に残る `xi:fallback` は、原文と同じく `reference/dom/domdocument/` 配下の例示コード2件だけになります。折りたたみマーカーのほうは、`reference/win32service/setup.xml` と `reference/yaz/setup.xml` の Configuration 節に付いた2組を除いて、原文に残っているものだけになります。この2組は php/doc-en#3538 で en 側が節ごと削除したものに ja が追従していない別件で、本PRの対象コミットとは無関係です。
