### PR TITLE
機械的なマークアップ変更を一括同期

### DIFF
--- a/language/predefined/argumentcounterror.xml
+++ b/language/predefined/argumentcounterror.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: iwamot Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: iwamot Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.argumentcounterror" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>ArgumentCountError</title>

--- a/language/predefined/argumentcounterror.xml
+++ b/language/predefined/argumentcounterror.xml
@@ -14,9 +14,9 @@
     <ooclass><classname>ArgumentCountError</classname></ooclass> は、
     ユーザー定義の関数あるいはメソッドに渡された引数が少なすぎる場合にスローされます。
    </para>
-   <para>
+   <simpara>
     可変長引数でない組み込み関数に、多過ぎる引数を渡した場合にもスローされます。
-   </para>
+   </simpara>
   </section>
  
   <section xml:id="argumentcounterror.synopsis">

--- a/language/predefined/backedenum.xml
+++ b/language/predefined/backedenum.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9eb4a46bba05da229be4c8f7a3cb64702e1a2f95 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
 <reference xml:id="class.backedenum" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>BackedEnum インターフェイス</title>
  <titleabbrev>BackedEnum</titleabbrev>

--- a/language/predefined/backedenum.xml
+++ b/language/predefined/backedenum.xml
@@ -9,14 +9,14 @@
 
   <section xml:id="backedenum.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     <classname>BackedEnum</classname> インターフェイスは、
     Backed Enum を定義すると、PHP のエンジンが自動的に適用します。
     ユーザー定義のクラスとして実装してはいけません。
     列挙型はメソッドのオーバーライドを禁止しています。
     デフォルトの実装は PHP のエンジンから提供されるからです。
     このインターフェイスは、型チェックのためだけに存在しています。
-   </para>
+   </simpara>
   </section>
 
   <section xml:id="backedenum.synopsis">

--- a/language/predefined/backedenum/from.xml
+++ b/language/predefined/backedenum/from.xml
@@ -18,7 +18,7 @@
    文字列型や整数型の値を、存在する場合に
    列挙型の case に変換します。
    マッチする case が定義されていない場合は、
-   <classname>ValueError</classname>
+   <exceptionname>ValueError</exceptionname>
    がスローされます。
   </para>
 

--- a/language/predefined/closure.xml
+++ b/language/predefined/closure.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: a97672ab04d97f510faee2abe8d961014f77f96d Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <reference xml:id="class.closure" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/language/predefined/closure.xml
+++ b/language/predefined/closure.xml
@@ -11,23 +11,23 @@
 
   <section xml:id="closure.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     <link linkend="functions.anonymous">無名関数</link> を表すために使うクラスです。
-   </para>
+   </simpara>
 
-   <para>
+   <simpara>
     無名関数は、Closure 型のオブジェクトを生成します。
     このクラスにはメソッドが用意され、
     生成した無名関数をさらにコントロールできるようになっています。
-   </para>
+   </simpara>
 
-   <para>
+   <simpara>
     ここであげたメソッド以外にも、このクラスには
     <literal>__invoke</literal> メソッドが存在します。
     これは、<link linkend="language.oop5.magic.invoke">マジックメソッド __invoke()</link>
     を実装した他のクラスとの一貫性を保つためのものであり、
     関数をコールするときにこのメソッドは使われません。
-   </para>
+   </simpara>
 
   </section>
 

--- a/language/predefined/closure/bindto.xml
+++ b/language/predefined/closure/bindto.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 80720e59fc88b2522fe2e119b0148caaaa214b0b Maintainer: takagi Status: ready -->
+<!-- EN-Revision: c62ef37e0d58067b393a6cf3a14aefed90bc0bff Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 
 <refentry xml:id="closure.bindto" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/language/predefined/closure/bindto.xml
+++ b/language/predefined/closure/bindto.xml
@@ -18,39 +18,39 @@
    <methodparam><type class="union"><type>object</type><type>null</type></type><parameter>newThis</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>object</type><type>string</type><type>null</type></type><parameter>newScope</parameter><initializer>"static"</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    自身と同じ本体とバインド変数を持つ新しい <link linkend="functions.anonymous">無名関数</link>
    を作って返します。しかし、バインドするオブジェクトは変わって新しいクラスのスコープとなります。
-  </para>
+  </simpara>
 
-  <para>
+  <simpara>
    “バインドするオブジェクト” によって、<literal>$this</literal>
    が関数本体で持つ値が決まり、“クラスのスコープ”
    は、無名関数からどのクラスの private メンバーや protected メンバーにアクセスできるのかが決まります。
    すなわち、無名関数から見えるメンバーは、
    その無名関数が <parameter>newScope</parameter>
    クラスのメソッドであった場合と同じものになります。
-  </para>
+  </simpara>
 
-  <para>
+  <simpara>
    static なクロージャは何もオブジェクトをバインドできません
    (<parameter>newThis</parameter> の値は &null; でなければなりません) が、
    それでもこのメソッドを使ってクラスのスコープを変えることができます。
-  </para>
+  </simpara>
 
-  <para>
+  <simpara>
    このメソッドが static でないクロージャに関して保証するのは、
    バインドされたインスタンスを持っていればスコープ内にあるということです。
    また、その逆も成り立ちます。そのため、static でないクロージャにスコープとして
    &null; インスタンスを渡すとそれはstaticとなり、staticでなくスコープにもないクロージャに
    &null; でないインスタンスを渡すと、特定されていない何らかのクラスのスコープに入ります。
-  </para>
+  </simpara>
 
   <note>
-   <para>
+   <simpara>
     単に無名関数を複製したいだけの場合は、
     <link linkend="language.oop5.cloning">cloning</link> を使うこともできます。
-   </para>
+   </simpara>
   </note>
 
  </refsect1>
@@ -61,22 +61,22 @@
    <varlistentry>
     <term><parameter>newThis</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       指定した無名関数をバインドするオブジェクト。クロージャのバインドを解除するには
       &null; を指定します。
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>newScope</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       クロージャを関連づけるクラススコープ、あるいは 'static' で現在のスコープを維持します。
       オブジェクトを渡した場合は、そのオブジェクトの型をその代わりに使います。
       これは、バインドしたオブジェクトの protected メソッドや private
       メソッドのアクセス権を決めます。
       内部クラス (のオブジェクト) を をパラメータとして渡すことはできません。
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -84,10 +84,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    新しい <classname>Closure</classname> オブジェクトを返します。
    失敗した場合に &null; を返します。
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/language/predefined/closure/construct.xml
+++ b/language/predefined/closure/construct.xml
@@ -15,12 +15,12 @@
    <modifier>private</modifier> <methodname>Closure::__construct</methodname>
    <void/>
   </constructorsynopsis>
