### PR TITLE
revcheck に現れないマークアップの原文乖離を修正

### DIFF
--- a/language/predefined/closure/call.xml
+++ b/language/predefined/closure/call.xml
@@ -14,10 +14,10 @@
    <methodparam><type>object</type><parameter>newThis</parameter></methodparam>
    <methodparam rep="repeat"><type>mixed</type><parameter>args</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    クロージャを一時的に <parameter>newThis</parameter> に束縛し、
    指定したパラメータでそれを呼び出します。
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -25,26 +25,26 @@
    <varlistentry>
     <term><parameter>newThis</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       この呼び出しの間だけクロージャを束縛するオブジェクト。
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>args</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       クロージャに渡すパラメータがある場合は、ここで指定します。
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    クロージャの戻り値を返します。
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/language/predefined/requestparsebodyexception.xml
+++ b/language/predefined/requestparsebodyexception.xml
@@ -11,7 +11,7 @@
   <section xml:id="RequestParseBodyException.intro">
    &reftitle.intro;
    <simpara>
-    <classname>RequestParseBodyException</classname> は、
+    <exceptionname>RequestParseBodyException</exceptionname> は、
     <function>request_parse_body</function> 内でリクエストボディが無効な場合にスローされます。
     これは、 <literal>Content-Type</literal> ヘッダーに基づいて判断されます。
    </simpara>

--- a/language/predefined/typeerror.xml
+++ b/language/predefined/typeerror.xml
@@ -11,7 +11,7 @@
   <section xml:id="typeerror.intro">
    &reftitle.intro;
    <para>
-    <ooclass><classname>TypeError</classname></ooclass> がスローされるのは、以下の場合です:
+    <exceptionname>TypeError</exceptionname> がスローされるのは、以下の場合です:
     <simplelist>
      <member>
       クラスのプロパティに設定されている値が、プロパティで宣言されている型と一致しない場合。
@@ -66,9 +66,9 @@
        <entry>
         strict モードの場合に、
         PHP の組み込みの関数に渡す引数の数を間違えた場合でも、
-        <classname>TypeError</classname> はスローされなくなりました。
-        代わりに、<classname>TypeError</classname> を継承した
-        <classname>ArgumentCountError</classname>
+        <exceptionname>TypeError</exceptionname> はスローされなくなりました。
+        代わりに、<exceptionname>TypeError</exceptionname> を継承した
+        <exceptionname>ArgumentCountError</exceptionname>
         がスローされるようになっています。
        </entry>
       </row>


### PR DESCRIPTION
#429 の作業中に発見。いずれも revtag が該当コミットより先を指しているため revcheck には現れない既訳バグ。

- `language/predefined/closure/call.xml` — 4段落を `para` から `simpara` に
- `language/predefined/requestparsebodyexception.xml` — `classname` を `exceptionname` に1箇所
- `language/predefined/typeerror.xml` — `classname` を `exceptionname` に3箇所、本文中の `<ooclass><classname>` を `exceptionname` に1箇所
