### PR TITLE
通常作業外で追従済の php/doc-en#3415 のrevtagをその後の追従状況も含め推移的に更新

### DIFF
--- a/language/predefined/arithmeticerror.xml
+++ b/language/predefined/arithmeticerror.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <reference xml:id="class.arithmeticerror" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>ArithmeticError</title>

--- a/language/predefined/assertionerror.xml
+++ b/language/predefined/assertionerror.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <reference xml:id="class.assertionerror" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>AssertionError</title>
  <titleabbrev>AssertionError</titleabbrev>

--- a/language/predefined/closedgeneratorexception.xml
+++ b/language/predefined/closedgeneratorexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 49b7f738f43c1ea2113cc7931357a10224824539 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: mumumu Status: ready -->
 <reference xml:id="class.closedgeneratorexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>ClosedGeneratorException クラス</title>
  <titleabbrev>ClosedGeneratorException</titleabbrev>

--- a/language/predefined/compileerror.xml
+++ b/language/predefined/compileerror.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
 <reference xml:id="class.compileerror" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>CompileError</title>
  <titleabbrev>CompileError</titleabbrev>

--- a/language/predefined/divisionbyzeroerror.xml
+++ b/language/predefined/divisionbyzeroerror.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <reference xml:id="class.divisionbyzeroerror" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>DivisionByZeroError</title>
  <titleabbrev>DivisionByZeroError</titleabbrev>

--- a/language/predefined/error.xml
+++ b/language/predefined/error.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <reference xml:id="class.error" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>Error</title>
  <titleabbrev>Error</titleabbrev>

--- a/language/predefined/internaliterator.xml
+++ b/language/predefined/internaliterator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
 <reference xml:id="class.internaliterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>InternalIterator クラス</title>
  <titleabbrev>InternalIterator</titleabbrev>

--- a/language/predefined/iterator.xml
+++ b/language/predefined/iterator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9eb4a46bba05da229be4c8f7a3cb64702e1a2f95 Maintainer: satoruyoshida Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: satoruyoshida Status: ready -->
 <!-- Credits: mumumu -->
 <reference xml:id="class.iterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/language/predefined/parseerror.xml
+++ b/language/predefined/parseerror.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <!-- CREDITS: mumumu -->
 <reference xml:id="class.parseerror" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>ParseError</title>

--- a/language/predefined/unhandledmatcherror.xml
+++ b/language/predefined/unhandledmatcherror.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
 <reference xml:id="class.unhandledmatcherror" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>UnhandledMatchError</title>
  <titleabbrev>UnhandledMatchError</titleabbrev>

--- a/language/predefined/valueerror.xml
+++ b/language/predefined/valueerror.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
 <reference xml:id="class.valueerror" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>ValueError</title>
  <titleabbrev>ValueError</titleabbrev>

--- a/language/predefined/weakmap.xml
+++ b/language/predefined/weakmap.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c4650e160398873696e59305a11db9645e0b7304 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
 <reference xml:id="class.weakmap" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>WeakMap クラス</title>

--- a/reference/com/com-exception.xml
+++ b/reference/com/com-exception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
 <reference xml:id="class.com-exception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>com_exception クラス</title>

--- a/reference/com/com-safearray-proxy.xml
+++ b/reference/com/com-safearray-proxy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 94ef70805b847c24941dfd7828df2f5a0fd48c96 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: mumumu Status: ready -->
 <reference xml:id="class.com-safearray-proxy" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>com_safearray_proxy クラス</title>
  <titleabbrev>com_safearray_proxy</titleabbrev>

--- a/reference/com/com.xml
+++ b/reference/com/com.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi,mumumu -->
 <reference xml:id="class.com" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <titleabbrev>com</titleabbrev>

--- a/reference/com/compersisthelper.xml
+++ b/reference/com/compersisthelper.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
 <reference xml:id="class.compersisthelper" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>COMPersistHelper クラス</title>

--- a/reference/com/dotnet.xml
+++ b/reference/com/dotnet.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <reference role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="class.dotnet">
  <titleabbrev>dotnet</titleabbrev>

--- a/reference/com/variant.xml
+++ b/reference/com/variant.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi,mumumu -->
 <reference xml:id="class.variant" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <titleabbrev>variant</titleabbrev>

--- a/reference/curl/curlfile.xml
+++ b/reference/curl/curlfile.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <reference xml:id="class.curlfile" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/curl/curlhandle.xml
+++ b/reference/curl/curlhandle.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: mumumu Status: ready -->
 <reference xml:id="class.curlhandle" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>CurlHandle クラス</title>

--- a/reference/curl/curlmultihandle.xml
+++ b/reference/curl/curlmultihandle.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: mumumu Status: ready -->
 <reference xml:id="class.curlmultihandle" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>CurlMultiHandle クラス</title>

--- a/reference/curl/curlsharehandle.xml
+++ b/reference/curl/curlsharehandle.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: mumumu Status: ready -->
 <reference xml:id="class.curlsharehandle" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>CurlShareHandle クラス</title>

--- a/reference/curl/curlstringfile.xml
+++ b/reference/curl/curlstringfile.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
 <reference xml:id="class.curlstringfile" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>CURLStringFile クラス</title>

--- a/reference/datetime/dateerror.xml
+++ b/reference/datetime/dateerror.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 696b6b9e32d8d4ef4cfd874caf677a47a6cbadb4 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
 <reference xml:id="class.dateerror" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>DateError クラス</title>
  <titleabbrev>DateError</titleabbrev>

--- a/reference/datetime/dateexception.xml
+++ b/reference/datetime/dateexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 696b6b9e32d8d4ef4cfd874caf677a47a6cbadb4 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
 <reference xml:id="class.dateexception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>DateException クラス</title>
  <titleabbrev>DateException</titleabbrev>

--- a/reference/datetime/dateinterval.xml
+++ b/reference/datetime/dateinterval.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9154789dfc9cb8aa5df644bfba5e86c2deba4cb8 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <reference xml:id="class.dateinterval" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/datetime/dateinvalidoperationexception.xml
+++ b/reference/datetime/dateinvalidoperationexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 696b6b9e32d8d4ef4cfd874caf677a47a6cbadb4 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
 <reference xml:id="class.dateinvalidoperationexception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>DateInvalidOperationException クラス</title>
  <titleabbrev>DateInvalidOperationException</titleabbrev>

--- a/reference/datetime/dateinvalidtimezoneexception.xml
+++ b/reference/datetime/dateinvalidtimezoneexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 696b6b9e32d8d4ef4cfd874caf677a47a6cbadb4 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
 <reference xml:id="class.dateinvalidtimezoneexception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>DateInvalidTimeZoneException クラス</title>
  <titleabbrev>DateInvalidTimeZoneException</titleabbrev>

--- a/reference/datetime/datemalformedintervalstringexception.xml
+++ b/reference/datetime/datemalformedintervalstringexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 696b6b9e32d8d4ef4cfd874caf677a47a6cbadb4 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
 <reference xml:id="class.datemalformedintervalstringexception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>DateMalformedIntervalStringException クラス</title>
  <titleabbrev>DateMalformedIntervalStringException</titleabbrev>

--- a/reference/datetime/datemalformedperiodstringexception.xml
+++ b/reference/datetime/datemalformedperiodstringexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 696b6b9e32d8d4ef4cfd874caf677a47a6cbadb4 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
 <reference xml:id="class.datemalformedperiodstringexception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>DateMalformedPeriodStringException クラス</title>
  <titleabbrev>DateMalformedPeriodStringException</titleabbrev>

--- a/reference/datetime/datemalformedstringexception.xml
+++ b/reference/datetime/datemalformedstringexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 696b6b9e32d8d4ef4cfd874caf677a47a6cbadb4 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
 <reference xml:id="class.datemalformedstringexception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>DateMalformedStringException クラス</title>
  <titleabbrev>DateMalformedStringException</titleabbrev>

