### PR TITLE
doc-en と同期し strings の文法修正と opcache_invalidate() の説明の誤りを反映（11ファイル・2モジュール完訳）

### DIFF
--- a/reference/opcache/functions/opcache-invalidate.xml
+++ b/reference/opcache/functions/opcache-invalidate.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 87d6bb1bbd5f118f5b0cf0160438f06c0f91ea45 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 82cdc19b6292e0f840e6b22ca430105d9f0aa89e Maintainer: mumumu Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.opcache-invalidate">
  <refnamediv>
@@ -18,8 +18,7 @@
   <simpara>
    この関数は opcode キャッシュのうち、特定のスクリプトを無効にします。
    <parameter>force</parameter> パラメータが指定されていないか、 &false; の場合は、スクリプトの更新時刻が opcode キャッシュ時の更新時刻より新しい場合にだけ無効にします。
-   この関数は、インメモリキャッシュ の情報だけを無効にします。
-   ファイルキャッシュ の情報は無効にしません。
+   <link linkend="ini.opcache.file-cache">opcache.file_cache</link> ディレクティブが有効な場合は、対応するファイルキャッシュのエントリも無効にします。
   </simpara>
  </refsect1>
 

--- a/reference/strings/functions/crypt.xml
+++ b/reference/strings/functions/crypt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d76a7fe17dd2488e47d664a8ab38e161b13ac843 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 46efd980535e8de6f6639a0015d2ad1e4bfe9d00 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: shimooka,mumumu -->
 <refentry xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://docbook.org/ns/docbook" xml:id="function.crypt">
  <refnamediv>
@@ -41,13 +41,13 @@
    <function>password_hash</function> は <function>crypt</function> のシンプルなラッパーであり、既存のパスワードハッシュと互換性があります。
    <function>password_hash</function> を使うことを推奨します。
   </para>
-  <para>
+  <simpara>
    ハッシュ方式は、salt 引数によって決まります。
    salt を省略した場合は、標準の 2 文字 (DES) の salt を自動生成します。
    あるいは、MD5 crypt() が使えれば 12 文字 (MD5) の salt を自動生成します。
    PHP の定数 <constant>CRYPT_SALT_LENGTH</constant> には、
    ハッシュで使用できる salt の最大長が格納されています。
-  </para>
+  </simpara>
   <para>
    標準の DES ベースの場合、<function>crypt</function>
    は出力の最初の 2 文字を salt として使用します。また、

--- a/reference/strings/functions/get-html-translation-table.xml
+++ b/reference/strings/functions/get-html-translation-table.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: eabde0419cf90f596f60db00e31fcb6ebe41ac55 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 46efd980535e8de6f6639a0015d2ad1e4bfe9d00 Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa,shimooka,mumumu -->
 <refentry xml:id="function.get-html-translation-table" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -23,15 +23,15 @@
    において内部的に使用される変換テーブルを返します。
   </para>
   <note>
-   <para>
+   <simpara>
     特殊文字はいくつかの方法でエンコードすることができます。
     例えば、<literal>"</literal> は <literal>&amp;quot;</literal>,
-    <literal>&amp;#34;</literal> もしくは <literal>&amp;#x22</literal>
+    <literal>&amp;#34;</literal> もしくは <literal>&amp;#x22;</literal>
     としてエンコードすることができます。
     <function>get_html_translation_table</function> の返す値は、
     <function>htmlspecialchars</function> や
     <function>htmlentities</function> で使っている形式だけです。
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/strings/functions/localeconv.xml
+++ b/reference/strings/functions/localeconv.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 92367aee7c51055f62de8c85851ba57aaf3cce7c Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 46efd980535e8de6f6639a0015d2ad1e4bfe9d00 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: shimooka -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.localeconv">
  <refnamediv>
@@ -141,11 +141,11 @@
     </tgroup>
    </informaltable>
   </para>
-  <para>
+  <simpara>
    <literal>p_sign_posn</literal> や <literal>n_sign_posn</literal>
    は、フォーマッタオプションの文字列を含みます。それぞれの数字は
    上に一覧されている条件の 1 つを表します。
-  </para>
+  </simpara>
   <para>
    groupingフィールドには、グループ化する方法を表す数字を定義する配
    列が含まれます。例えば、nl_NL ロケール用の通貨 groupingフィールド

--- a/reference/strings/functions/quoted-printable-decode.xml
+++ b/reference/strings/functions/quoted-printable-decode.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 6330e4d73192c49a6867c6bbc3cbf09d63a1e36a Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 46efd980535e8de6f6639a0015d2ad1e4bfe9d00 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: shimooka -->
 <refentry xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://docbook.org/ns/docbook" xml:id="function.quoted-printable-decode">
  <refnamediv>
@@ -14,13 +14,13 @@
    <type>string</type><methodname>quoted_printable_decode</methodname>
    <methodparam><type>string</type><parameter>string</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    この関数は、quoted printable 文字列をデコードし、
    8 ビットバイナリ文字列を返します
    (<link xlink:href="&url.rfc;2821">RFC2821</link> の section 4.5.2
    ではなく <link xlink:href="&url.rfc;2045">RFC2045</link> の section 6.7
    によれば、付随するピリオドは行の開始から削除されません) 。
-  </para>
+  </simpara>
   <para>
    この関数は <function>imap_qprint</function> に似ていますが、
    動作に IMAP モジュールを必要としないという違いがあります。

--- a/reference/strings/functions/setlocale.xml
+++ b/reference/strings/functions/setlocale.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ec01a42be50e84f192c0b19fc6e9cf40a0f7ac31 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 46efd980535e8de6f6639a0015d2ad1e4bfe9d00 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: shimooka,mumumu -->
 <refentry xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://docbook.org/ns/docbook" xml:id="function.setlocale">
  <refnamediv>