-  <para>
+  <simpara>
     このメソッドは、
     <classname>Closure</classname> クラスのインスタンスを作れないようにするために存在します。
     このクラスのオブジェクトを作るには、
     <link linkend="functions.anonymous">無名関数</link> のページに書かれている手順を使います。
-  </para>
+  </simpara>
 
  </refsect1>
 

--- a/language/predefined/closure/construct.xml
+++ b/language/predefined/closure/construct.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9c74079f12d67cabb52c124d761f48275417d7eb Maintainer: takagi Status: ready -->
+<!-- EN-Revision: c62ef37e0d58067b393a6cf3a14aefed90bc0bff Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 
 <refentry xml:id="closure.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/language/predefined/closure/fromcallable.xml
+++ b/language/predefined/closure/fromcallable.xml
@@ -19,8 +19,8 @@
    現在のスコープを用いて、指定された <parameter>callback</parameter> から新しい
    <link linkend="functions.anonymous">無名関数</link> を作って返します。
    このメソッドは、現在のスコープで <parameter>callback</parameter>
-   が呼び出し可能かどうかをチェックし、可能でなければ <classname>TypeError
-   </classname> をスローします。
+   が呼び出し可能かどうかをチェックし、可能でなければ <exceptionname>TypeError
+   </exceptionname> をスローします。
   </para>
   <note>
    <para>
@@ -48,7 +48,7 @@
   <para>
    新しく作られた <classname>Closure</classname> を返します。
    <parameter>callback</parameter> が現在のスコープで呼び出し可能でなければ、
-   <classname>TypeError</classname> をスローします。
+   <exceptionname>TypeError</exceptionname> をスローします。
   </para>
  </refsect1>
 

--- a/language/predefined/closure/getcurrent.xml
+++ b/language/predefined/closure/getcurrent.xml
@@ -41,7 +41,7 @@
   &reftitle.errors;
   <simpara>
    クロージャのコンテキスト外から呼び出された場合、
-   <classname>Error</classname> をスローします。
+   <exceptionname>Error</exceptionname> をスローします。
   </simpara>
  </refsect1>
 

--- a/language/predefined/closure/getcurrent.xml
+++ b/language/predefined/closure/getcurrent.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 31e56c25f90ebedf9aa4aa4877fbc859e1e0529c Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: c62ef37e0d58067b393a6cf3a14aefed90bc0bff Maintainer: mumumu Status: ready -->
 <refentry xml:id="closure.getcurrent" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Closure::getCurrent</refname>

--- a/language/predefined/closure/getcurrent.xml
+++ b/language/predefined/closure/getcurrent.xml
@@ -13,16 +13,16 @@
    <modifier>public</modifier> <modifier>static</modifier> <type>Closure</type><methodname>Closure::getCurrent</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    現在実行中のクロージャを返します。このメソッドは主に、
    <literal>use</literal> キーワードを使ってクロージャ変数への参照をキャプチャすることなく、
    再帰的なクロージャを実装するのに役立ちます。
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    このメソッドはクロージャの内部から呼び出す必要があります。
    クロージャのコンテキスト外から呼び出すと、
    <literal>Error: Current function is not a closure.</literal> が発生します。
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -32,17 +32,17 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    現在実行中の <classname>Closure</classname> を返します。
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    クロージャのコンテキスト外から呼び出された場合、
    <classname>Error</classname> をスローします。
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
@@ -72,10 +72,10 @@ echo $fibonacci(10); // 出力: 55
   </example>
   <example xml:id="closure.getcurrent.example.comparison">
    <title>従来のアプローチとの比較</title>
-   <para>
+   <simpara>
     PHP 8.5 より前のバージョンでは、再帰的なクロージャを実装するには
     <literal>use</literal> キーワードを使ってクロージャ変数への参照をキャプチャする必要がありました:
-   </para>
+   </simpara>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/language/predefined/countable.xml
+++ b/language/predefined/countable.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 267a3d4e60d8a6da941e72d195386b5841052cca Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
 <reference xml:id="class.countable" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>Countable インターフェイス</title>

--- a/language/predefined/countable.xml
+++ b/language/predefined/countable.xml
@@ -10,10 +10,10 @@
 
   <section xml:id="countable.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     <classname>Countable</classname> を実装したクラスは、
     <function>count</function> 関数で使用することができます。
-   </para>
+   </simpara>
   </section>
 
   <section xml:id="countable.synopsis">

--- a/language/predefined/fiber.xml
+++ b/language/predefined/fiber.xml
@@ -10,11 +10,11 @@
 
   <section xml:id="fiber.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     ファイバー(Fiber) は 完全なスタックを持つ、停止可能な関数です。
     ファイバー はコールスタック中のどこからでも停止することができますし、
     後に再開されるまで実行を停止したままにできます。
-   </para>
+   </simpara>
   </section>
 
   <section xml:id="fiber.synopsis">
@@ -35,7 +35,7 @@
 
   <section xml:id="fiber.seealso">
    &reftitle.seealso;
-   <para><link linkend="language.fibers">ファイバーの概要</link></para>
+   <simpara><link linkend="language.fibers">ファイバーの概要</link></simpara>
   </section>
 
  </partintro>

--- a/language/predefined/fiber.xml
+++ b/language/predefined/fiber.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4b06b2d5c3a28a13504972df0f0be6deffabb4c5 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
 <reference xml:id="class.fiber" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude"
  annotations="non-interactive">
  <title>Fiber クラス</title>

--- a/language/predefined/fiber/getcurrent.xml
+++ b/language/predefined/fiber/getcurrent.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 8fee3ae9715ffa15922469eb7d98f4878917a6ee Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: c62ef37e0d58067b393a6cf3a14aefed90bc0bff Maintainer: mumumu Status: ready -->
 <refentry xml:id="fiber.getcurrent" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Fiber::getCurrent</refname>

--- a/language/predefined/fiber/getcurrent.xml
+++ b/language/predefined/fiber/getcurrent.xml
@@ -13,8 +13,8 @@
    <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>Fiber</type><type>null</type></type><methodname>Fiber::getCurrent</methodname>
    <void/>
   </methodsynopsis>
-  <para>
-  </para>
+  <simpara>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -24,10 +24,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    現在実行中の <classname>Fiber</classname> のインスタンスを返します。
    このメソッドがファイバーの外から実行された場合は &null; を返します。
-  </para>
+  </simpara>
  </refsect1>
 
 </refentry>