--- a/reference/datetime/dateobjecterror.xml
+++ b/reference/datetime/dateobjecterror.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 696b6b9e32d8d4ef4cfd874caf677a47a6cbadb4 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
 <reference xml:id="class.dateobjecterror" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>DateObjectError クラス</title>
  <titleabbrev>DateObjectError</titleabbrev>

--- a/reference/datetime/daterangeerror.xml
+++ b/reference/datetime/daterangeerror.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 696b6b9e32d8d4ef4cfd874caf677a47a6cbadb4 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
 <reference xml:id="class.daterangeerror" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>DateRangeError クラス</title>
  <titleabbrev>DateRangeError</titleabbrev>

--- a/reference/dom/domchildnode.xml
+++ b/reference/dom/domchildnode.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9eb4a46bba05da229be4c8f7a3cb64702e1a2f95 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
 <reference xml:id="class.domchildnode" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>DOMChildNode インターフェイス</title>
  <titleabbrev>DOMChildNode</titleabbrev>

--- a/reference/dom/domparentnode.xml
+++ b/reference/dom/domparentnode.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9eb4a46bba05da229be4c8f7a3cb64702e1a2f95 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
 <reference xml:id="class.domparentnode" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>DOMParentNode インターフェイス</title>
  <titleabbrev>DOMParentNode</titleabbrev>

--- a/reference/ev/evprepare.xml
+++ b/reference/ev/evprepare.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 33e5f4ef7243bc1282acb1cba93e8f99c1debe68 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: takagi Status: ready -->
 <reference xml:id="class.evprepare" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>EvPrepare クラス</title>
  <titleabbrev>EvPrepare</titleabbrev>

--- a/reference/hash/hashcontext.xml
+++ b/reference/hash/hashcontext.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
 <reference xml:id="class.hashcontext" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>HashContext クラス</title>

--- a/reference/image/gdfont.xml
+++ b/reference/image/gdfont.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: mumumu Status: ready -->
 <reference xml:id="class.gdfont" role="class" xmlns="http://docbook.org/ns/docbook">
  <title>GdFont クラス</title>
  <titleabbrev>GdFont</titleabbrev>

--- a/reference/image/gdimage.xml
+++ b/reference/image/gdimage.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: mumumu Status: ready -->
 <reference xml:id="class.gdimage" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>GdImage クラス</title>

--- a/reference/imagick/imagick.xml
+++ b/reference/imagick/imagick.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c44e9cb68b9b65771f9c45db2c07a06c63d71359 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <reference role="class" xml:id="class.imagick" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title><classname>Imagick</classname> クラス</title>
  <titleabbrev>Imagick</titleabbrev>

--- a/reference/imagick/imagickdraw.xml
+++ b/reference/imagick/imagickdraw.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14af302c9c0e561fa6f9cdd956268758ba9a89c5 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: takagi Status: ready -->
 <reference role="class" xml:id="class.imagickdraw" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title><classname>ImagickDraw</classname> クラス</title>
  <titleabbrev>ImagickDraw</titleabbrev>

--- a/reference/imagick/imagickpixel.xml
+++ b/reference/imagick/imagickpixel.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d4ff25da7728718115a721a916fc38fc2589ec7e Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: takagi Status: ready -->
 <reference role="class" xml:id="class.imagickpixel" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title><classname>ImagickPixel</classname> クラス</title>
  <titleabbrev>ImagickPixel</titleabbrev>

--- a/reference/imagick/imagickpixeliterator.xml
+++ b/reference/imagick/imagickpixeliterator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d4ff25da7728718115a721a916fc38fc2589ec7e Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: takagi Status: ready -->
 <reference role="class" xml:id="class.imagickpixeliterator" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title><classname>ImagickPixelIterator</classname> クラス</title>
  <titleabbrev>ImagickPixelIterator</titleabbrev>

--- a/reference/imap/imap.connection.xml
+++ b/reference/imap/imap.connection.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: mumumu Status: ready -->
 <reference xml:id="class.imap-connection" role="class" xmlns="http://docbook.org/ns/docbook">
  <title>IMAP\Connection クラス</title>
  <titleabbrev>IMAP\Connection</titleabbrev>

--- a/reference/intl/intlcodepointbreakiterator.xml
+++ b/reference/intl/intlcodepointbreakiterator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
 <reference xml:id="class.intlcodepointbreakiterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>IntlCodePointBreakIterator クラス</title>

--- a/reference/intl/intldatepatterngenerator.xml
+++ b/reference/intl/intldatepatterngenerator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
 <reference xml:id="class.intldatepatterngenerator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>IntlDatePatternGenerator クラス</title>
  <titleabbrev>IntlDatePatternGenerator</titleabbrev>

--- a/reference/intl/intlexception.xml
+++ b/reference/intl/intlexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
 <reference xml:id="class.intlexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>intl のエラー用の例外クラス</title>

--- a/reference/intl/intlgregoriancalendar.xml
+++ b/reference/intl/intlgregoriancalendar.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
 <reference xml:id="class.intlgregoriancalendar" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>IntlGregorianCalendar クラス</title>

--- a/reference/intl/intliterator.xml
+++ b/reference/intl/intliterator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
 <reference xml:id="class.intliterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>IntlIterator クラス</title>

--- a/reference/intl/intlrulebasedbreakiterator.xml
+++ b/reference/intl/intlrulebasedbreakiterator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
 <reference xml:id="class.intlrulebasedbreakiterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>IntlRuleBasedBreakIterator クラス</title>

--- a/reference/intl/messageformatter.xml
+++ b/reference/intl/messageformatter.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <reference xml:id="class.messageformatter" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>MessageFormatter クラス</title>
  <titleabbrev>MessageFormatter</titleabbrev>

--- a/reference/intl/resourcebundle.xml
+++ b/reference/intl/resourcebundle.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <reference xml:id="class.resourcebundle" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>ResourceBundle クラス</title>
  <titleabbrev>ResourceBundle</titleabbrev>

--- a/reference/json/jsonexception.xml
+++ b/reference/json/jsonexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
 <reference xml:id="class.jsonexception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>JsonException クラス</title>
  <titleabbrev>JsonException</titleabbrev>

--- a/reference/json/jsonserializable.xml
+++ b/reference/json/jsonserializable.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9eb4a46bba05da229be4c8f7a3cb64702e1a2f95 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <reference xml:id="class.jsonserializable" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>JsonSerializable インターフェイス</title>

--- a/reference/libxml/libxmlerror.xml
+++ b/reference/libxml/libxmlerror.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 2a8b2f1c53edae923b5bb196183e476e5cca46a3 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: takagi Status: ready -->
 
 <reference xml:id="class.libxmlerror" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>LibXMLError クラス</title>

--- a/reference/memcached/memcached.xml
+++ b/reference/memcached/memcached.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 1d8068ecb070fdc360d750e0c1f3f15796e61ec0 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <reference xml:id="class.memcached" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>Memcached クラス</title>

