### PR TITLE
doc-en と同期し <para> を <simpara> に変更（45ファイル・訳文の変更なし）

### DIFF
--- a/appendices/migration72/new-features.xml
+++ b/appendices/migration72/new-features.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 6d29533483657c036e49edb5ea88c7103d126681 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: takagi Status: ready -->
 
 <sect1 xml:id="migration72.new-features" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>新機能</title>
@@ -157,13 +157,13 @@ $db->quote('über', PDO::PARAM_STR | PDO::PARAM_STR_NATL);
  <sect2 xml:id="migration72.new-features.additional-emulated-prepares-debugging-info">
   <title><link linkend="book.pdo">PDO</link> のデバッグ情報にプリペアのエミュレートの内容を追加</title>
 
-  <para>
+  <simpara>
    <function>PDOStatement::debugDumpParams</function> メソッドが改良されて、
    データベースに送信される SQL を表示できるようになりました。
    これは、プレースホルダの内容をバインド変数の値で置き換えた後の生のクエリです。
    この機能は、プリペア機能のエミュレートをデバッグしやすくするために用意されました
    (そのため、プリペア機能のエミュレートが有効になっているときしか使えません)。
-  </para>
+  </simpara>
  </sect2>
 
  <sect2 xml:id="migration72.new-features.extended-ops-in-ldap">

--- a/appendices/migration83/other-changes.xml
+++ b/appendices/migration83/other-changes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: mumumu Status: ready -->
 <sect1 xml:id="migration83.other-changes" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>その他の変更</title>
 

--- a/reference/mysqli/book.xml
+++ b/reference/mysqli/book.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 038bdb1d98c2481e291616a310945b38523965da Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa,mumumu -->
 <book xml:id="book.mysqli" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <?phpdoc extension-membership="bundledexternal" ?>
@@ -30,9 +30,9 @@
    にあります。
   </para>
 
-  <para>
+  <simpara>
    このドキュメントの一部は、Oracle Corporation の許可を得て MySQL マニュアルから引用したものです。
-  </para>
+  </simpara>
   
   <para>
    このドキュメントのサンプルでは、<link xlink:href="&url.mysql.example;">world</link>

--- a/reference/mysqli/constants.xml
+++ b/reference/mysqli/constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e11d90ec66baf31038e800870913ff2baec5ba72 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa,mumumu -->
 <appendix xml:id="mysqli.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
@@ -453,9 +453,9 @@
      (<type>int</type>)
     </term>
     <listitem>
-     <para>
+     <simpara>
       フィールドは、マルチインデックスの一部です。
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry xml:id="constant.mysqli-group-flag">

--- a/reference/mysqli/mysqli/change-user.xml
+++ b/reference/mysqli/mysqli/change-user.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ee14f82484f6289278255f798f1e8b93cdc2cab5 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa,mumumu -->
 <refentry xml:id="mysqli.change-user" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -33,13 +33,13 @@
    このメソッドは新しい接続が確立できなかった場合に、現在の接続を切断しません。
    その点で <methodname>mysqli::connect</methodname> と異なります。
   </para>
-  <para>
+  <simpara>
    ユーザーを正しく変更するには、<parameter>username</parameter> と
    <parameter>password</parameter> 引数を正しく渡す必要があります。
    またそのユーザーが対象のデータベースに対する適切なパーミッションを
    持っている必要があります。どんな理由であれ、認証に失敗するとカレントユーザーの
    認証が継続されます。
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -177,13 +177,13 @@ Default database:
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     このコマンドを使用すると、常に、カレントのデータベース接続は
     あたかも完全に新しいデータベース接続であるかのようになります。
     これにより、全てのアクティブなトランザクションはロールバックされ、
     一時テーブルは全てクローズされ、ロックされたテーブルはすべて
     開放されます。
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/mysqli/mysqli/dump-debug-info.xml
+++ b/reference/mysqli/mysqli/dump-debug-info.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 035c126c0393fe154bac46e2c3c489ebadce48a5 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="mysqli.dump-debug-info" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -21,11 +21,11 @@
    <type>bool</type><methodname>mysqli_dump_debug_info</methodname>
    <methodparam><type>mysqli</type><parameter>mysql</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    この関数は SUPER 権限を持ったユーザーによって実行されるされることを
    想定しており、<parameter>link</parameter> で指定した接続に関連する
    MySQL サーバーのデバッグ情報をログに出力します。
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/mysqli/mysqli/errno.xml
+++ b/reference/mysqli/mysqli/errno.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 614d77598aa2aaa3ddf3e8494812a3b82864d590 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="mysqli.errno" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -34,10 +34,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    直近のコールが失敗した場合、エラーコードを返します。
    ゼロは、何もエラーが発生しなかったことを示します。