--- a/language/predefined/fiber/getreturn.xml
+++ b/language/predefined/fiber/getreturn.xml
@@ -30,7 +30,7 @@
    ファイバーが値を返さなかった場合、
    ファイバーそのものが開始されていないか、
    終了していないか、例外をスローしている場合で、
-   それらの場合は <classname>FiberError</classname> がスローされます。
+   それらの場合は <exceptionname>FiberError</exceptionname> がスローされます。
   </para>
  </refsect1>
 

--- a/language/predefined/fiber/isrunning.xml
+++ b/language/predefined/fiber/isrunning.xml
@@ -13,8 +13,8 @@
    <modifier>public</modifier> <type>bool</type><methodname>Fiber::isRunning</methodname>
    <void/>
   </methodsynopsis>
-  <para>
-  </para>
+  <simpara>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/language/predefined/fiber/isrunning.xml
+++ b/language/predefined/fiber/isrunning.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: c62ef37e0d58067b393a6cf3a14aefed90bc0bff Maintainer: mumumu Status: ready -->
 <refentry xml:id="fiber.isrunning" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Fiber::isRunning</refname>

--- a/language/predefined/fiber/isstarted.xml
+++ b/language/predefined/fiber/isstarted.xml
@@ -13,8 +13,8 @@
    <modifier>public</modifier> <type>bool</type><methodname>Fiber::isStarted</methodname>
    <void/>
   </methodsynopsis>
-  <para>
-  </para>
+  <simpara>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -24,11 +24,11 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    ファイバーが既に開始した後にのみ、
    &true; を返します。
    そうでない場合、&false; を返します。
-  </para>
+  </simpara>
  </refsect1>
 
 </refentry>

--- a/language/predefined/fiber/isstarted.xml
+++ b/language/predefined/fiber/isstarted.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 8fee3ae9715ffa15922469eb7d98f4878917a6ee Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: c62ef37e0d58067b393a6cf3a14aefed90bc0bff Maintainer: mumumu Status: ready -->
 <refentry xml:id="fiber.isstarted" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Fiber::isStarted</refname>

--- a/language/predefined/fiber/issuspended.xml
+++ b/language/predefined/fiber/issuspended.xml
@@ -13,8 +13,8 @@
    <modifier>public</modifier> <type>bool</type><methodname>Fiber::isSuspended</methodname>
    <void/>
   </methodsynopsis>
-  <para>
-  </para>
+  <simpara>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -24,10 +24,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    ファイバーが現在停止中の場合に &true; を返します。
    そうでない場合、&false; を返します。
-  </para>
+  </simpara>
  </refsect1>
 
 </refentry>

--- a/language/predefined/fiber/issuspended.xml
+++ b/language/predefined/fiber/issuspended.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 8fee3ae9715ffa15922469eb7d98f4878917a6ee Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: c62ef37e0d58067b393a6cf3a14aefed90bc0bff Maintainer: mumumu Status: ready -->
 <refentry xml:id="fiber.issuspended" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Fiber::isSuspended</refname>

--- a/language/predefined/fiber/isterminated.xml
+++ b/language/predefined/fiber/isterminated.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 8fee3ae9715ffa15922469eb7d98f4878917a6ee Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: c62ef37e0d58067b393a6cf3a14aefed90bc0bff Maintainer: mumumu Status: ready -->
 <refentry xml:id="fiber.isterminated" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Fiber::isTerminated</refname>

--- a/language/predefined/fiber/isterminated.xml
+++ b/language/predefined/fiber/isterminated.xml
@@ -13,8 +13,8 @@
    <modifier>public</modifier> <type>bool</type><methodname>Fiber::isTerminated</methodname>
    <void/>
   </methodsynopsis>
-  <para>
-  </para>
+  <simpara>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -24,11 +24,11 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    ファイバーが終了した後にのみ、&true; を返します。
    値を返したか、例外をスローした場合のいずれかに限ります。
    そうでない場合、&false; を返します。
-  </para>
+  </simpara>
  </refsect1>
 
 </refentry>

--- a/language/predefined/fiber/resume.xml
+++ b/language/predefined/fiber/resume.xml
@@ -20,7 +20,7 @@
   </para>
   <simpara>
    このメソッドがコールされた時点で ファイバーが停止していない場合、
-   <classname>FiberError</classname> がスローされます。
+   <exceptionname>FiberError</exceptionname> がスローされます。
   </simpara>
  </refsect1>
 

--- a/language/predefined/fiber/resume.xml
+++ b/language/predefined/fiber/resume.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 8fee3ae9715ffa15922469eb7d98f4878917a6ee Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: c62ef37e0d58067b393a6cf3a14aefed90bc0bff Maintainer: mumumu Status: ready -->
 <refentry xml:id="fiber.resume" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Fiber::resume</refname>

--- a/language/predefined/fiber/resume.xml
+++ b/language/predefined/fiber/resume.xml
@@ -18,10 +18,10 @@
    <methodname>Fiber::suspend</methodname>
    の呼び出し結果として、指定した値を渡すことでファイバーを再開します。
   </para>
-  <para>
+  <simpara>
    このメソッドがコールされた時点で ファイバーが停止していない場合、
    <classname>FiberError</classname> がスローされます。
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/language/predefined/fiber/start.xml
+++ b/language/predefined/fiber/start.xml
@@ -13,13 +13,13 @@
    <modifier>public</modifier> <type>mixed</type><methodname>Fiber::start</methodname>
    <methodparam rep="repeat"><type>mixed</type><parameter>args</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    ファイバーを構築する際に使われる callable に対して、可変長引数を指定します。
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    このメソッドをコールした時点で ファイバーが既に開始されている場合、
    <classname>FiberError</classname> がスローされます。
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -28,10 +28,10 @@
    <varlistentry>
     <term><parameter>args</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       ファイバーのコンストラクタに指定する callable を呼び出す際に、
       使用する引数。
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>

--- a/language/predefined/fiber/start.xml
+++ b/language/predefined/fiber/start.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 8fee3ae9715ffa15922469eb7d98f4878917a6ee Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: c62ef37e0d58067b393a6cf3a14aefed90bc0bff Maintainer: mumumu Status: ready -->
 <refentry xml:id="fiber.start" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Fiber::start</refname>

--- a/language/predefined/fiber/start.xml
+++ b/language/predefined/fiber/start.xml
@@ -18,7 +18,7 @@
   </simpara>
   <simpara>
    このメソッドをコールした時点で ファイバーが既に開始されている場合、