--- a/reference/memcached/memcachedexception.xml
+++ b/reference/memcached/memcachedexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 7e39bbe13d2efaa73423ea16ad6ecf2fa4d13217 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: takagi Status: ready -->
 
 <reference xml:id="class.memcachedexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/mysql_xdevapi/mysql-xdevapi.baseresult.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.baseresult.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 98bf51d2b9db0a9acd1c9bcce8eecc5bcf60a63d Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: mumumu Status: ready -->
 
 <reference xml:id="class.mysql-xdevapi-baseresult" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/mysql_xdevapi/mysql-xdevapi.client.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.client.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 41eaa8885278649e257d581b95af2ce82ecb8919 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: mumumu Status: ready -->
 
 <reference xml:id="class.mysql-xdevapi-client" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/mysql_xdevapi/mysql-xdevapi.collection.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.collection.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 98bf51d2b9db0a9acd1c9bcce8eecc5bcf60a63d Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: mumumu Status: ready -->
 
 <reference xml:id="class.mysql-xdevapi-collection" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/mysql_xdevapi/mysql-xdevapi.collectionadd.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.collectionadd.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 98bf51d2b9db0a9acd1c9bcce8eecc5bcf60a63d Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: mumumu Status: ready -->
 
 <reference xml:id="class.mysql-xdevapi-collectionadd" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/mysql_xdevapi/mysql-xdevapi.collectionfind.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.collectionfind.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 98bf51d2b9db0a9acd1c9bcce8eecc5bcf60a63d Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: mumumu Status: ready -->
 
 <reference xml:id="class.mysql-xdevapi-collectionfind" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/mysql_xdevapi/mysql-xdevapi.collectionmodify.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.collectionmodify.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 98bf51d2b9db0a9acd1c9bcce8eecc5bcf60a63d Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: mumumu Status: ready -->
 
 <reference xml:id="class.mysql-xdevapi-collectionmodify" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/mysql_xdevapi/mysql-xdevapi.collectionremove.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.collectionremove.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 98bf51d2b9db0a9acd1c9bcce8eecc5bcf60a63d Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: mumumu Status: ready -->
 
 <reference xml:id="class.mysql-xdevapi-collectionremove" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/mysql_xdevapi/mysql-xdevapi.columnresult.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.columnresult.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 98bf51d2b9db0a9acd1c9bcce8eecc5bcf60a63d Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: mumumu Status: ready -->
 
 <reference xml:id="class.mysql-xdevapi-columnresult" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/mysql_xdevapi/mysql-xdevapi.crudoperationbindable.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.crudoperationbindable.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 98bf51d2b9db0a9acd1c9bcce8eecc5bcf60a63d Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: mumumu Status: ready -->
 
 <reference xml:id="class.mysql-xdevapi-crudoperationbindable" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/mysql_xdevapi/mysql-xdevapi.crudoperationlimitable.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.crudoperationlimitable.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 98bf51d2b9db0a9acd1c9bcce8eecc5bcf60a63d Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: mumumu Status: ready -->
 
 <reference xml:id="class.mysql-xdevapi-crudoperationlimitable" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/mysql_xdevapi/mysql-xdevapi.crudoperationskippable.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.crudoperationskippable.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 98bf51d2b9db0a9acd1c9bcce8eecc5bcf60a63d Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: mumumu Status: ready -->
 
 <reference xml:id="class.mysql-xdevapi-crudoperationskippable" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/mysql_xdevapi/mysql-xdevapi.crudoperationsortable.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.crudoperationsortable.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 98bf51d2b9db0a9acd1c9bcce8eecc5bcf60a63d Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: mumumu Status: ready -->
 
 <reference xml:id="class.mysql-xdevapi-crudoperationsortable" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/mysql_xdevapi/mysql-xdevapi.databaseobject.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.databaseobject.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 98bf51d2b9db0a9acd1c9bcce8eecc5bcf60a63d Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: mumumu Status: ready -->
 
 <reference xml:id="class.mysql-xdevapi-databaseobject" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/mysql_xdevapi/mysql-xdevapi.docresult.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.docresult.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 98bf51d2b9db0a9acd1c9bcce8eecc5bcf60a63d Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: mumumu Status: ready -->
 
 <reference xml:id="class.mysql-xdevapi-docresult" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/mysql_xdevapi/mysql-xdevapi.driver.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.driver.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 6ceccac7860f382f16ac1407baf54f656e85ca0b Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: mumumu Status: ready -->
 
 <reference xml:id="class.mysql-xdevapi-driver" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/mysql_xdevapi/mysql-xdevapi.exception.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.exception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 98bf51d2b9db0a9acd1c9bcce8eecc5bcf60a63d Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: mumumu Status: ready -->
 
 <reference xml:id="class.mysql-xdevapi-exception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/mysql_xdevapi/mysql-xdevapi.executable.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.executable.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 98bf51d2b9db0a9acd1c9bcce8eecc5bcf60a63d Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: mumumu Status: ready -->
 
 <reference xml:id="class.mysql-xdevapi-executable" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/mysql_xdevapi/mysql-xdevapi.executionstatus.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.executionstatus.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 98bf51d2b9db0a9acd1c9bcce8eecc5bcf60a63d Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: mumumu Status: ready -->
 
 <reference xml:id="class.mysql-xdevapi-executionstatus" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/mysql_xdevapi/mysql-xdevapi.expression.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.expression.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 98bf51d2b9db0a9acd1c9bcce8eecc5bcf60a63d Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: mumumu Status: ready -->
 
 <reference xml:id="class.mysql-xdevapi-expression" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/mysql_xdevapi/mysql-xdevapi.fieldmetadata.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.fieldmetadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 98bf51d2b9db0a9acd1c9bcce8eecc5bcf60a63d Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: mumumu Status: ready -->
 
 <reference xml:id="class.mysql-xdevapi-fieldmetadata" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/mysql_xdevapi/mysql-xdevapi.result.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.result.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 98bf51d2b9db0a9acd1c9bcce8eecc5bcf60a63d Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: mumumu Status: ready -->
 
 <reference xml:id="class.mysql-xdevapi-result" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/mysql_xdevapi/mysql-xdevapi.rowresult.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.rowresult.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 98bf51d2b9db0a9acd1c9bcce8eecc5bcf60a63d Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: mumumu Status: ready -->
 
 <reference xml:id="class.mysql-xdevapi-rowresult" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/mysql_xdevapi/mysql-xdevapi.schema.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.schema.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 98bf51d2b9db0a9acd1c9bcce8eecc5bcf60a63d Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: mumumu Status: ready -->
 
 <reference xml:id="class.mysql-xdevapi-schema" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/mysql_xdevapi/mysql-xdevapi.schemaobject.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.schemaobject.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 98bf51d2b9db0a9acd1c9bcce8eecc5bcf60a63d Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: mumumu Status: ready -->
 
 <reference xml:id="class.mysql-xdevapi-schemaobject" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/mysql_xdevapi/mysql-xdevapi.session.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.session.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 98bf51d2b9db0a9acd1c9bcce8eecc5bcf60a63d Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: mumumu Status: ready -->
 
 <reference xml:id="class.mysql-xdevapi-session" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/mysql_xdevapi/mysql-xdevapi.sqlstatement.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.sqlstatement.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 6ceccac7860f382f16ac1407baf54f656e85ca0b Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: mumumu Status: ready -->
 
 <reference xml:id="class.mysql-xdevapi-sqlstatement" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/mysql_xdevapi/mysql-xdevapi.sqlstatementresult.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.sqlstatementresult.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 98bf51d2b9db0a9acd1c9bcce8eecc5bcf60a63d Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: mumumu Status: ready -->
 
 <reference xml:id="class.mysql-xdevapi-sqlstatementresult" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/mysql_xdevapi/mysql-xdevapi.statement.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.statement.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 6ceccac7860f382f16ac1407baf54f656e85ca0b Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: mumumu Status: ready -->
 
 <reference xml:id="class.mysql-xdevapi-statement" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/mysql_xdevapi/mysql-xdevapi.table.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.table.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 18f9cbcbc404fa3161104e4f3969531f686457af Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: mumumu Status: ready -->
 
 <reference xml:id="class.mysql-xdevapi-table" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/mysql_xdevapi/mysql-xdevapi.tabledelete.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.tabledelete.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 18f9cbcbc404fa3161104e4f3969531f686457af Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: mumumu Status: ready -->
 
 <reference xml:id="class.mysql-xdevapi-tabledelete" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/mysql_xdevapi/mysql-xdevapi.tableinsert.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.tableinsert.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 18f9cbcbc404fa3161104e4f3969531f686457af Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: mumumu Status: ready -->
 
 <reference xml:id="class.mysql-xdevapi-tableinsert" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/mysql_xdevapi/mysql-xdevapi.tableselect.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.tableselect.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 18f9cbcbc404fa3161104e4f3969531f686457af Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: mumumu Status: ready -->
 
 <reference xml:id="class.mysql-xdevapi-tableselect" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/mysql_xdevapi/mysql-xdevapi.tableupdate.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.tableupdate.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 18f9cbcbc404fa3161104e4f3969531f686457af Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: mumumu Status: ready -->
 
 <reference xml:id="class.mysql-xdevapi-tableupdate" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/mysql_xdevapi/mysql-xdevapi.warning.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.warning.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 98bf51d2b9db0a9acd1c9bcce8eecc5bcf60a63d Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: mumumu Status: ready -->
 
 <reference xml:id="class.mysql-xdevapi-warning" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/mysqli/mysqli.xml