-  </para>
+  </simpara>
  </refsect1>
  
  <refsect1 role="examples">

--- a/reference/mysqli/mysqli/init.xml
+++ b/reference/mysqli/mysqli/init.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: mumumu Status: ready -->
 
 <refentry xml:id="mysqli.init" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -27,11 +27,11 @@
    MYSQLオブジェクトを割り当てるか、初期化します。
   </para>
   <note>
-   <para>
+   <simpara>
     この関数が呼び出された後の、あらゆる mysqli の関数呼び出し
     (<function>mysqli_options</function> と <function>mysqli_ssl_set</function> を除く)
     は、<function>mysqli_real_connect</function> 関数が呼び出されるまで失敗します。
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/mysqli/mysqli/multi-query.xml
+++ b/reference/mysqli/mysqli/multi-query.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 1beae37b6904f55cfd33dbe99ad83a23eb78b144 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="mysqli.multi-query" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/mysqli/mysqli/options.xml
+++ b/reference/mysqli/mysqli/options.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e309a62b16c7dc48883b1b426bb8c15918488681 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="mysqli.options" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/mysqli/mysqli/ping.xml
+++ b/reference/mysqli/mysqli/ping.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="mysqli.ping" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/mysqli/mysqli/rollback.xml
+++ b/reference/mysqli/mysqli/rollback.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 976425d4f6eec32448be3cc22ec063015921b753 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="mysqli.rollback" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -24,9 +24,9 @@
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>name</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    データベースの現在のトランザクションをロールバックします。
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/mysqli/mysqli/select-db.xml
+++ b/reference/mysqli/mysqli/select-db.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 63b99082ef83eade08151f8cb528246fded81db9 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="mysqli.select-db" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -27,11 +27,11 @@
    デフォルトのデータベースを設定します。
   </para>
   <note>
-   <para>
+   <simpara>
     この関数は、接続のデフォルトデータベースを変更する際にのみ使用します。
     デフォルトデータベースは、<function>mysqli_connect</function> の
     4 番目の引数でも指定可能です。
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/mysqli/mysqli/sqlstate.xml
+++ b/reference/mysqli/mysqli/sqlstate.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d9de192baa45cdf33168eea8a45d14216def4395 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: takagi Status: ready -->
 <refentry xml:id="mysqli.sqlstate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>mysqli::$sqlstate</refname>
@@ -26,11 +26,11 @@
    を参照ください。
   </para>
   <note>
-   <para>
+   <simpara>
     すべての MySQL エラーが SQLSTATE に対応しているわけではないことに
     注意してください。そのようなエラーが発生した場合は、
     <literal>HY000</literal>（一般的なエラー）が返されます。
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/mysqli/mysqli/use-result.xml
+++ b/reference/mysqli/mysqli/use-result.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 63b99082ef83eade08151f8cb528246fded81db9 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="mysqli.use-result" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -31,7 +31,7 @@
    関数をコールしなければ、データベース接続上の次のクエリは失敗します。
   </para>
   <note>
-   <para>
+   <simpara>
     <function>mysqli_use_result</function> は、データベースから結果セットの
     全体を転送するわけではありません。そのため、セット内の行を移動するために
     <function>mysqli_data_seek</function> を使用することはできません。
@@ -41,7 +41,7 @@
     使用すべきではありません。なぜなら、この関数はサーバーとの接続を保持
     し続け、取得しているデータに関連するテーブルについて、他のスレッドから
     更新ができなくなるからです。
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/mysqli/mysqli_driver.xml
+++ b/reference/mysqli/mysqli_driver.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa,mumumu -->
 <reference xml:id="class.mysqli-driver" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>mysqli_driver クラス</title>