-   <classname>FiberError</classname> がスローされます。
+   <exceptionname>FiberError</exceptionname> がスローされます。
   </simpara>
  </refsect1>
 

--- a/language/predefined/fiber/suspend.xml
+++ b/language/predefined/fiber/suspend.xml
@@ -33,7 +33,7 @@
   </para>
   <para>
    このメソッドがファイバーの外部からコールされた場合、
-   <classname>FiberError</classname> がスローされます。
+   <exceptionname>FiberError</exceptionname> がスローされます。
   </para>
  </refsect1>
 

--- a/language/predefined/fiber/throw.xml
+++ b/language/predefined/fiber/throw.xml
@@ -20,7 +20,7 @@
   </para>
   <simpara>
    このメソッドがコールされた時点でファイバーが停止していない場合、
-   <classname>FiberError</classname> がスローされます。
+   <exceptionname>FiberError</exceptionname> がスローされます。
   </simpara>
  </refsect1>
 

--- a/language/predefined/fiber/throw.xml
+++ b/language/predefined/fiber/throw.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: b3a0b9924ba577a3abf246c1bd1a6cf5c4bf14dc Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: c62ef37e0d58067b393a6cf3a14aefed90bc0bff Maintainer: mumumu Status: ready -->
 <refentry xml:id="fiber.throw" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Fiber::throw</refname>

--- a/language/predefined/fiber/throw.xml
+++ b/language/predefined/fiber/throw.xml
@@ -18,10 +18,10 @@
    <methodname>Fiber::suspend</methodname> への呼び出しから、
    指定した例外をスローさせることでファイバーを再開させます。
   </para>
-  <para>
+  <simpara>
    このメソッドがコールされた時点でファイバーが停止していない場合、
    <classname>FiberError</classname> がスローされます。
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/language/predefined/fibererror/construct.xml
+++ b/language/predefined/fibererror/construct.xml
@@ -23,7 +23,7 @@
   &reftitle.errors;
   <simpara>
    このメソッドがコールされると、
-   <classname>Error</classname> 例外がスローされます。
+   <exceptionname>Error</exceptionname> 例外がスローされます。
   </simpara>
  </refsect1>
 </refentry>

--- a/language/predefined/fibererror/construct.xml
+++ b/language/predefined/fibererror/construct.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e50e79746736dbdfbabe9bd3566793b3ddf38f58 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: c62ef37e0d58067b393a6cf3a14aefed90bc0bff Maintainer: mumumu Status: ready -->
 <refentry xml:id="fibererror.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>FiberError::__construct</refname>

--- a/language/predefined/fibererror/construct.xml
+++ b/language/predefined/fibererror/construct.xml
@@ -21,10 +21,10 @@
  </refsect1>
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    このメソッドがコールされると、
    <classname>Error</classname> 例外がスローされます。
-  </para>
+  </simpara>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/language/predefined/generator.xml
+++ b/language/predefined/generator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <reference xml:id="class.generator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/language/predefined/generator.xml
+++ b/language/predefined/generator.xml
@@ -11,16 +11,16 @@
 
   <section xml:id="generator.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     <classname>Generator</classname> は <link
     linkend="language.generators">ジェネレータ</link> が返すオブジェクトです。
-   </para>
+   </simpara>
    
    <caution>
-    <para>
+    <simpara>
      <classname>Generator</classname> オブジェクトのインスタンスは
      <link linkend="language.oop5.basic.new">new</link> では作れません。
-    </para>
+    </simpara>
    </caution>
 
   </section>
@@ -47,7 +47,7 @@
 
   <section xml:id="generator.seealso">
    &reftitle.seealso;
-   <para><link linkend="language.oop5.iterations">オブジェクトの反復処理</link> も参照ください。</para>
+   <simpara><link linkend="language.oop5.iterations">オブジェクトの反復処理</link> も参照ください。</simpara>
   </section>
 
  </partintro>

--- a/language/predefined/internaliterator/current.xml
+++ b/language/predefined/internaliterator/current.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 460f49a93d103cac99556147cb9325b095ca3d42 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: c62ef37e0d58067b393a6cf3a14aefed90bc0bff Maintainer: mumumu Status: ready -->
 <refentry xml:id="internaliterator.current" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>InternalIterator::current</refname>

--- a/language/predefined/internaliterator/current.xml
+++ b/language/predefined/internaliterator/current.xml
@@ -13,9 +13,9 @@
    <modifier>public</modifier> <type>mixed</type><methodname>InternalIterator::current</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    現在の要素を返します。
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,9 +25,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    現在の要素を返します。
-  </para>
+  </simpara>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/language/predefined/internaliterator/key.xml
+++ b/language/predefined/internaliterator/key.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 460f49a93d103cac99556147cb9325b095ca3d42 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: c62ef37e0d58067b393a6cf3a14aefed90bc0bff Maintainer: mumumu Status: ready -->
 <refentry xml:id="internaliterator.key" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>InternalIterator::key</refname>

--- a/language/predefined/internaliterator/key.xml
+++ b/language/predefined/internaliterator/key.xml
@@ -13,9 +13,9 @@
    <modifier>public</modifier> <type>mixed</type><methodname>InternalIterator::key</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    現在の要素のキーを返します。
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,9 +25,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    現在の要素のキーを返します。
-  </para>
+  </simpara>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/language/predefined/internaliterator/next.xml
+++ b/language/predefined/internaliterator/next.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 460f49a93d103cac99556147cb9325b095ca3d42 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: c62ef37e0d58067b393a6cf3a14aefed90bc0bff Maintainer: mumumu Status: ready -->
 <refentry xml:id="internaliterator.next" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>InternalIterator::next</refname>

--- a/language/predefined/internaliterator/next.xml
+++ b/language/predefined/internaliterator/next.xml
@@ -13,9 +13,9 @@
    <modifier>public</modifier> <type>void</type><methodname>InternalIterator::next</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    現在位置を次の要素に移動します。
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,9 +25,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/language/predefined/internaliterator/rewind.xml
+++ b/language/predefined/internaliterator/rewind.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 460f49a93d103cac99556147cb9325b095ca3d42 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: c62ef37e0d58067b393a6cf3a14aefed90bc0bff Maintainer: mumumu Status: ready -->
 <refentry xml:id="internaliterator.rewind" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>InternalIterator::rewind</refname>