+++ b/reference/mysqli/mysqli.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa -->
 <reference xml:id="class.mysqli" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>mysqli クラス</title>

--- a/reference/mysqli/mysqli_result.xml
+++ b/reference/mysqli/mysqli_result.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
 <reference xml:id="class.mysqli-result" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>mysqli_result クラス</title>
  <titleabbrev>mysqli_result</titleabbrev>

--- a/reference/mysqli/mysqli_sql_exception.xml
+++ b/reference/mysqli/mysqli_sql_exception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <reference xml:id="class.mysqli-sql-exception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>mysqli_sql_exception クラス</title>

--- a/reference/mysqli/mysqli_stmt.xml
+++ b/reference/mysqli/mysqli_stmt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa -->
 <reference xml:id="class.mysqli-stmt" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>mysqli_stmt クラス</title>

--- a/reference/mysqli/mysqli_warning.xml
+++ b/reference/mysqli/mysqli_warning.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <reference xml:id="class.mysqli-warning" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>mysqli_warning クラス</title>

--- a/reference/oci8/ocicollection.xml
+++ b/reference/oci8/ocicollection.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: satoruyoshida Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: satoruyoshida Status: ready -->
 <reference xml:id="class.ocicollection" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>OCICollection クラス</title>
  <titleabbrev>OCICollection</titleabbrev>

--- a/reference/oci8/ocilob.xml
+++ b/reference/oci8/ocilob.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: satoruyoshida Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: satoruyoshida Status: ready -->
 <reference xml:id="class.ocilob" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>OCILob クラス</title>
  <titleabbrev>OCILob</titleabbrev>

--- a/reference/openssl/opensslasymmetrickey.xml
+++ b/reference/openssl/opensslasymmetrickey.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: mumumu Status: ready -->
 <reference xml:id="class.opensslasymmetrickey" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>OpenSSLAsymmetricKey クラス</title>

--- a/reference/openssl/opensslcertificate.xml
+++ b/reference/openssl/opensslcertificate.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: mumumu Status: ready -->
 <reference xml:id="class.opensslcertificate" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>OpenSSLCertificate クラス</title>

--- a/reference/openssl/opensslcertificatesigningrequest.xml
+++ b/reference/openssl/opensslcertificatesigningrequest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: mumumu Status: ready -->
 <reference xml:id="class.opensslcertificatesigningrequest" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>OpenSSLCertificateSigningRequest クラス</title>

--- a/reference/pdo/pdostatement.xml
+++ b/reference/pdo/pdostatement.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: shimooka Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: shimooka Status: ready -->
 <!-- CREDITS: hirokawa,takagi -->
 <reference xml:id="class.pdostatement" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>PDOStatement クラス</title>

--- a/reference/phar/PharData.xml
+++ b/reference/phar/PharData.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <reference xml:id="class.phardata" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>PharData クラス</title>

--- a/reference/phar/PharException.xml
+++ b/reference/phar/PharException.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <reference xml:id="class.pharexception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>PharException クラス</title>

--- a/reference/phar/PharFileInfo.xml
+++ b/reference/phar/PharFileInfo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <reference xml:id="class.pharfileinfo" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>PharFileInfo クラス</title>

--- a/reference/pspell/pspell.config.xml
+++ b/reference/pspell/pspell.config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: mumumu Status: ready -->
 <reference xml:id="class.pspell-config" role="class" xmlns="http://docbook.org/ns/docbook">
  <title>PSpell\Config クラス</title>
  <titleabbrev>PSpell\Config</titleabbrev>

--- a/reference/pspell/pspell.dictionary.xml
+++ b/reference/pspell/pspell.dictionary.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: mumumu Status: ready -->
 <reference xml:id="class.pspell-dictionary" role="class" xmlns="http://docbook.org/ns/docbook">
  <title>PSpell\Dictionary クラス</title>
  <titleabbrev>PSpell\Dictionary</titleabbrev>

--- a/reference/reflection/reflection.xml
+++ b/reference/reflection/reflection.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <reference xml:id="class.reflection" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>Reflection クラス</title>

--- a/reference/reflection/reflectionenum.xml
+++ b/reference/reflection/reflectionenum.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
 <reference xml:id="class.reflectionenum" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>ReflectionEnum クラス</title>
  <titleabbrev>ReflectionEnum</titleabbrev>

--- a/reference/reflection/reflectionenumbackedcase.xml
+++ b/reference/reflection/reflectionenumbackedcase.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
 <reference xml:id="class.reflectionenumbackedcase" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>ReflectionEnumBackedCase クラス</title>
  <titleabbrev>ReflectionEnumBackedCase</titleabbrev>

--- a/reference/reflection/reflectionenumunitcase.xml
+++ b/reference/reflection/reflectionenumunitcase.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
 <reference xml:id="class.reflectionenumunitcase" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>ReflectionEnumUnitCase クラス</title>
  <titleabbrev>ReflectionEnumUnitCase</titleabbrev>

--- a/reference/reflection/reflectionexception.xml
+++ b/reference/reflection/reflectionexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <reference xml:id="class.reflectionexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>ReflectionException クラス</title>

--- a/reference/reflection/reflectionextension.xml
+++ b/reference/reflection/reflectionextension.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <reference xml:id="class.reflectionextension" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>ReflectionExtension クラス</title>

--- a/reference/reflection/reflectionfiber.xml
+++ b/reference/reflection/reflectionfiber.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
 <reference xml:id="class.reflectionfiber" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>ReflectionFiber クラス</title>
  <titleabbrev>ReflectionFiber</titleabbrev>

--- a/reference/reflection/reflectionfunctionabstract.xml
+++ b/reference/reflection/reflectionfunctionabstract.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <reference xml:id="class.reflectionfunctionabstract" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>ReflectionFunctionAbstract クラス</title>

--- a/reference/reflection/reflectiongenerator.xml
+++ b/reference/reflection/reflectiongenerator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
 <reference xml:id="class.reflectiongenerator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>ReflectionGenerator クラス</title>

--- a/reference/reflection/reflectionintersectiontype.xml
+++ b/reference/reflection/reflectionintersectiontype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
 <reference xml:id="class.reflectionintersectiontype" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>ReflectionIntersectionType クラス</title>

--- a/reference/reflection/reflectionnamedtype.xml
+++ b/reference/reflection/reflectionnamedtype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
 <reference xml:id="class.reflectionnamedtype" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>ReflectionNamedType クラス</title>

--- a/reference/reflection/reflectionobject.xml
+++ b/reference/reflection/reflectionobject.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
 <reference xml:id="class.reflectionobject" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>ReflectionObject クラス</title>

--- a/reference/reflection/reflectionparameter.xml
+++ b/reference/reflection/reflectionparameter.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <reference xml:id="class.reflectionparameter" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>ReflectionParameter クラス</title>

--- a/reference/reflection/reflectionreference.xml
+++ b/reference/reflection/reflectionreference.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
 <reference xml:id="class.reflectionreference" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>ReflectionReference クラス</title>

--- a/reference/reflection/reflectiontype.xml
+++ b/reference/reflection/reflectiontype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
 <reference xml:id="class.reflectiontype" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>ReflectionType クラス</title>

--- a/reference/reflection/reflectionuniontype.xml
+++ b/reference/reflection/reflectionuniontype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
 <reference xml:id="class.reflectionuniontype" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>ReflectionUnionType クラス</title>

--- a/reference/reflection/reflector.xml
+++ b/reference/reflection/reflector.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9eb4a46bba05da229be4c8f7a3cb64702e1a2f95 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <reference xml:id="class.reflector" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>Reflector インターフェイス</title>