@@ -11,10 +11,10 @@
 <!-- {{{ ClassName intro -->
   <section xml:id="mysqli-driver.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     <classname>mysqli_driver</classname> クラスは、monostate パターンのインスタンスです。
     つまり、任意の数の <classname>mysqli_driver</classname> インスタンスからアクセスできるドライバはたったひとつということです。
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
  

--- a/reference/mysqli/mysqli_result/fetch-fields.xml
+++ b/reference/mysqli/mysqli_result/fetch-fields.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 5152c78db935ea2463e20a01ae0e3f3573314d78 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: mumumu Status: ready -->
 <refentry xml:id="mysqli-result.fetch-fields" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mysqli_result::fetch_fields</refname>

--- a/reference/mysqli/mysqli_result/fetch-object.xml
+++ b/reference/mysqli/mysqli_result/fetch-object.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c5ccd084c8f830801a939bf1829ddddcaf019730 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: takagi Status: ready -->
 <!-- CREDITS: shimooka,mumumu -->
 <refentry xml:id="mysqli-result.fetch-object" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -87,11 +87,11 @@
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    <parameter>constructor_args</parameter> が空でないのに、
    そのクラスがコンストラクタを持たない場合、
    <classname>ValueError</classname> がスローされます。
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/mysqli/mysqli_result/num-rows.xml
+++ b/reference/mysqli/mysqli_result/num-rows.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 181e9c5572ed04ed712b8d7f858f61a94647c6ac Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: takagi Status: ready -->
 <refentry xml:id="mysqli-result.num-rows" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mysqli_result::$num_rows</refname>
@@ -96,12 +96,12 @@ Result set has 239 rows.
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     <function>mysqli_stmt_num_rows</function> と異なり、
     この関数にはオブジェクト指向のメソッドがありません。
     オブジェクト指向のやり方の場合、getter のプロパティ
     (mysqli_result::$num_rows) を使って下さい。
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/mysqli/mysqli_sql_exception/getsqlstate.xml
+++ b/reference/mysqli/mysqli_sql_exception/getsqlstate.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 035c126c0393fe154bac46e2c3c489ebadce48a5 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: mumumu Status: ready -->
 <refentry xml:id="mysqli-sql-exception.getsqlstate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>mysqli_sql_exception::getSqlState</refname>
@@ -23,12 +23,12 @@
    を参照ください。
   </para>
   <note>
-   <para>
+   <simpara>
     すべての MySQL で発生するエラーが、
     SQLSTATE エラーコードに対応しているわけではありません。
     対応していないエラーコードについては、
     <literal>HY000</literal> (一般エラー) が使われます。
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/mysqli/mysqli_stmt/affected-rows.xml
+++ b/reference/mysqli/mysqli_stmt/affected-rows.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 2d5c6bed30ea22d847bf03dad1072f075694b4c3 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="mysqli-stmt.affected-rows" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -18,15 +18,15 @@
    <type class="union"><type>int</type><type>string</type></type><methodname>mysqli_stmt_affected_rows</methodname>
    <methodparam><type>mysqli_stmt</type><parameter>statement</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    <literal>INSERT</literal>、
    <literal>UPDATE</literal> あるいは <literal>DELETE</literal>
    クエリによって変更された行の数を返します。
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    SELECT クエリに対しては、
    <function>mysqli_stmt_num_rows</function> 関数と同じように動作します。
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -51,10 +51,10 @@
    <function>mysqli_stmt_affected_rows</function> がコールされたことを示します。
   </para>
   <note>
-   <para>
+   <simpara>
     変更された行の数が PHP の int 型の最大値をこえる場合は、変更された
     行の数は文字列として返されます。
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/mysqli/mysqli_stmt/bind-result.xml
+++ b/reference/mysqli/mysqli_stmt/bind-result.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 2e61d37d1d91ec32ecadf2a872e0a4109d02bc68 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="mysqli-stmt.bind-result" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -55,12 +55,12 @@
    </para>
   </note>
   <tip>
-   <para>
+   <simpara>
     この関数は、結果が単一の値の場合に役立つものです。
     反復可能な結果セットを取得したり、
     行をオブジェクトや配列で取得したい場合は、
     <function>mysqli_stmt_get_result</function> を使って下さい。
-   </para>
+   </simpara>
   </tip>
  </refsect1>
 

--- a/reference/mysqli/mysqli_stmt/execute.xml
+++ b/reference/mysqli/mysqli_stmt/execute.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ec946465e5ee9dc4dc19f1a28510697066a19eac Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="mysqli-stmt.execute" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/mysqli/mysqli_stmt/reset.xml
+++ b/reference/mysqli/mysqli_stmt/reset.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 035c126c0393fe154bac46e2c3c489ebadce48a5 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="mysqli-stmt.reset" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -21,9 +21,9 @@
    <type>bool</type><methodname>mysqli_stmt_reset</methodname>
    <methodparam><type>mysqli_stmt</type><parameter>statement</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    クライアントおよびサーバーで、実行後のプリペアドステートメントをリセットします。
-  </para>
+  </simpara>
   <para>
    サーバー上のステートメント、<function>mysqli_stmt_send_long_data</function>
    で送信したデータ、バッファリングされていない結果、そして現在のエラーをリセットします。

--- a/reference/mysqli/mysqli_stmt/send-long-data.xml
+++ b/reference/mysqli/mysqli_stmt/send-long-data.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 035c126c0393fe154bac46e2c3c489ebadce48a5 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="mysqli-stmt.send-long-data" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -24,13 +24,13 @@
    <methodparam><type>int</type><parameter>param_num</parameter></methodparam>
    <methodparam><type>string</type><parameter>data</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    パラメータのデータを、サーバーに分割して送信します。例えば blob のサイズが
    <literal>max_allowed_packet</literal> を越えてしまう場合などに使用します。
    この関数は、カラムに文字やバイナリのデータを送信するために複数回
    コールすることが可能です。そのカラムの型は TEXT あるいは BLOB である
    必要があります。
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/mysqli/mysqli_stmt/sqlstate.xml
+++ b/reference/mysqli/mysqli_stmt/sqlstate.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d68e83b719028bb068785cccc3205c23be530564 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: takagi Status: ready -->
 <refentry xml:id="mysqli-stmt.sqlstate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>mysqli_stmt::$sqlstate</refname>
@@ -137,11 +137,11 @@ Error: 42S02.
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     すべての MySQL エラーが SQLSTATE に対応しているわけではないことに
     注意してください。そのようなエラーが発生した場合は、
     <literal>HY000</literal>（一般的なエラー）が返されます。
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/mysqli/overview.xml
+++ b/reference/mysqli/overview.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e8ac70bf549a723cb36465667a6109d9933b8619 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: mumumu Status: ready -->
 <chapter xml:id="mysqli.overview" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
 
   <title>mysqli の概要</title>
@@ -49,9 +49,9 @@
     例を挙げると、データベース抽象化レイヤーの <link linkend="mysqli.overview.pdo">PHP Data Objects (PDO)</link> は各データベース専用のドライバの中からひとつを選んで使います。 数あるドライバの中のひとつに PDO MYSQL ドライバがあり、 これが MySQL サーバーとのインターフェイスとなります。 
   </para>
 
-  <para>
+  <simpara>
     人によっては、コネクタとドライバを混同して使うこともあって、 混乱の元となります。 MySQL 関連のドキュメントでは、<quote>ドライバ</quote> という用語は、 コネクタパッケージのうち、 データベース固有の機能を提供するソフトウェアという意味で 予約されています。 
-  </para>
+  </simpara>
 
   <para>
     <emphasis role="bold">拡張モジュールとは?</emphasis>
@@ -275,7 +275,7 @@
     MySQL Native ドライバ、<literal>mysqlnd</literal> が開発されたのです。
   </para>
 
-  <para>
+  <simpara>
     <literal>mysqli</literal> 拡張モジュール
     と PDO MySQL ドライバはそれぞれ、
     <literal>libmysqlclient</literal> や
@@ -285,7 +285,7 @@
     <literal>libmysqlclient</literal> と比較して、
     大幅な省メモリ化や高速化が実現されています。
     これらの改善を利用することを強くお勧めします。
-  </para>
+  </simpara>
 
   <para>
     MySQL Native ドライバ は、

--- a/reference/pdo/configure.xml
+++ b/reference/pdo/configure.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 78cd8f0ba32f4d9921bb8b7eca066de8de29924d Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: takagi Status: ready -->
 <!-- CREDITS: shimooka -->
 <section xml:id="pdo.installation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.install;
@@ -11,13 +11,13 @@
  <procedure xml:id="pdo.install.unix51up">
   <title>Unix システムへの PDO のインストール</title>
   <step>
-   <para>
+   <simpara>
     PDO および <link linkend="ref.pdo-sqlite">PDO_SQLITE</link>
     ドライバは、デフォルトで有効となっています。
     必要に応じて、使用するデータベース用の PDO ドライバを有効にすることができます。
     <link linkend="pdo.drivers">データベースごとの PDO ドライバについてのドキュメント</link>
     を参照ください。
-   </para>
+   </simpara>
    <note>
     <para>
      PDO を共有モジュールとしてビルドする場合 (<emphasis>非推奨です</emphasis>)、

--- a/reference/pdo/connections.xml
+++ b/reference/pdo/connections.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e7e4ffe9a10a4dcd9903a7abf125a811d0eda023 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa,shimooka,mumumu -->
 
 <chapter xml:id="pdo.connections" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -119,14 +119,14 @@ $dbh = new PDO('mysql:host=localhost;dbname=test', $user, $pass, array(
    </programlisting>
   </example>
  </para>
- <para>
+ <simpara>
   <constant>PDO::ATTR_PERSISTENT</constant> オプションの値は、
   数値でない &string; の値が設定されない限り、(持続的な接続が有効/無効かを示す)
   &boolean; に変換されます。
   数値でない &string; を設定する場合、複数の接続プールを使うことができます。
   これは互換性がない異なる接続設定を使う場合に便利です。たとえば、
   異なる <constant>PDO::MYSQL_ATTR_USE_BUFFERED_QUERY</constant> の値を設定する場合が挙げられます。
- </para>
+ </simpara>
  <note>
   <para>
    持続的な接続を使用したい場合は、ドライバのオプションを表す配列に

--- a/reference/pdo/ini.xml
+++ b/reference/pdo/ini.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: eae19eb5fe0f5bebcbce382ea7a505cedeb5a883 Maintainer: shimooka Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: shimooka Status: ready -->
 <section xml:id="pdo.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;
  &extension.runtime;

--- a/reference/pdo/pdo/connect.xml
+++ b/reference/pdo/pdo/connect.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: KentarouTakeda Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: KentarouTakeda Status: ready -->
 <!-- CREDITS: KentarouTakeda -->
 <refentry xml:id="pdo.connect" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>

--- a/reference/pdo/pdo/errorcode.xml
+++ b/reference/pdo/pdo/errorcode.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 661e6858acade9f5a08fc8f9c07b605f42f4a700 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: takagi Status: ready -->
 <!-- CREDITS: shimooka,mumumu -->
 <refentry xml:id="pdo.errorcode" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -25,7 +25,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    SQLSTATE を返します。これは、ANSI SQL-92 標準で定義された英数 5
    文字の ID です。簡潔に言えば、SQLSTATE は 2文字のクラス値の後に
    3 文字のサブクラス値が続きます。クラス値 01 はワーニングを表し、
@@ -35,7 +35,7 @@
    ODBC かも知れません) に由来するワーニングやエラーに固有の値です。
    あらゆるクラスでのサブクラス値 '000' は SQLSTATE
    に対するサブクラスがない事を示しています。
-  </para>
+  </simpara>
   <para>
    <methodname>PDO::errorCode</methodname> はデータベースハンドラに
    直接行った操作に対するエラーコードのみを取得します。

--- a/reference/pdo/pdo/errorinfo.xml
+++ b/reference/pdo/pdo/errorinfo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 661e6858acade9f5a08fc8f9c07b605f42f4a700 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: takagi Status: ready -->
 <!-- CREDITS: shimooka,mumumu -->
 <refentry xml:id="pdo.errorinfo" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/pdo/pdo/getavailabledrivers.xml
+++ b/reference/pdo/pdo/getavailabledrivers.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 661e6858acade9f5a08fc8f9c07b605f42f4a700 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: takagi Status: ready -->
 <!-- CREDITS: shimooka,mumumu -->
 <refentry xml:id="pdo.getavailabledrivers" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/pdo/pdo/prepare.xml
+++ b/reference/pdo/pdo/prepare.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: takagi Status: ready -->
 <!-- CREDITS: shimooka,mumumu -->
 <refentry xml:id="pdo.prepare" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -37,12 +37,12 @@
    複数使用することはできません。
   </para>
   <note>
-   <para>
+   <simpara>
     パラメータマーカーが表せるのは、データリテラルだけです。
     リテラルの一部やキーワード、識別子、その他のクエリのパーツをパラメータにバインドすることはできません。
     たとえば、SQL 文の IN() 句などで、
     ひとつのパラメータに複数の値を割り当てることはできません。
-   </para>
+   </simpara>
   </note>
   <para>
    異なるパラメータを用いて複数回実行されるような文に対し
@@ -126,10 +126,10 @@
    (<link linkend="pdo.error-handling">エラー処理</link> の方法に依存します)。
   </para>
   <note>
-   <para>
+   <simpara>
     プリペアドステートメントをエミュレートする際にデータベースサーバーとの通信は行いません。
     したがって <methodname>PDO::prepare</methodname> はステートメントのチェックを行いません。
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/pdo/pdo/quote.xml
+++ b/reference/pdo/pdo/quote.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c142be811735a5542c8a2e4c4ed2f81e8cc3acc6 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: takagi Status: ready -->
 <!-- CREDITS: shimooka -->
 <refentry xml:id="pdo.quote" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -35,11 +35,11 @@
    しばしばより高速で、サーバーやクライアント側でコンパイル済みの形式でクエリを
    キャッシュする事が可能です。
   </para>
-  <para>
+  <simpara>
    全ての PDO ドライバがこのメソッドを実装しているわけではありません
    (たとえば PDO_ODBC などの例があります)。
    代わりにプリペアドステートメントを使用することを検討してください。
-  </para>
+  </simpara>
   <caution>
    <title>セキュリティ: デフォルトの文字セット</title>
    <para>
@@ -59,20 +59,20 @@
     <varlistentry>
      <term><parameter>string</parameter></term>
       <listitem>
-       <para>
+       <simpara>
         クオートされる文字列を指定します。
-       </para>
+       </simpara>
       </listitem>
      </varlistentry>
     <varlistentry>
      <term><parameter>type</parameter></term>
       <listitem>
-       <para>
+       <simpara>
         クオートするスタイルを変更するため、
         ドライバにデータ型のヒントを提供します。
         たとえば <constant>PDO_PARAM_LOB</constant> は、
         ドライバにバイナリデータをエスケープするように伝えます。
-       </para>
+       </simpara>
       </listitem>
      </varlistentry>
    </variablelist>
@@ -80,11 +80,11 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    理論上安全なクオートされた SQL ステートメントの文字列を返します。
    ドライバがこの方法での引用符付けをサポートしていない場合は
    &false; を返します。
-  </para>
+  </simpara>
  </refsect1>
 
 

--- a/reference/pdo/pdorow.xml
+++ b/reference/pdo/pdorow.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 812ed835faa11b611c112d2a16777aebf70eb020 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: mumumu Status: ready -->
 <reference xml:id="class.pdorow" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>PDORow クラス</title>
  <titleabbrev>PDORow</titleabbrev>
@@ -23,13 +23,13 @@
     <classname>PDORow</classname> オブジェクトは
     アクセスした結果セットに存在するカラム名に対応するプロパティを作成します。
    </para>
-   <para>
+   <simpara>
     <classname>PDORow</classname> は、
     <constant>PDO::FETCH_OBJ</constant> と <constant>PDO::FETCH_BOTH</constant>
     のモードを両方使ったかのように、返されるデータにアクセスできます。
     つまり、返されるデータはオブジェクトのプロパティのようにアクセスできますし、
     カラム名やカラムのオフセット番号でインデックスされた配列としてもアクセスできます。
-   </para>
+   </simpara>
    <para>
     プロパティが未定義の場合は、警告を発生させることなく &null; を返します。
    </para>

--- a/reference/pdo/pdostatement/debugdumpparams.xml
+++ b/reference/pdo/pdostatement/debugdumpparams.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 661e6858acade9f5a08fc8f9c07b605f42f4a700 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="pdostatement.debugdumpparams" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/pdo/pdostatement/errorinfo.xml
+++ b/reference/pdo/pdostatement/errorinfo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 661e6858acade9f5a08fc8f9c07b605f42f4a700 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: takagi Status: ready -->
 <!-- CREDITS: shimooka,mumumu -->
 <refentry xml:id="pdostatement.errorinfo" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/pdo/pdostatement/execute.xml
+++ b/reference/pdo/pdostatement/execute.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 216c5dc1ef01b98d6ccafe51056e4df68e77cbf6 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: takagi Status: ready -->
 <!-- CREDITS: shimooka,mumumu -->
 <refentry xml:id="pdostatement.execute" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -169,11 +169,11 @@ $sth->execute($params);
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     ドライバによっては、次のステートメントを実行する前に
     <link linkend="pdostatement.closecursor">カーソルを閉じ</link>
     なければならないものもあります。
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/pdo/pdostatement/fetch.xml
+++ b/reference/pdo/pdostatement/fetch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c142be811735a5542c8a2e4c4ed2f81e8cc3acc6 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa,mumumu -->
 <refentry xml:id="pdostatement.fetch" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -38,22 +38,22 @@
        デフォルトは <constant>PDO::ATTR_DEFAULT_FETCH_MODE</constant> の値
        (そのデフォルトは <constant>PDO::FETCH_BOTH</constant>) です。
        <itemizedlist>
-        <listitem><para>
+        <listitem><simpara>
          <literal>PDO::FETCH_ASSOC</literal>: は、結果セットに
          返された際のカラム名で添字を付けた配列を返します。
-        </para></listitem>
-        <listitem><para>
+        </simpara></listitem>
+        <listitem><simpara>
          <literal>PDO::FETCH_BOTH</literal> (デフォルト):
          結果セットに返された際のカラム名と
          0 で始まるカラム番号で添字を付けた配列を返します。
-        </para></listitem>
-        <listitem><para>
+        </simpara></listitem>
+        <listitem><simpara>
          <literal>PDO::FETCH_BOUND</literal>:
          &true; を返し、結果セットのカラムの値を
          <methodname>PDOStatement::bindColumn</methodname>
          メソッドでバインドされた PHP 変数に代入します。
-        </para></listitem>
-        <listitem><para>
+        </simpara></listitem>
+        <listitem><simpara>
          <literal>PDO::FETCH_CLASS</literal>:
          要求されたクラスの新規インスタンスを返します。
          結果セットのカラムをクラスのプロパティにマップしつつ、
@@ -73,38 +73,38 @@
          含まれている場合 (例: <literal>PDO::FETCH_CLASS |
          PDO::FETCH_CLASSTYPE</literal>) は、最初のカラムの値から
          クラス名を決定します。
-        </para></listitem>
-        <listitem><para>
+        </simpara></listitem>
+        <listitem><simpara>
          <literal>PDO::FETCH_INTO</literal>:
          結果セットのカラムがクラス内の名前付けされたプロパティに
          マッピングされている要求された既存インスタンスを更新します。
-        </para></listitem>
-        <listitem><para>
+        </simpara></listitem>
+        <listitem><simpara>
          <literal>PDO::FETCH_LAZY</literal>:
          <literal>PDO::FETCH_BOTH</literal> と<literal>PDO::FETCH_OBJ</literal>の
          組合せで、アクセスされるオブジェクトプロパティ名を作成する <classname>PDORow</classname> オブジェクトを返します。
-        </para></listitem>
-        <listitem><para>
+        </simpara></listitem>
+        <listitem><simpara>
          <literal>PDO::FETCH_NAMED</literal>:
          <literal>PDO::FETCH_ASSOC</literal> と同じ形式の配列を返します。
          ただし、同じ名前のカラムが複数あった場合は、そのキーが指す値は、
          同じ名前のカラムのすべての値を含む配列になります。
-        </para></listitem>
-        <listitem><para>
+        </simpara></listitem>
+        <listitem><simpara>
          <literal>PDO::FETCH_NUM</literal>:
          結果セットに返された際の 0
          から始まるカラム番号を添字とする配列を返します。
-        </para></listitem>
-        <listitem><para>
+        </simpara></listitem>
+        <listitem><simpara>
          <literal>PDO::FETCH_OBJ</literal>:
          結果セットに返された際のカラム名と同名のプロパティを有する
          匿名のオブジェクトを返します。
-        </para></listitem>
-        <listitem><para>
+        </simpara></listitem>
+        <listitem><simpara>
          <literal>PDO::FETCH_PROPS_LATE</literal>:
          <literal>PDO::FETCH_CLASS</literal> とともに使用すると、
          まずクラスのコンストラクタを呼び出してから、カラムの値をプロパティに代入します。
-        </para></listitem>
+        </simpara></listitem>
        </itemizedlist>
       </para>
      </listitem>

--- a/reference/pdo/pdostatement/fetchall.xml
+++ b/reference/pdo/pdostatement/fetchall.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 44bcc82c7d1a0dea5578093833d3172c0c742f5a Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: takagi Status: ready -->
 <!-- CREDITS: shimooka,mumumu -->
 <refentry xml:id="pdostatement.fetchall" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/pdo/pdostatement/getattribute.xml
+++ b/reference/pdo/pdostatement/getattribute.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 661e6858acade9f5a08fc8f9c07b605f42f4a700 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: takagi Status: ready -->
 <!-- CREDITS: shimooka -->
 <refentry xml:id="pdostatement.getattribute" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -20,11 +20,11 @@
    文の属性を取得します。現時点で共通の属性は存在しませんが、
    ドライバ固有の属性のみ存在します。
    <itemizedlist>
-    <listitem><para><literal>PDO::ATTR_CURSOR_NAME</literal>
+    <listitem><simpara><literal>PDO::ATTR_CURSOR_NAME</literal>
      (Firebird と ODBC 固有):
      <literal>UPDATE ... WHERE CURRENT OF</literal>
      に対するカーソル名を取得する
-    </para></listitem>
+    </simpara></listitem>
    </itemizedlist>
    ドライバ固有の属性は、
    他のドライバでは使っては <emphasis>いけない</emphasis>

--- a/reference/pdo/pdostatement/rowcount.xml
+++ b/reference/pdo/pdostatement/rowcount.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: a5950d8ae47e8befb9fa5f774ddb96a860833ed5 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: takagi Status: ready -->
 <!-- CREDITS: shimooka,mumumu -->
 <refentry xml:id="pdostatement.rowcount" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -30,12 +30,12 @@
    これに頼ってはいけません。
   </para>
     <note>
-     <para>
+     <simpara>
       このメソッドは、PostgreSQL ドライバの場合かつ、
       ステートメント属性 <constant>PDO::ATTR_CURSOR</constant> 
       の設定が <constant>PDO::CURSOR_SCROLL</constant> の場合にだけ
       "0" (ゼロ)  を返します。
-     </para>
+     </simpara>
   </note>
  </refsect1>
 

--- a/reference/pdo/pdostatement/setattribute.xml
+++ b/reference/pdo/pdostatement/setattribute.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 661e6858acade9f5a08fc8f9c07b605f42f4a700 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: takagi Status: ready -->
 <!-- CREDITS: shimooka -->
 <refentry xml:id="pdostatement.setattribute" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -21,11 +21,11 @@
    文の属性を設定します。現時点で共通の属性は存在しませんが、
    ドライバ固有の属性のみ存在します。
    <itemizedlist>
-    <listitem><para><literal>PDO::ATTR_CURSOR_NAME</literal>
+    <listitem><simpara><literal>PDO::ATTR_CURSOR_NAME</literal>
      (Firebird と ODBC 固有):
      <literal>UPDATE ... WHERE CURRENT OF</literal>
      に対するカーソル名を取得する
-    </para></listitem>
+    </simpara></listitem>
    </itemizedlist>
    ドライバ固有の属性は、
    他のドライバでは使っては <emphasis>いけない</emphasis>


### PR DESCRIPTION
php/doc-en@1cc1b81 「Bulk PDO and mysqli grammar fixes」(php/doc-en#5712) への追随です。

原文側の変更は (a) 英文法・冠詞・タイポの修正と (b) `<para>` から `<simpara>` への変換で、(a) は訳文に影響しないため、ja 側の変更は (b) のミラーと EN-Revision の更新のみです。

| 内容 | 件数 |
|---|---|
| `<para>` から `<simpara>` へのミラーと EN-Revision の更新 | 32ファイル（49箇所） |
| EN-Revision の更新のみ | 13ファイル |

内訳: reference/mysqli 25件 / reference/pdo 18件 / appendices 2件

php/doc-en#5712 の対象のうち、訳文の変更を伴う以下の 7 ファイルは本 PR には含めていません。

- reference/pdo/constants.xml
- reference/mysqli/configure.xml
- reference/mysqli/ini.xml
- reference/mysqli/quickstart.xml
- reference/mysqli/summary.xml
- reference/mysqli/mysqli/poll.xml
- reference/mysqli/mysqli/stmt-init.xml