--- a/language/predefined/internaliterator/rewind.xml
+++ b/language/predefined/internaliterator/rewind.xml
@@ -13,9 +13,9 @@
    <modifier>public</modifier> <type>void</type><methodname>InternalIterator::rewind</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    イテレータの最初の要素に巻き戻します。
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,9 +25,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/language/predefined/internaliterator/valid.xml
+++ b/language/predefined/internaliterator/valid.xml
@@ -13,9 +13,9 @@
    <modifier>public</modifier> <type>bool</type><methodname>InternalIterator::valid</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    現在位置が有効かどうかを調べます。
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,9 +25,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    現在位置が有効かどうかを返します。
-  </para>
+  </simpara>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/language/predefined/internaliterator/valid.xml
+++ b/language/predefined/internaliterator/valid.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 460f49a93d103cac99556147cb9325b095ca3d42 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: c62ef37e0d58067b393a6cf3a14aefed90bc0bff Maintainer: mumumu Status: ready -->
 <refentry xml:id="internaliterator.valid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>InternalIterator::valid</refname>

--- a/language/predefined/sensitiveparametervalue.xml
+++ b/language/predefined/sensitiveparametervalue.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
 <reference xml:id="class.sensitiveparametervalue" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>SensitiveParameterValue クラス</title>
  <titleabbrev>SensitiveParameterValue</titleabbrev>

--- a/language/predefined/sensitiveparametervalue.xml
+++ b/language/predefined/sensitiveparametervalue.xml
@@ -9,16 +9,16 @@
 
   <section xml:id="sensitiveparametervalue.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     <classname>SensitiveParameterValue</classname> クラスを使うと、
     秘密の値をうっかり公開してしまうことを防ぐために値をラップすることができます。
-   </para>
-   <para>
+   </simpara>
+   <simpara>
     <classname>SensitiveParameter</classname>
     アトリビュートを持つパラメータに渡される値は、
     スタックトレース中では <classname>SensitiveParameterValue</classname>
     オブジェクトで自動的にラップされます。
-   </para>
+   </simpara>
   </section>
 
   <section xml:id="sensitiveparametervalue.synopsis">
@@ -52,9 +52,9 @@
     <varlistentry xml:id="sensitiveparametervalue.props.value">
      <term><varname>value</varname></term>
      <listitem>
-      <para>
+      <simpara>
        うっかり公開してしまうことを防ぎたい、秘密の値
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/language/predefined/stringable.xml
+++ b/language/predefined/stringable.xml
@@ -23,13 +23,13 @@
     暗黙のうちに存在すると見なされますが、
     明示的に宣言することもできますし、宣言すべきです。
    </para>
-   <para>
+   <simpara>
     このインターフェイスの一番の存在意義は、
     文字列プリミティブや、
     文字列にキャストできるオブジェクトを受け入れる
     union型 <literal>string|Stringable</literal>
     に対する型チェックを、関数ができるようにすることです。
-   </para>
+   </simpara>
   </section>
 
   <section xml:id="stringable.synopsis">

--- a/language/predefined/stringable.xml
+++ b/language/predefined/stringable.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
 <reference xml:id="class.stringable" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>Stringable インターフェイス</title>

--- a/language/predefined/throwable.xml
+++ b/language/predefined/throwable.xml
@@ -12,15 +12,15 @@
   <section xml:id="throwable.intro">
    &reftitle.intro;
    <simpara>
-    <classname>Throwable</classname>
+    <exceptionname>Throwable</exceptionname>
     は、&throw; 文でスロー可能なあらゆるオブジェクトが実装する基底インターフェイスです。
-    <classname>Error</classname> や <classname>Exception</classname>
+    <exceptionname>Error</exceptionname> や <exceptionname>Exception</exceptionname>
     も、これを実装しています。
    </simpara>
    <note>
     <simpara>
-     PHP のクラスが <classname>Throwable</classname> インターフェイスを直接実装することはできません。
-     そのかわりに、<classname>Exception</classname> を継承する必要があります。
+     PHP のクラスが <exceptionname>Throwable</exceptionname> インターフェイスを直接実装することはできません。
+     そのかわりに、<exceptionname>Exception</exceptionname> を継承する必要があります。
     </simpara>
    </note>
   </section>
@@ -61,7 +61,7 @@
       <row>
        <entry>8.0.0</entry>
        <entry>
-        <classname>Throwable</classname> は、
+        <exceptionname>Throwable</exceptionname> は、
         <interfacename>Stringable</interfacename> を新たに実装しました。
        </entry>
       </row>

--- a/language/predefined/throwable.xml
+++ b/language/predefined/throwable.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 09caff9ea664f7154a7d37e92b2c332c28462404 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <reference xml:id="class.throwable" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/language/predefined/throwable.xml
+++ b/language/predefined/throwable.xml
@@ -11,17 +11,17 @@
 
   <section xml:id="throwable.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     <classname>Throwable</classname>
     は、&throw; 文でスロー可能なあらゆるオブジェクトが実装する基底インターフェイスです。
     <classname>Error</classname> や <classname>Exception</classname>
     も、これを実装しています。
-   </para>
+   </simpara>
    <note>
-    <para>
+    <simpara>
      PHP のクラスが <classname>Throwable</classname> インターフェイスを直接実装することはできません。
      そのかわりに、<classname>Exception</classname> を継承する必要があります。
-    </para>
+    </simpara>
    </note>
   </section>
 

--- a/language/predefined/traversable.xml
+++ b/language/predefined/traversable.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c777ef397d0c333ce142ab8122abcad2aa63ba83 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: c62ef37e0d58067b393a6cf3a14aefed90bc0bff Maintainer: takagi Status: ready -->
 <reference xml:id="class.traversable" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title><interfacename>Traversable</interfacename> インターフェイス</title>

--- a/language/predefined/traversable.xml
+++ b/language/predefined/traversable.xml
@@ -10,9 +10,9 @@
 
   <section xml:id="traversable.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     そのクラスの中身が &foreach; を使用してたどれるかどうかを検出するインターフェイスです。
-   </para>
+   </simpara>
    <para>
     これは抽象インターフェイスであり、単体で実装することはできません。
     <interfacename>IteratorAggregate</interfacename> あるいは
@@ -29,10 +29,10 @@
     </oointerface>
    </classsynopsis>
 
-   <para>
+   <simpara>
     このインターフェイスにはメソッドがありません。
     traverse 可能なすべてのクラス用の基底インターフェイスとしてのみ存在しています。
-   </para>
+   </simpara>
 
   </section>
 

--- a/language/predefined/unitenum.xml
+++ b/language/predefined/unitenum.xml
@@ -9,14 +9,14 @@
 
   <section xml:id="unitenum.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     <classname>UnitEnum</classname> インターフェイスは、
     全ての列挙型に対して、PHP のエンジンが自動的に適用するものです。
     ユーザー定義のクラスとして実装してはいけません。
     列挙型はメソッドのオーバーライドを禁止しています。
     デフォルトの実装は PHP のエンジンから提供されるからです。
     このインターフェイスは、型チェックのためだけに存在しています。