--- a/reference/session/sessionhandler.xml
+++ b/reference/session/sessionhandler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 62126c55f1c6ed444043e7272c4f9e233818a44b Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <reference xml:id="class.sessionhandler" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>SessionHandler クラス</title>

--- a/reference/session/sessionidinterface.xml
+++ b/reference/session/sessionidinterface.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9eb4a46bba05da229be4c8f7a3cb64702e1a2f95 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
 <reference xml:id="class.sessionidinterface" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>SessionIdInterface クラス</title>

--- a/reference/session/sessionupdatetimestamphandlerinterface.xml
+++ b/reference/session/sessionupdatetimestamphandlerinterface.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9eb4a46bba05da229be4c8f7a3cb64702e1a2f95 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
 <reference xml:id="class.sessionupdatetimestamphandlerinterface" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>SessionUpdateTimestampHandlerInterface クラス</title>

--- a/reference/simplexml/simplexmlelement.xml
+++ b/reference/simplexml/simplexmlelement.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <reference xml:id="class.simplexmlelement" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>SimpleXMLElement クラス</title>
  <titleabbrev>SimpleXMLElement</titleabbrev>

--- a/reference/simplexml/simplexmliterator.xml
+++ b/reference/simplexml/simplexmliterator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <reference xml:id="class.simplexmliterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>SimpleXMLIterator クラス</title>
  <titleabbrev>SimpleXMLIterator</titleabbrev>

--- a/reference/soap/soapheader.xml
+++ b/reference/soap/soapheader.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <reference xml:id="class.soapheader" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>SoapHeader クラス</title>

--- a/reference/soap/soapparam.xml
+++ b/reference/soap/soapparam.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <reference xml:id="class.soapparam" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>SoapParam クラス</title>

--- a/reference/soap/soapvar.xml
+++ b/reference/soap/soapvar.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <reference xml:id="class.soapvar" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>SoapVar クラス</title>

--- a/reference/sockets/addressinfo.xml
+++ b/reference/sockets/addressinfo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: mumumu Status: ready -->
 <reference xml:id="class.addressinfo" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>AddressInfo クラス</title>

--- a/reference/sockets/socket.xml
+++ b/reference/sockets/socket.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: mumumu Status: ready -->
 <reference xml:id="class.socket" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>Socket クラス</title>

--- a/reference/solr/solrclientexception.xml
+++ b/reference/solr/solrclientexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 38e65393c58b006a923c5bb7878aee5c73e21b20 Maintainer: satoruyoshida Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: satoruyoshida Status: ready -->
 <reference xml:id="class.solrclientexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>SolrClientException クラス</title>

--- a/reference/solr/solrdocumentfield.xml
+++ b/reference/solr/solrdocumentfield.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ecaa2146429a7f88de40dfce14718afc896b74c5 Maintainer: satoruyoshida Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: satoruyoshida Status: ready -->
 <!-- Credits: mumumu -->
 <reference xml:id="class.solrdocumentfield" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/solr/solrexception.xml
+++ b/reference/solr/solrexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: satoruyoshida Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: satoruyoshida Status: ready -->
 <reference xml:id="class.solrexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>SolrException クラス</title>

--- a/reference/solr/solrgenericresponse.xml
+++ b/reference/solr/solrgenericresponse.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ecaa2146429a7f88de40dfce14718afc896b74c5 Maintainer: satoruyoshida Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: satoruyoshida Status: ready -->
 <reference xml:id="class.solrgenericresponse" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>SolrGenericResponse クラス</title>

--- a/reference/solr/solrillegalargumentexception.xml
+++ b/reference/solr/solrillegalargumentexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: b7fc1cdcf2682e481669db5f07dcfeefea0ee555 Maintainer: satoruyoshida Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: satoruyoshida Status: ready -->
 <reference xml:id="class.solrillegalargumentexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>SolrIllegalArgumentException クラス</title>

--- a/reference/solr/solrillegaloperationexception.xml
+++ b/reference/solr/solrillegaloperationexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 38e65393c58b006a923c5bb7878aee5c73e21b20 Maintainer: satoruyoshida Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: satoruyoshida Status: ready -->
 <reference xml:id="class.solrillegaloperationexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>SolrIllegalOperationException クラス</title>

--- a/reference/solr/solrinputdocument.xml
+++ b/reference/solr/solrinputdocument.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ecaa2146429a7f88de40dfce14718afc896b74c5 Maintainer: satoruyoshida Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: satoruyoshida Status: ready -->
 <reference xml:id="class.solrinputdocument" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>SolrInputDocument クラス</title>

--- a/reference/solr/solrmodifiableparams.xml
+++ b/reference/solr/solrmodifiableparams.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ecaa2146429a7f88de40dfce14718afc896b74c5 Maintainer: satoruyoshida Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: satoruyoshida Status: ready -->
 <reference xml:id="class.solrmodifiableparams" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>SolrModifiableParams クラス</title>

--- a/reference/solr/solrobject.xml
+++ b/reference/solr/solrobject.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ecaa2146429a7f88de40dfce14718afc896b74c5 Maintainer: satoruyoshida Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: satoruyoshida Status: ready -->
 <reference xml:id="class.solrobject" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>SolrObject クラス</title>

--- a/reference/solr/solrparams.xml
+++ b/reference/solr/solrparams.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 79930e5bd33c2f11c2e9bda5fb5557ee41909a7d Maintainer: satoruyoshida Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: satoruyoshida Status: ready -->
 <reference xml:id="class.solrparams" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>SolrParams クラス</title>

--- a/reference/solr/solrpingresponse.xml
+++ b/reference/solr/solrpingresponse.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ecaa2146429a7f88de40dfce14718afc896b74c5 Maintainer: satoruyoshida Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: satoruyoshida Status: ready -->
 <reference xml:id="class.solrpingresponse" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>SolrPingResponse クラス</title>

--- a/reference/solr/solrqueryresponse.xml
+++ b/reference/solr/solrqueryresponse.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ecaa2146429a7f88de40dfce14718afc896b74c5 Maintainer: satoruyoshida Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: satoruyoshida Status: ready -->
 <reference xml:id="class.solrqueryresponse" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>SolrQueryResponse クラス</title>

--- a/reference/solr/solrresponse.xml
+++ b/reference/solr/solrresponse.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: satoruyoshida Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: satoruyoshida Status: ready -->
 <reference xml:id="class.solrresponse" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>SolrResponse クラス</title>

--- a/reference/solr/solrserverexception.xml
+++ b/reference/solr/solrserverexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: iwamot Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: iwamot Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.solrserverexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/solr/solrupdateresponse.xml
+++ b/reference/solr/solrupdateresponse.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ecaa2146429a7f88de40dfce14718afc896b74c5 Maintainer: satoruyoshida Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: satoruyoshida Status: ready -->
 <reference xml:id="class.solrupdateresponse" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>SolrUpdateResponse クラス</title>

--- a/reference/solr/solrutils.xml
+++ b/reference/solr/solrutils.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 734ddd27ada5fdc8fbd2724e4c9e08881649dec1 Maintainer: satoruyoshida Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: satoruyoshida Status: ready -->
 <reference xml:id="class.solrutils" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>SolrUtils クラス</title>

--- a/reference/spl/appenditerator.xml
+++ b/reference/spl/appenditerator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <reference xml:id="class.appenditerator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>AppendIterator クラス</title>

--- a/reference/spl/badfunctioncallexception.xml
+++ b/reference/spl/badfunctioncallexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <reference xml:id="class.badfunctioncallexception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>BadFunctionCallException クラス</title>

--- a/reference/spl/badmethodcallexception.xml
+++ b/reference/spl/badmethodcallexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <reference xml:id="class.badmethodcallexception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>BadMethodCallException クラス</title>

--- a/reference/spl/cachingiterator.xml
+++ b/reference/spl/cachingiterator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <reference xml:id="class.cachingiterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>CachingIterator クラス</title>
  <titleabbrev>CachingIterator</titleabbrev>