@@ -26,7 +26,7 @@
    ロケール情報を設定します。
   </para>
   <warning>
-   <para>
+   <simpara>
     ロケール情報は、スレッド毎ではなくプロセス毎に維持されます。
     もし PHP を マルチスレッドサーバーAPI 上で動作させている場合、
     スクリプトを実行している間にロケールの設定が突然変わるのを
@@ -37,7 +37,7 @@
     を使用してプロセスワイドなロケールを変更する事により発生します。
     Windows では、PHP 7.0.5 以降、
     ロケール情報はスレッド単位で維持されるようになっています。
-   </para>
+   </simpara>
   </warning>
  </refsect1>
 

--- a/reference/strings/functions/str-repeat.xml
+++ b/reference/strings/functions/str-repeat.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e095023e408c8cb6378ae16bb6870343a3946919 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 46efd980535e8de6f6639a0015d2ad1e4bfe9d00 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: shimooka,mumumu -->
 <refentry xml:id="function.str-repeat" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -36,9 +36,9 @@
     <varlistentry>
      <term><parameter>times</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        <parameter>string</parameter> を繰り返す回数。
-      </para>
+      </simpara>
       <para>
        <parameter>times</parameter> は 0 以上でなければなりません。
        <parameter>times</parameter> が

--- a/reference/strings/functions/stripos.xml
+++ b/reference/strings/functions/stripos.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4b72b23513caa3a8bc520d459a0417defc7b3880 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 46efd980535e8de6f6639a0015d2ad1e4bfe9d00 Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa,mumumu -->
 <refentry xml:id="function.stripos" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -20,10 +20,10 @@
    文字列 <parameter>haystack</parameter> の中で
    <parameter>needle</parameter> が最初に現れる位置を探します。
   </para>
-  <para>
+  <simpara>
    <function>strpos</function> と異なり、<function>stripos</function>
    は大文字小文字を区別しません。
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/strings/functions/strncasecmp.xml
+++ b/reference/strings/functions/strncasecmp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9b68bf2b63200534e022bc65e800cae6c75abf26 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 46efd980535e8de6f6639a0015d2ad1e4bfe9d00 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: shimooka -->
 <refentry xml:id="function.strncasecmp" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -90,7 +90,7 @@
 $var1 = 'Hello John';
 $var2 = 'hello Doe';
 if (strncasecmp($var1, $var2, 5) === 0) {
-    echo 'First 5 characters of $var1 and $var2 are equals in a case-insensitive string comparison';
+    echo 'First 5 characters of $var1 and $var2 are equal in a case-insensitive string comparison';
 }
 ?>
 ]]>

--- a/reference/strings/functions/strpbrk.xml
+++ b/reference/strings/functions/strpbrk.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 45042fef652f1b4e904e809fcbfcf31f6c60670b Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 46efd980535e8de6f6639a0015d2ad1e4bfe9d00 Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="function.strpbrk" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -15,10 +15,10 @@
    <methodparam><type>string</type><parameter>string</parameter></methodparam>
    <methodparam><type>string</type><parameter>characters</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    <function>strpbrk</function> は、文字列 <parameter>string</parameter>
-   から <parameter>characters</parameter> を探します。
-  </para>
+   から <parameter>characters</parameter> に含まれる文字のいずれかを探します。
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/strings/functions/strripos.xml
+++ b/reference/strings/functions/strripos.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 95d05546430b9e5db225dd42a0d285b870f0da42 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 46efd980535e8de6f6639a0015d2ad1e4bfe9d00 Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="function.strripos" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -20,10 +20,10 @@
    文字列 <parameter>haystack</parameter> の中で、
    <parameter>needle</parameter> が最後に現れる位置を探します。
   </para>
-  <para>
+  <simpara>
    <function>strrpos</function> と異なり、<function>strripos</function>
    は大文字小文字を区別しません。
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">


### PR DESCRIPTION
## 概要

doc-en の 2 件への追従。

- php/doc-en#5726 — strings 関数の英文の文法修正と `<para>` → `<simpara>` 化
- php/doc-en#5723 — `opcache_invalidate()` の説明の誤りの修正

## strings（10件）— php/doc-en#5726

大半は `<para>` → `<simpara>` のミラーで、訳文は変更していない。原文の記述が変わったのは 2 件。

- `functions/strpbrk.xml` — 原文の "for a `characters`"（`characters` そのものを探す）が誤りで、
  "for any of the characters in `characters`" に修正された。既訳も同じ誤りを引き継いでいたので追従した
- `functions/strncasecmp.xml` — コード例の出力文字列の文法修正（`are equals` → `are equal`）

対象ファイル:

- functions/{crypt,get-html-translation-table,localeconv,quoted-printable-decode,setlocale}.xml
- functions/{str-repeat,stripos,strncasecmp,strpbrk,strripos}.xml

## opcache（1件）— php/doc-en#5723

- `functions/opcache-invalidate.xml` — 「インメモリキャッシュのみを無効化し、ファイルキャッシュは
  無効化しない」という記述が誤りで、`opcache.file_cache` が有効なら対応するファイルキャッシュの
  エントリも無効化される、に修正された

## その他

- `functions/get-html-translation-table.xml` は原文の `&#x22` のセミコロン欠落修正にも追従した。
- php/doc-en#5726 は 11 ファイルを変更しているが、`functions/ltrim.xml` は #424 で取り込み済み。

---

このマージにより strings（110件）と opcache（14件）が完訳になります。