-   </para>
+   </simpara>
   </section>
 
   <section xml:id="unitenum.synopsis">

--- a/language/predefined/unitenum.xml
+++ b/language/predefined/unitenum.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9eb4a46bba05da229be4c8f7a3cb64702e1a2f95 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
 <reference xml:id="class.unitenum" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>UnitEnum インターフェイス</title>
  <titleabbrev>UnitEnum</titleabbrev>

--- a/reference/bc/bcmath/number/add.xml
+++ b/reference/bc/bcmath/number/add.xml
@@ -61,7 +61,7 @@
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
-   このメソッドは、以下の場合に <classname>ValueError</classname> をスローします:
+   このメソッドは、以下の場合に <exceptionname>ValueError</exceptionname> をスローします:
    <simplelist>
     <member><parameter>num</parameter> が、BCMath で有効でない数値形式の文字列である場合</member>
     <member><parameter>scale</parameter> が範囲外の値である場合</member>

--- a/reference/bc/bcmath/number/div.xml
+++ b/reference/bc/bcmath/number/div.xml
@@ -65,7 +65,7 @@
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
-   このメソッドは、以下の場合に <classname>ValueError</classname> をスローします:
+   このメソッドは、以下の場合に <exceptionname>ValueError</exceptionname> をスローします:
    <simplelist>
     <member><parameter>num</parameter> が、BCMath で有効でない数値形式の文字列である場合</member>
     <member><parameter>scale</parameter> が範囲外の値である場合</member>

--- a/reference/bc/bcmath/number/sqrt.xml
+++ b/reference/bc/bcmath/number/sqrt.xml
@@ -48,7 +48,7 @@
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
-   このメソッドは、以下の場合に <classname>ValueError</classname> をスローします:
+   このメソッドは、以下の場合に <exceptionname>ValueError</exceptionname> をスローします:
    <simplelist>
     <member><varname>$this</varname> が負の値である場合</member>
     <member><parameter>scale</parameter> が範囲外の値である場合</member>

--- a/reference/bc/book.xml
+++ b/reference/bc/book.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: c62ef37e0d58067b393a6cf3a14aefed90bc0bff Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa,mumumu -->
  
 <book xml:id="book.bc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/bc/book.xml
+++ b/reference/bc/book.xml
@@ -10,18 +10,18 @@
  
  <preface xml:id="intro.bc">
   &reftitle.intro;
-  <para>
+  <simpara>
     任意の精度の演算をサポートするために、PHP は 
     <literal>2147483647</literal> (または <literal>0x7FFFFFFF</literal>) までの
     任意のサイズおよび精度の小数桁をサポートする BCMath を提供します。
     十分なメモリがあれば、文字列表現もサポートします。
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    有効(別名 well-formed) な BCMath数 は、以下の正規表現にマッチする文字列です。
    <literal>/^[+-]?[0-9]*(\.[0-9]*)?$/</literal>.
-  </para>
+  </simpara>
   <caution>
-   <para>
+   <simpara>
     <type>string</type>
     であることが期待されている <type>float</type> 型の値を BCMath 関数に渡してしまうと、
     PHP が <type>float</type> 型の値を <type>string</type> 型に変換するやり方の影響で、
@@ -31,7 +31,7 @@
     PHP 8.0.0 以前では
     小数点の記号がロケール依存(BCMath は常に小数点(.)を期待しています)
     であったりするためです。