--- a/reference/spl/callbackfilteriterator.xml
+++ b/reference/spl/callbackfilteriterator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <reference xml:id="class.callbackfilteriterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>CallbackFilterIterator クラス</title>

--- a/reference/spl/directoryiterator.xml
+++ b/reference/spl/directoryiterator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <reference xml:id="class.directoryiterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>DirectoryIterator クラス</title>
  <titleabbrev>DirectoryIterator</titleabbrev>

--- a/reference/spl/domainexception.xml
+++ b/reference/spl/domainexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <reference xml:id="class.domainexception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>DomainException クラス</title>

--- a/reference/spl/emptyiterator.xml
+++ b/reference/spl/emptyiterator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <reference xml:id="class.emptyiterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>EmptyIterator クラス</title>

--- a/reference/spl/filesystemiterator.xml
+++ b/reference/spl/filesystemiterator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <reference xml:id="class.filesystemiterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>FilesystemIterator クラス</title>

--- a/reference/spl/filteriterator.xml
+++ b/reference/spl/filteriterator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <reference xml:id="class.filteriterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>FilterIterator クラス</title>
  <titleabbrev>FilterIterator</titleabbrev>

--- a/reference/spl/globiterator.xml
+++ b/reference/spl/globiterator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <reference xml:id="class.globiterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/spl/infiniteiterator.xml
+++ b/reference/spl/infiniteiterator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <reference xml:id="class.infiniteiterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>InfiniteIterator クラス</title>

--- a/reference/spl/invalidargumentexception.xml
+++ b/reference/spl/invalidargumentexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <reference xml:id="class.invalidargumentexception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>InvalidArgumentException クラス</title>

--- a/reference/spl/iteratoriterator.xml
+++ b/reference/spl/iteratoriterator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <reference xml:id="class.iteratoriterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>IteratorIterator クラス</title>

--- a/reference/spl/lengthexception.xml
+++ b/reference/spl/lengthexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <reference xml:id="class.lengthexception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>LengthException クラス</title>

--- a/reference/spl/limititerator.xml
+++ b/reference/spl/limititerator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <reference xml:id="class.limititerator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>LimitIterator クラス</title>
  <titleabbrev>LimitIterator</titleabbrev>

--- a/reference/spl/logicexception.xml
+++ b/reference/spl/logicexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <reference xml:id="class.logicexception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>LogicException クラス</title>

--- a/reference/spl/multipleiterator.xml
+++ b/reference/spl/multipleiterator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <reference xml:id="class.multipleiterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>MultipleIterator クラス</title>

--- a/reference/spl/norewinditerator.xml
+++ b/reference/spl/norewinditerator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <reference xml:id="class.norewinditerator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>NoRewindIterator クラス</title>

--- a/reference/spl/outeriterator.xml
+++ b/reference/spl/outeriterator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9eb4a46bba05da229be4c8f7a3cb64702e1a2f95 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <reference xml:id="class.outeriterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>OuterIterator インターフェイス</title>

--- a/reference/spl/outofrangeexception.xml
+++ b/reference/spl/outofrangeexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <reference xml:id="class.outofrangeexception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>OutOfRangeException クラス</title>

--- a/reference/spl/overflowexception.xml
+++ b/reference/spl/overflowexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <reference xml:id="class.overflowexception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>OverflowException クラス</title>

--- a/reference/spl/parentiterator.xml
+++ b/reference/spl/parentiterator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <reference xml:id="class.parentiterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>ParentIterator クラス</title>

--- a/reference/spl/rangeexception.xml
+++ b/reference/spl/rangeexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <reference xml:id="class.rangeexception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>RangeException クラス</title>

--- a/reference/spl/recursivearrayiterator.xml
+++ b/reference/spl/recursivearrayiterator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 75dfe6f1169abbe5c6787c4b54f4c0bfa62da3fe Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <reference xml:id="class.recursivearrayiterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>RecursiveArrayIterator クラス</title>

--- a/reference/spl/recursivecachingiterator.xml
+++ b/reference/spl/recursivecachingiterator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <reference xml:id="class.recursivecachingiterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>RecursiveCachingIterator クラス</title>

--- a/reference/spl/recursivecallbackfilteriterator.xml
+++ b/reference/spl/recursivecallbackfilteriterator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <reference xml:id="class.recursivecallbackfilteriterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>RecursiveCallbackFilterIterator クラス</title>

--- a/reference/spl/recursivedirectoryiterator.xml
+++ b/reference/spl/recursivedirectoryiterator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <reference xml:id="class.recursivedirectoryiterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>RecursiveDirectoryIterator クラス</title>

--- a/reference/spl/recursiveiterator.xml
+++ b/reference/spl/recursiveiterator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9eb4a46bba05da229be4c8f7a3cb64702e1a2f95 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <reference xml:id="class.recursiveiterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>RecursiveIterator インターフェイス</title>

--- a/reference/spl/recursiveiteratoriterator.xml
+++ b/reference/spl/recursiveiteratoriterator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <reference xml:id="class.recursiveiteratoriterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>RecursiveIteratorIterator クラス</title>

--- a/reference/spl/recursiveregexiterator.xml
+++ b/reference/spl/recursiveregexiterator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <reference xml:id="class.recursiveregexiterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>RecursiveRegexIterator クラス</title>

--- a/reference/spl/recursivetreeiterator.xml
+++ b/reference/spl/recursivetreeiterator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <reference xml:id="class.recursivetreeiterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/spl/regexiterator.xml
+++ b/reference/spl/regexiterator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <reference xml:id="class.regexiterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>RegexIterator クラス</title>
  <titleabbrev>RegexIterator</titleabbrev>

--- a/reference/spl/runtimeexception.xml
+++ b/reference/spl/runtimeexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <reference xml:id="class.runtimeexception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>RuntimeException クラス</title>

--- a/reference/spl/seekableiterator.xml
+++ b/reference/spl/seekableiterator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 62126c55f1c6ed444043e7272c4f9e233818a44b Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <reference xml:id="class.seekableiterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>SeekableIterator インターフェイス</title>

--- a/reference/spl/spldoublylinkedlist.xml
+++ b/reference/spl/spldoublylinkedlist.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <reference xml:id="class.spldoublylinkedlist" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>SplDoublyLinkedList クラス</title>

--- a/reference/spl/splfileinfo.xml
+++ b/reference/spl/splfileinfo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <reference xml:id="class.splfileinfo" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/spl/splfileobject.xml
+++ b/reference/spl/splfileobject.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: masakielastic Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: masakielastic Status: ready -->
 <!-- Credits: mumumu -->
 <reference xml:id="class.splfileobject" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/spl/splheap.xml
+++ b/reference/spl/splheap.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <reference xml:id="class.splheap" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>SplHeap クラス</title>
  <titleabbrev>SplHeap</titleabbrev>

--- a/reference/spl/splmaxheap.xml
+++ b/reference/spl/splmaxheap.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <reference xml:id="class.splmaxheap" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>SplMaxHeap クラス</title>
  <titleabbrev>SplMaxHeap</titleabbrev>

--- a/reference/spl/splminheap.xml
+++ b/reference/spl/splminheap.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <reference xml:id="class.splminheap" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>SplMinHeap クラス</title>
  <titleabbrev>SplMinHeap</titleabbrev>

--- a/reference/spl/splobserver.xml
+++ b/reference/spl/splobserver.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9eb4a46bba05da229be4c8f7a3cb64702e1a2f95 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <reference xml:id="class.splobserver" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>SplObserver インターフェイス</title>

--- a/reference/spl/splqueue.xml
+++ b/reference/spl/splqueue.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <reference xml:id="class.splqueue" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>SplQueue クラス</title>
  <titleabbrev>SplQueue</titleabbrev>

--- a/reference/spl/splstack.xml
+++ b/reference/spl/splstack.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <reference xml:id="class.splstack" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>SplStack クラス</title>
  <titleabbrev>SplStack</titleabbrev>

--- a/reference/spl/splsubject.xml
+++ b/reference/spl/splsubject.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9eb4a46bba05da229be4c8f7a3cb64702e1a2f95 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <reference xml:id="class.splsubject" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>SplSubject インターフェイス</title>

--- a/reference/spl/spltempfileobject.xml
+++ b/reference/spl/spltempfileobject.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
 <reference xml:id="class.spltempfileobject" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>SplTempFileObject クラス</title>

--- a/reference/spl/underflowexception.xml
+++ b/reference/spl/underflowexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <reference xml:id="class.underflowexception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>UnderflowException クラス</title>

--- a/reference/spl/unexpectedvalueexception.xml
+++ b/reference/spl/unexpectedvalueexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <reference xml:id="class.unexpectedvalueexception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>UnexpectedValueException クラス</title>

--- a/reference/sqlite3/sqlite3exception.xml
+++ b/reference/sqlite3/sqlite3exception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: df58adf8fff5cf7dea921a841e28ea2478e678ea Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
 <reference xml:id="class.sqlite3exception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>SQLite3Exception クラス</title>
  <titleabbrev>SQLite3Exception</titleabbrev>

--- a/reference/sqlite3/sqlite3result.xml
+++ b/reference/sqlite3/sqlite3result.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <reference xml:id="class.sqlite3result" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>SQLite3Result クラス</title>
  <titleabbrev>SQLite3Result</titleabbrev>

--- a/reference/sqlite3/sqlite3stmt.xml
+++ b/reference/sqlite3/sqlite3stmt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <reference xml:id="class.sqlite3stmt" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>SQLite3Stmt クラス</title>
  <titleabbrev>SQLite3Stmt</titleabbrev>

--- a/reference/stream/php-user-filter.xml
+++ b/reference/stream/php-user-filter.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <reference xml:id="class.php-user-filter" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/stream/streamwrapper.xml
+++ b/reference/stream/streamwrapper.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ecaa2146429a7f88de40dfce14718afc896b74c5 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: c62ef37e0d58067b393a6cf3a14aefed90bc0bff Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 
 <reference xml:id="class.streamwrapper" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/tidy/tidy.xml
+++ b/reference/tidy/tidy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <reference xml:id="class.tidy" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title><classname>tidy</classname> クラス</title>
  <titleabbrev>tidy</titleabbrev>

--- a/reference/tidy/tidynode.xml
+++ b/reference/tidy/tidynode.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <reference xml:id="class.tidynode" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title><classname>tidyNode</classname> クラス</title>

--- a/reference/tokenizer/phptoken.xml
+++ b/reference/tokenizer/phptoken.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
 <reference xml:id="class.phptoken" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>PhpToken クラス</title>

--- a/reference/v8js/v8js.xml
+++ b/reference/v8js/v8js.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 6ceccac7860f382f16ac1407baf54f656e85ca0b Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: takagi Status: ready -->
 
 <reference xml:id="class.v8js" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title><classname>V8Js</classname> クラス</title>

--- a/reference/v8js/v8jsexception.xml
+++ b/reference/v8js/v8jsexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 38e65393c58b006a923c5bb7878aee5c73e21b20 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: takagi Status: ready -->
 
 <reference xml:id="class.v8jsexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/varnish/varnishadmin.xml
+++ b/reference/varnish/varnishadmin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 816c55b8e18c5c286e5baa4570109622a0128c37 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: takagi Status: ready -->
 <!-- CREDITS: satoruyoshida -->
 <reference xml:id="class.varnishadmin" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/varnish/varnishexception.xml
+++ b/reference/varnish/varnishexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 38e65393c58b006a923c5bb7878aee5c73e21b20 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: takagi Status: ready -->
 <!-- CREDITS: satoruyoshida -->
 <reference xml:id="class.varnishexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/varnish/varnishlog.xml
+++ b/reference/varnish/varnishlog.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 6ceccac7860f382f16ac1407baf54f656e85ca0b Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: takagi Status: ready -->
 
 <reference xml:id="class.varnishlog" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/varnish/varnishstat.xml
+++ b/reference/varnish/varnishstat.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 816c55b8e18c5c286e5baa4570109622a0128c37 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: takagi Status: ready -->
 <!-- CREDITS: satoruyoshida -->
 <reference xml:id="class.varnishstat" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/win32service/win32serviceexception.xml
+++ b/reference/win32service/win32serviceexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 6ceccac7860f382f16ac1407baf54f656e85ca0b Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
 
 <reference xml:id="class.win32serviceexception"
  role="exception"

--- a/reference/wkhtmltox/wkhtmltox.image.converter.xml
+++ b/reference/wkhtmltox/wkhtmltox.image.converter.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 3f75f75dcf86e42bc79d5753836fee49ea6a97be Maintainer: iwamot Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: iwamot Status: ready -->
 
 <reference xml:id="class.wkhtmltox-image-converter" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/wkhtmltox/wkhtmltox.pdf.converter.xml
+++ b/reference/wkhtmltox/wkhtmltox.pdf.converter.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 3f75f75dcf86e42bc79d5753836fee49ea6a97be Maintainer: iwamot Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: iwamot Status: ready -->
 
 <reference xml:id="class.wkhtmltox-pdf-converter" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/xml/xmlparser.xml
+++ b/reference/xml/xmlparser.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: mumumu Status: ready -->
 <reference xml:id="class.xmlparser" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>XMLParser クラス</title>

--- a/reference/xmlwriter/xmlwriter.xml
+++ b/reference/xmlwriter/xmlwriter.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
 <reference xml:id="class.xmlwriter" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>XMLWriter クラス</title>

--- a/reference/yaf/yaf-action-abstract.xml
+++ b/reference/yaf/yaf-action-abstract.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: eec6a4a36bf452bf271f116e7b6b9bb09d1181c3 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: takagi Status: ready -->
 
 <reference xml:id="class.yaf-action-abstract" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/yaf/yaf-application.xml
+++ b/reference/yaf/yaf-application.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 62126c55f1c6ed444043e7272c4f9e233818a44b Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: takagi Status: ready -->
 
 <reference xml:id="class.yaf-application" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/yaf/yaf-bootstrap-abstract.xml
+++ b/reference/yaf/yaf-bootstrap-abstract.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 40ec84c3b39ae43075e2f98238907ae72cbd4bf8 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: takagi Status: ready -->
 
 <reference xml:id="class.yaf-bootstrap-abstract" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/yaf/yaf-config-abstract.xml
+++ b/reference/yaf/yaf-config-abstract.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d762a76c7171fc7babbe5719ebe7ca8ae9a13737 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: takagi Status: ready -->
 
 <reference xml:id="class.yaf-config-abstract" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/yaf/yaf-config-simple.xml
+++ b/reference/yaf/yaf-config-simple.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ecaa2146429a7f88de40dfce14718afc896b74c5 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: takagi Status: ready -->
 
 <reference xml:id="class.yaf-config-simple" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/yaf/yaf-controller-abstract.xml
+++ b/reference/yaf/yaf-controller-abstract.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 73fae4ee51b644b72028e610abefefced57c18ad Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: takagi Status: ready -->
 
 <reference xml:id="class.yaf-controller-abstract" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/yaf/yaf-dispatcher.xml
+++ b/reference/yaf/yaf-dispatcher.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ecaa2146429a7f88de40dfce14718afc896b74c5 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: takagi Status: ready -->
 
 <reference xml:id="class.yaf-dispatcher" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/yaf/yaf-exception-dispatchfailed.xml
+++ b/reference/yaf/yaf-exception-dispatchfailed.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: bb9b140e65773bcd6ee3a88a08b60925db5a08c3 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: takagi Status: ready -->
 
 <reference xml:id="class.yaf-exception-dispatchfailed" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/yaf/yaf-exception-loadfailed-action.xml
+++ b/reference/yaf/yaf-exception-loadfailed-action.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: bb9b140e65773bcd6ee3a88a08b60925db5a08c3 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: takagi Status: ready -->
 
 <reference xml:id="class.yaf-exception-loadfailed-action" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/yaf/yaf-exception-loadfailed-controller.xml