-   </para>
+   </simpara>
    <informalexample>
     <programlisting role="php">
 <![CDATA[

--- a/reference/bc/configure.xml
+++ b/reference/bc/configure.xml
@@ -3,11 +3,11 @@
 <!-- EN-Revision: 96c9d88bad9a7d7d44bfb7f26c226df7ee9ddf26 Maintainer: hirokawa Status: ready -->
 <section xml:id="bc.installation" xmlns="http://docbook.org/ns/docbook">
  &reftitle.install;
- <para>
+ <simpara>
   これらの関数は、PHPが構築オプション
   <option role="configure">--enable-bcmath</option>
   を付けてコンパイルされている場合にのみ使用できます。
- </para>
+ </simpara>
  &windows.builtin;
 </section>
 

--- a/reference/bc/configure.xml
+++ b/reference/bc/configure.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 96c9d88bad9a7d7d44bfb7f26c226df7ee9ddf26 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: c62ef37e0d58067b393a6cf3a14aefed90bc0bff Maintainer: hirokawa Status: ready -->
 <section xml:id="bc.installation" xmlns="http://docbook.org/ns/docbook">
  &reftitle.install;
  <simpara>

--- a/reference/bc/functions/bcadd.xml
+++ b/reference/bc/functions/bcadd.xml
@@ -68,7 +68,7 @@
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
-   この関数は、以下の場合に <classname>ValueError</classname> をスローします:
+   この関数は、以下の場合に <exceptionname>ValueError</exceptionname> をスローします:
    <simplelist>
     <member><parameter>num1</parameter> もしくは <parameter>num1</parameter> が、BCMath で有効でない数値形式の文字列である場合</member>
     <member><parameter>scale</parameter> が範囲外の値である場合</member>

--- a/reference/bc/functions/bcceil.xml
+++ b/reference/bc/functions/bcceil.xml
@@ -43,7 +43,7 @@
  <refsect1 role="errors">
   &reftitle.errors;
   <simpara>
-   この関数は、<parameter>num</parameter> が BCMath で有効でない数値形式の文字列である場合、<classname>ValueError</classname> をスローします。
+   この関数は、<parameter>num</parameter> が BCMath で有効でない数値形式の文字列である場合、<exceptionname>ValueError</exceptionname> をスローします。
   </simpara>
  </refsect1>
 

--- a/reference/bc/functions/bcround.xml
+++ b/reference/bc/functions/bcround.xml
@@ -41,7 +41,7 @@
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
-   この関数は、以下の場合に <classname>ValueError</classname> をスローします:
+   この関数は、以下の場合に <exceptionname>ValueError</exceptionname> をスローします:
    <simplelist>
     <member><parameter>num</parameter> が、BCMath で有効でない数値形式の文字列である場合</member>
     <member>無効な <parameter>mode</parameter> を指定した場合</member>

--- a/reference/bc/ini.xml
+++ b/reference/bc/ini.xml
@@ -40,10 +40,10 @@
      <type>int</type>
     </term>
     <listitem>
-     <para>
+     <simpara>
       全ての bcmath 関数に関する 10 進桁数。
       <function>bcscale</function> も参照ください。
-     </para>
+     </simpara>
      <note>
       <simpara><classname>BcMath\Number</classname> クラスは、この設定の影響を受けません。</simpara>
      </note>

--- a/reference/bc/ini.xml
+++ b/reference/bc/ini.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c7e83fbbbcde9f54affc09424d032c38492a3ff4 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: c62ef37e0d58067b393a6cf3a14aefed90bc0bff Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: shimooka -->
 <section xml:id="bc.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;

--- a/reference/imagick/imagick/setfont.xml
+++ b/reference/imagick/imagick/setfont.xml
@@ -13,7 +13,7 @@
    <modifier>public</modifier> <type>bool</type><methodname>Imagick::setFont</methodname>
    <methodparam><type>string</type><parameter>font</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    オブジェクトのフォントプロパティを設定します。
    このメソッドは、たとえば caption: pseudo-format
    のフォントを設定したりする際に使用します。
@@ -22,7 +22,7 @@
    このメソッドを <function>ImagickDraw::setFont</function> と混同してはいけません。
    こちらは、ある特定の ImagickDraw オブジェクトのフォントを設定するメソッドです。
    &imagick.method.available.0x637;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/imagick/imagick/setfont.xml
+++ b/reference/imagick/imagick/setfont.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 65c4446ab35754d2f3cd8abec11302650a150bf9 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: c62ef37e0d58067b393a6cf3a14aefed90bc0bff Maintainer: takagi Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagick.setfont">
  <refnamediv>
   <refname>Imagick::setFont</refname>

--- a/reference/imap/functions/imap-getsubscribed.xml
+++ b/reference/imap/functions/imap-getsubscribed.xml
@@ -82,19 +82,19 @@
      </simpara>
     </listitem>
     <listitem>
-     <para>
+     <simpara>
       <constant>LATT_REFERRAL</constant> - このコンテナはリモートメールボックスと関連を持ちます。
-     </para>
+     </simpara>
     </listitem>
     <listitem>
-     <para>
+     <simpara>
       <constant>LATT_HASCHILDREN</constant> - このメールボックスは選択可能な子を持ちます。
-     </para>
+     </simpara>
     </listitem>
     <listitem>
-     <para>
+     <simpara>
       <constant>LATT_HASNOCHILDREN</constant> - このメールボックスは選択可能な子を持ちません。
-     </para>
+     </simpara>
     </listitem>
    </itemizedlist>
    この関数は、失敗した時に &false; を返します。

--- a/reference/libxml/functions/libxml-disable-entity-loader.xml
+++ b/reference/libxml/functions/libxml-disable-entity-loader.xml
@@ -20,12 +20,12 @@
    <type>bool</type><methodname>libxml_disable_entity_loader</methodname>
    <methodparam choice="opt"><type>bool</type><parameter>disable</parameter><initializer>&true;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    外部エンティティ読み込み機能の有効/無効を切り替えます。
    外部エンティティの読み込みを無効にすると、
    XML文書を読み込む際に問題が起こる可能性があることに注意して下さい。
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    libxml 2.9.0 以降では、エンティティの置換はデフォルトで無効になっているため、<constant>LIBXML_NOENT</constant>,
    <constant>LIBXML_DTDVALID</constant>, or <constant>LIBXML_DTDLOAD</constant>.
    を使って内部エンティティの参照を解決する必要がない限り、
@@ -33,7 +33,7 @@
    一般的には、外部エンティティの読み込みを抑制するのであれば、
    <function>libxml_set_external_entity_loader</function> を使うことが望ましいです。
    <constant>LIBXML_NO_XXE</constant> 定数を使ってこれを防ぐこともできます (PHP 8.4.0 以降、Libxml &gt;= 2.13.0 でのみ利用可能)。
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -43,12 +43,12 @@
     <varlistentry>
      <term><parameter>disable</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        libxml を使用する拡張モジュール
        (<xref linkend="book.dom" />、<xref linkend="book.xmlwriter" />
        および <xref linkend="book.xmlreader" />) で、外部エンティティの読み込み機能を
        無効 (&true;) あるいは有効 (&false;) にします。
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -57,9 +57,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    変更前の値を返します。
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/libxml/functions/libxml-disable-entity-loader.xml
+++ b/reference/libxml/functions/libxml-disable-entity-loader.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: c62ef37e0d58067b393a6cf3a14aefed90bc0bff Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 
 <refentry xml:id="function.libxml-disable-entity-loader" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/mbstring/functions/mb-stripos.xml
+++ b/reference/mbstring/functions/mb-stripos.xml
@@ -18,7 +18,7 @@
    <methodparam choice="opt"><type>int</type><parameter>offset</parameter><initializer>0</initializer></methodparam>
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>encoding</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    <function>mb_stripos</function> は、
    <parameter>needle</parameter> が
    <parameter>haystack</parameter> の中で最初に現れる位置を返します。
@@ -26,7 +26,7 @@
    <function>mb_stripos</function> は大文字小文字を区別しません。
    <parameter>needle</parameter> が見つからなかった場合は
    &false; を返します。
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;

--- a/reference/mbstring/functions/mb-stripos.xml
+++ b/reference/mbstring/functions/mb-stripos.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 95d05546430b9e5db225dd42a0d285b870f0da42 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: c62ef37e0d58067b393a6cf3a14aefed90bc0bff Maintainer: takagi Status: ready -->
 <refentry xml:id="function.mb-stripos" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mb_stripos</refname>

--- a/reference/mbstring/functions/mb-stristr.xml
+++ b/reference/mbstring/functions/mb-stristr.xml
@@ -18,7 +18,7 @@
    <methodparam choice="opt"><type>bool</type><parameter>before_needle</parameter><initializer>&false;</initializer></methodparam>
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>encoding</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    <function>mb_stristr</function> は、
    <parameter>haystack</parameter> の中で最初に
    <parameter>needle</parameter> が現れる場所を探し、
@@ -27,7 +27,7 @@
    <function>mb_stristr</function> は大文字小文字を区別しません。
    <parameter>needle</parameter> が見つからなかった場合は
    &false; を返します。
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -52,13 +52,13 @@
     <varlistentry>
      <term><parameter>before_needle</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        この関数が <parameter>haystack</parameter> のどの部分を返すのかを指定します。
        &true; の場合は、<parameter>haystack</parameter> の先頭から
        <parameter>needle</parameter> が最初に現れる位置までを返します (needle を含めません)。
        &false; の場合は、<parameter>needle</parameter> が最初に現れる位置から
        <parameter>haystack</parameter> の最後までを返します (needle を含めます)。
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/mbstring/functions/mb-stristr.xml
+++ b/reference/mbstring/functions/mb-stristr.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 95d05546430b9e5db225dd42a0d285b870f0da42 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: c62ef37e0d58067b393a6cf3a14aefed90bc0bff Maintainer: takagi Status: ready -->
 <refentry xml:id="function.mb-stristr" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mb_stristr</refname>

--- a/reference/mbstring/functions/mb-strrichr.xml
+++ b/reference/mbstring/functions/mb-strrichr.xml
@@ -52,13 +52,13 @@
     <varlistentry>
      <term><parameter>before_needle</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        この関数が <parameter>haystack</parameter> のどの部分を返すのかを指定します。
        &true; の場合は、<parameter>haystack</parameter> の先頭から
        <parameter>needle</parameter> が最後に現れる位置までを返します。
        &false; の場合は、<parameter>needle</parameter> が最後に現れる位置から
        <parameter>haystack</parameter> の最後までを返します。
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/mbstring/functions/mb-strrichr.xml
+++ b/reference/mbstring/functions/mb-strrichr.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 95d05546430b9e5db225dd42a0d285b870f0da42 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: c62ef37e0d58067b393a6cf3a14aefed90bc0bff Maintainer: takagi Status: ready -->
 <refentry xml:id="function.mb-strrichr" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mb_strrichr</refname>

--- a/reference/mbstring/functions/mb-strripos.xml
+++ b/reference/mbstring/functions/mb-strripos.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 95d05546430b9e5db225dd42a0d285b870f0da42 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: c62ef37e0d58067b393a6cf3a14aefed90bc0bff Maintainer: takagi Status: ready -->
 <refentry xml:id="function.mb-strripos" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mb_strripos</refname>

--- a/reference/mbstring/functions/mb-strripos.xml
+++ b/reference/mbstring/functions/mb-strripos.xml
@@ -18,7 +18,7 @@
    <methodparam choice="opt"><type>int</type><parameter>offset</parameter><initializer>0</initializer></methodparam>
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>encoding</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    <function>mb_strripos</function> は、マルチバイト対応の
    <function>strripos</function> 操作を、文字数に基づいて行います。
    <parameter>needle</parameter> の位置を
@@ -26,7 +26,7 @@
    最初の文字の位置は 0、二番目の文字の位置は 1 という具合です。
    <function>mb_strrpos</function> とは異なり、
    <function>mb_strripos</function> は大文字小文字を区別しません。
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;

--- a/reference/mbstring/functions/mb-strstr.xml
+++ b/reference/mbstring/functions/mb-strstr.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 95d05546430b9e5db225dd42a0d285b870f0da42 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: c62ef37e0d58067b393a6cf3a14aefed90bc0bff Maintainer: takagi Status: ready -->
 <refentry xml:id="function.mb-strstr" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mb_strstr</refname>

--- a/reference/mbstring/functions/mb-strstr.xml
+++ b/reference/mbstring/functions/mb-strstr.xml
@@ -47,13 +47,13 @@
     <varlistentry>
      <term><parameter>before_needle</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        この関数が <parameter>haystack</parameter> のどの部分を返すのかを指定します。
        &true; の場合は、<parameter>haystack</parameter> の先頭から
        <parameter>needle</parameter> が最初に現れる位置までを返します (needle を含めません)。
        &false; の場合は、<parameter>needle</parameter> が最初に現れる位置から
        <parameter>haystack</parameter> の最後までを返します (needle を含めます)。
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/mysqli/mysqli_stmt/result-metadata.xml
+++ b/reference/mysqli/mysqli_stmt/result-metadata.xml
@@ -75,9 +75,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    結果のオブジェクトを返します。エラー時には &false; を返します。
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/pdo/pdostatement/setfetchmode.xml
+++ b/reference/pdo/pdostatement/setfetchmode.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 8a910daad2efdfd29acf6766be8bca7c32c3dd2a Maintainer: takagi Status: ready -->
+<!-- EN-Revision: c62ef37e0d58067b393a6cf3a14aefed90bc0bff Maintainer: takagi Status: ready -->
 <!-- CREDITS: shimooka,mumumu -->
 <refentry xml:id="pdostatement.setfetchmode" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/pdo/pdostatement/setfetchmode.xml
+++ b/reference/pdo/pdostatement/setfetchmode.xml
@@ -44,41 +44,41 @@
     <varlistentry>
      <term><parameter>mode</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        フェッチモードは、<link linkend="pdo.constants"><constant>PDO::FETCH_<replaceable>*</replaceable></constant></link> 定数の 1つでなければなりません。
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>colno</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        カラム番号。
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
     <term><parameter>class</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        クラス名。
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>constructorArgs</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        コンストラクタの引数。
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>object</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        オブジェクト。
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/spl/functions/iterator-apply.xml
+++ b/reference/spl/functions/iterator-apply.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 60809ebcf7d0c261b2f00e093e4fab70326ffc7b Maintainer: takagi Status: ready -->
+<!-- EN-Revision: c62ef37e0d58067b393a6cf3a14aefed90bc0bff Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="function.iterator-apply" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/spl/functions/iterator-apply.xml
+++ b/reference/spl/functions/iterator-apply.xml
@@ -16,9 +16,9 @@
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>args</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    イテレータ内のすべての要素に対して関数をコールします。
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -28,9 +28,9 @@
     <varlistentry>
      <term><parameter>iterator</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        順次処理したいイテレータオブジェクト
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
@@ -54,12 +54,12 @@
     <varlistentry>
      <term><parameter>args</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        コールバック関数に渡す引数。
        引数の <type>array</type>。
        <parameter>args</parameter> の個々の要素が
        コールバック <parameter>callback</parameter> に別々の引数として渡されます。
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -69,9 +69,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    イテレータの要素数を返します。
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">


### PR DESCRIPTION
将来の翻訳時の差分を予め減らすことを目的に `[skip-revcheck]` の付与された機械的なマークアップ変更を予め同期。

## 対象マークアップ

- `classname` -> `exceptionname`
- `para` -> `simpara`

## 元となるen側のPRやコミット

- php/doc-en@1cb9fe0974
- php/doc-en#4163
- php/doc-en#4187
- php/doc-en#4912
- php/doc-en#5630

（このPRで上の全てを追従したわけではない。判断の必要な変更は `EN-Revision` を進めず作業から除外した）