+++ b/reference/yaf/yaf-exception-loadfailed-controller.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: bb9b140e65773bcd6ee3a88a08b60925db5a08c3 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: takagi Status: ready -->
 
 <reference xml:id="class.yaf-exception-loadfailed-controller" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/yaf/yaf-exception-loadfailed-module.xml
+++ b/reference/yaf/yaf-exception-loadfailed-module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: bb9b140e65773bcd6ee3a88a08b60925db5a08c3 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: takagi Status: ready -->
 
 <reference xml:id="class.yaf-exception-loadfailed-module" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/yaf/yaf-exception-loadfailed-view.xml
+++ b/reference/yaf/yaf-exception-loadfailed-view.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: bb9b140e65773bcd6ee3a88a08b60925db5a08c3 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: takagi Status: ready -->
 
 <reference xml:id="class.yaf-exception-loadfailed-view" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/yaf/yaf-exception-loadfailed.xml
+++ b/reference/yaf/yaf-exception-loadfailed.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: bb9b140e65773bcd6ee3a88a08b60925db5a08c3 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: takagi Status: ready -->
 
 <reference xml:id="class.yaf-exception-loadfailed" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/yaf/yaf-exception-routerfailed.xml
+++ b/reference/yaf/yaf-exception-routerfailed.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: bb9b140e65773bcd6ee3a88a08b60925db5a08c3 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: takagi Status: ready -->
 
 <reference xml:id="class.yaf-exception-routerfailed" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/yaf/yaf-exception-startuperror.xml
+++ b/reference/yaf/yaf-exception-startuperror.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: bb9b140e65773bcd6ee3a88a08b60925db5a08c3 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: takagi Status: ready -->
 
 <reference xml:id="class.yaf-exception-startuperror" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/yaf/yaf-exception-typeerror.xml
+++ b/reference/yaf/yaf-exception-typeerror.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: bb9b140e65773bcd6ee3a88a08b60925db5a08c3 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: takagi Status: ready -->
 
 <reference xml:id="class.yaf-exception-typeerror" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/yaf/yaf-exception.xml
+++ b/reference/yaf/yaf-exception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ecaa2146429a7f88de40dfce14718afc896b74c5 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: takagi Status: ready -->
 
 <reference xml:id="class.yaf-exception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/yaf/yaf-plugin-abstract.xml
+++ b/reference/yaf/yaf-plugin-abstract.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 40ec84c3b39ae43075e2f98238907ae72cbd4bf8 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: takagi Status: ready -->
 
 <reference xml:id="class.yaf-plugin-abstract" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/yaf/yaf-registry.xml
+++ b/reference/yaf/yaf-registry.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ecaa2146429a7f88de40dfce14718afc896b74c5 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: takagi Status: ready -->
 
 <reference xml:id="class.yaf-registry" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/yaf/yaf-request-abstract.xml
+++ b/reference/yaf/yaf-request-abstract.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 6ceccac7860f382f16ac1407baf54f656e85ca0b Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: takagi Status: ready -->
 
 <reference xml:id="class.yaf-request-abstract" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/yaf/yaf-request-http.xml
+++ b/reference/yaf/yaf-request-http.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ecaa2146429a7f88de40dfce14718afc896b74c5 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: takagi Status: ready -->
 
 <reference xml:id="class.yaf-request-http" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/yaf/yaf-request-simple.xml
+++ b/reference/yaf/yaf-request-simple.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 6ceccac7860f382f16ac1407baf54f656e85ca0b Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: takagi Status: ready -->
 
 <reference xml:id="class.yaf-request-simple" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/yaf/yaf-response-abstract.xml
+++ b/reference/yaf/yaf-response-abstract.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 6ceccac7860f382f16ac1407baf54f656e85ca0b Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: takagi Status: ready -->
 
 <reference xml:id="class.yaf-response-abstract" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/yaf/yaf-response-cli.xml
+++ b/reference/yaf/yaf-response-cli.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 1f71c647dd6e32a7e4f03c33bac449c69ed2135b Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: takagi Status: ready -->
 
 <reference xml:id="class.yaf-response-cli" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/yaf/yaf-response-http.xml
+++ b/reference/yaf/yaf-response-http.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 1f71c647dd6e32a7e4f03c33bac449c69ed2135b Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: takagi Status: ready -->
 
 <reference xml:id="class.yaf-response-http" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/yaf/yaf-route-interface.xml
+++ b/reference/yaf/yaf-route-interface.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e434bf67baea73fa96b65c9b1021e30b97abacd3 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: takagi Status: ready -->
 
 <reference xml:id="class.yaf-route-interface" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/yaf/yaf-route-map.xml
+++ b/reference/yaf/yaf-route-map.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ecaa2146429a7f88de40dfce14718afc896b74c5 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 
 <reference xml:id="class.yaf-route-map" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/yaf/yaf-route-regex.xml
+++ b/reference/yaf/yaf-route-regex.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ecaa2146429a7f88de40dfce14718afc896b74c5 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: takagi Status: ready -->
 
 <reference xml:id="class.yaf-route-regex" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/yaf/yaf-route-rewrite.xml
+++ b/reference/yaf/yaf-route-rewrite.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ecaa2146429a7f88de40dfce14718afc896b74c5 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: takagi Status: ready -->
 
 <reference xml:id="class.yaf-route-rewrite" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/yaf/yaf-route-simple.xml
+++ b/reference/yaf/yaf-route-simple.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ecaa2146429a7f88de40dfce14718afc896b74c5 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: takagi Status: ready -->
 
 <reference xml:id="class.yaf-route-simple" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/yaf/yaf-route-supervar.xml
+++ b/reference/yaf/yaf-route-supervar.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ecaa2146429a7f88de40dfce14718afc896b74c5 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: takagi Status: ready -->
 
 <reference xml:id="class.yaf-route-supervar" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/yaf/yaf-router.xml
+++ b/reference/yaf/yaf-router.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ecaa2146429a7f88de40dfce14718afc896b74c5 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: takagi Status: ready -->
 
 <reference xml:id="class.yaf-router" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/yaf/yaf-session.xml
+++ b/reference/yaf/yaf-session.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ecaa2146429a7f88de40dfce14718afc896b74c5 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: takagi Status: ready -->
 
 <reference xml:id="class.yaf-session" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/yaf/yaf-view-interface.xml
+++ b/reference/yaf/yaf-view-interface.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 40ec84c3b39ae43075e2f98238907ae72cbd4bf8 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: takagi Status: ready -->
 
 <reference xml:id="class.yaf-view-interface" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/yaf/yaf-view-simple.xml
+++ b/reference/yaf/yaf-view-simple.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ecaa2146429a7f88de40dfce14718afc896b74c5 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: takagi Status: ready -->
 
 <reference xml:id="class.yaf-view-simple" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/zlib/deflatecontext.xml
+++ b/reference/zlib/deflatecontext.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: mumumu Status: ready -->
 <reference xml:id="class.deflatecontext" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>DeflateContext クラス</title>

--- a/reference/zlib/inflatecontext.xml
+++ b/reference/zlib/inflatecontext.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: mumumu Status: ready -->
 <reference xml:id="class.inflatecontext" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>InflateContext クラス</title>


### PR DESCRIPTION
#428 のrevtag修正（実際の更新は #418）や #427 はen側の機械的な修正への追随。それらに続き、更に前から存在していた php/doc-en#3415 （内容は追従済・revtagのみ未更新） の revtag を #428 と同じ基準で進める。

このPRの変更は `EN-Revision` のみ。かつ `[skip-revcheck]` 内の追従のみなのでrevcheckの結果は何も変わらないが、手打ちの `git log` 等でrevcheck外での更新を拾う際の偽陽性を防ぐ効果がある。

この作業により #428 で php/doc-en#3415 に更新がブロックされたrevtag139件が全件先へ進む。
