### PR TITLE
reference/datetime/formats.xml の para を simpara に揃える

### DIFF
--- a/reference/datetime/formats.xml
+++ b/reference/datetime/formats.xml
@@ -5,7 +5,7 @@
 <chapter xml:id="datetime.formats" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>サポートする日付と時刻の書式</title>
 
- <para>
+ <simpara>
   この節では
   <classname>DateTimeImmutable</classname>, <classname>DateTime</classname>,
  <function>date_create_immutable</function>, <function>date_create</function>, <function>date_parse</function>
@@ -19,16 +19,16 @@
   <literal>T</literal> とも書けます)。
   ダブルクォートで囲まれたフォーマットは大文字小文字を区別します。
   (<literal>"T"</literal> は <literal>T</literal> としか書けません)。
- </para>
- <para>
+ </simpara>
+ <simpara>
   <classname>DateTimeImmutable</classname> と <classname>DateTime</classname>
   オブジェクトをフォーマットするには、
   <function>DateTimeInterface::format</function> のドキュメントを参照ください。
- </para>
+ </simpara>
 
- <para>
+ <simpara>
   以下の一般的なルールを考慮すべきです。
- </para>
+ </simpara>
  <orderedlist>
   <listitem>
    <simpara>
@@ -143,19 +143,19 @@ object(DateTimeImmutable)#1 (3) {
  <sect1 annotations="chunk:false" xml:id="datetime.formats.time">
   <title>時刻の書式</title>
 
-  <para>
+  <simpara>
    このページでは、
    <classname>DateTimeImmutable</classname>, <classname>DateTime</classname>,
    <function>date_create</function>,
    <function>date_create_immutable</function>, そして
    <function>strtotime</function> のパーサーが理解する、
    BNFライクな時刻フォーマットを説明します。
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    <classname>DateTimeImmutable</classname> と <classname>DateTime</classname>
    オブジェクトをフォーマットするには、
    <function>DateTimeInterface::format</function> のドキュメントを参照ください。
-  </para>
+  </simpara>
 
   <table>
    <title>シンボル一覧</title>
@@ -306,7 +306,7 @@ object(DateTimeImmutable)#1 (3) {
  <sect1 annotations="chunk:false" xml:id="datetime.formats.date">
   <title>日付の書式</title>
   
-  <para>
+  <simpara>
    このページでは、
    <classname>DateTimeImmutable</classname>, <classname>DateTime</classname>,
    <function>date_create</function>,
@@ -314,12 +314,12 @@ object(DateTimeImmutable)#1 (3) {
    <function>strtotime</function>
    のパーサーが理解する、
    BNFライクな日付フォーマットを説明します。
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    <classname>DateTimeImmutable</classname> と <classname>DateTime</classname>
    オブジェクトをフォーマットするには、
    <function>DateTimeInterface::format</function> のドキュメントを参照ください。
-  </para>
+  </simpara>
 
   <table>
    <title>シンボル一覧</title>
@@ -542,43 +542,43 @@ object(DateTimeImmutable)#1 (3) {
   </table>
 
   <note>
-   <para>
+   <simpara>
     シンボル <literal>y</literal> または <literal>yy</literal> を含む書式について、
     100未満の年は特別な扱いになります。年が0から69までの間だった場合、
     2000を足した数になります。
     また、年が70から99までの間だった場合、1900を足した数になります。
     つまり、"00-01-01" は "2000-01-01"
     と解釈されます。
-   </para>
+   </simpara>
   </note>
 
   <note>
-   <para>
+   <simpara>
     書式「ドットかタブで区切られた、日、月、2桁の年」
     (<literal>dd</literal> [.\t] <literal>mm</literal> "."
     <literal>yy</literal>) は年が61から99の間のときだけ機能します。
     この範囲外の年を与えた場合には <emphasis>時刻の書式</emphasis> の
     "<literal>HH</literal> [.:] <literal>MM</literal> [.:] <literal>SS</literal>" が優先されます。
-   </para>
+   </simpara>
   </note>
 
   <note>
-   <para>
+   <simpara>
     書式「年 (年だけの指定)」は、時刻の指定が先に出現している場合のみ機能します。
     そうでない場合、指定された4桁が
     <literal>HH</literal> <literal>MM</literal>
     にマッチした場合にこれらふたつの日付要素が代わりに設定されます。
-   </para>
-   <para>
+   </simpara>
+   <simpara>
     年だけの指定を一貫してパースしたい場合は、
     <literal>Y</literal> を指定して
     <function>DateTimeImmutable::createFromFormat</function>
     を使ってください。
-   </para>
+   </simpara>
   </note>
 
   <caution>
-   <para>
+   <simpara>
     シンボル <literal>dd</literal> と <literal>DD</literal> について、
     オーバーフローやアンダーフローすることができます。
     つまり、 0 日は先月の最終日の意味になりますし、
@@ -586,45 +586,45 @@ object(DateTimeImmutable)#1 (3) {
     このルールにより、"2008-08-00" は "2008-07-31" と同一になり、
     "2008-06-31" は "2008-07-01" と同一になります
     ( 6 月は 30 日までしかないので)。
-   </para>
-   <para>
+   </simpara>
+   <simpara>
     「日」の範囲が 0 から 31 までに絞られていることに注意しましょう。
     先ほどの正規表現が示すとおりです。
     したがって、たとえば "2008-06-32" は日付文字列として妥当な形式ではなくなります。
-   </para>
-   <para>
+   </simpara>
+   <simpara>
     また、シンボル <literal>mm</literal> と <literal>MM</literal> についても
     0 を用いてアンダーフローすることができます。
     0 月は前年の 12 月を意味します。
     たとえば "2008-00-22" は "2007-12-22" と同一です。
-   </para>
-   <para>
+   </simpara>
+   <simpara>
     もしこれらを併用し、日も月もアンダーフローした場合は次のようになります。
     "2008-00-00" は、まず "2007-12-00" へと変換され、
     さらに "2007-11-30" へと変換されます。
     文字列 "0000-00-00" についても同様に "-0001-11-30" へと変形されます。
     (ISO 8601 における -1 年は、予測的グレゴリオ暦 (proleptic Gregorian calendar)
     で言うところの紀元前 2 年になります。)
-   </para>
+   </simpara>
   </caution>
  </sect1>
 
  <sect1 annotations="chunk:false" xml:id="datetime.formats.compound">
   <title>複合的な書式</title>
 
-  <para>
+  <simpara>
    このページでは、
    <classname>DateTimeImmutable</classname>, <classname>DateTime</classname>,
    <function>date_create</function>,
    <function>date_create_immutable</function> および
    <function>strtotime</function>  のパーサーが理解する、
    BNFライクな日付/時刻 複合フォーマットを説明します。
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    <classname>DateTimeImmutable</classname> と <classname>DateTime</classname>
    オブジェクトをフォーマットするには、
    <function>DateTimeInterface::format</function> のドキュメントを参照ください。
-  </para>
+  </simpara>
 
   <table>
    <title>シンボル一覧</title>
@@ -864,22 +864,22 @@ object(DateTimeImmutable)#1 (3) {
   </table>
 
   <note>
-   <para>
+   <simpara>
     書式「 ISO の年、 ISO の週番号」と
     「 ISO の年、 ISO の週番号、 ISO の曜日番号」で使われている
     "W" は大文字小文字を区別します。大文字の "W" だけが利用できます。
-   </para>
-   <para>
+   </simpara>
+   <simpara>
     「 SOAP 」、「 XMLRPC 」および「 WDDX 」の各書式中の
     "T" は大文字小文字を区別します。大文字の "T" だけが利用できます。
-   </para>
-   <para>
+   </simpara>
+   <simpara>
     書式「 Unix タイムスタンプ 」は、タイムゾーンを UTC に設定します。
-   </para>
-   <para>
+   </simpara>
+   <simpara>
     （訳注）書式「 Common Log Format 」は、 Apache ログにおける時刻の書式です。
-   </para>
-   <para>
+   </simpara>
+   <simpara>
     （訳注）書式「 ISO の年、 ISO の週番号」と
     「 ISO の年、 ISO の週番号、 ISO の曜日番号」は、
     ISO 8601で規定されている表記法です。
@@ -887,13 +887,13 @@ object(DateTimeImmutable)#1 (3) {
     たとえば、 ISO 8601 の定義では
     2010 年の第 1 週は 1 月 3 日から 1 月 9 日までとなり、
     2010 年の 1 月 1 日と 1 月 2 日は 2009 年の第 53 週に属します。
-   </para>
+   </simpara>
   </note>
  </sect1>
 
  <sect1 annotations="chunk:false" xml:id="datetime.formats.relative">
   <title>相対的な書式</title>
-  <para>
+  <simpara>
    このページでは、
    <classname>DateTimeImmutable</classname>,
    <classname>DateTime</classname>,
@@ -901,12 +901,12 @@ object(DateTimeImmutable)#1 (3) {
    <function>date_create_immutable</function>, そして
    <function>strtotime</function> のパーサーが理解する、
    BNFライクな相対日付/時刻フォーマットを説明します。
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    <classname>DateTimeImmutable</classname> と <classname>DateTime</classname>
    オブジェクトをフォーマットするには、
    <function>DateTimeInterface::format</function> のドキュメントを参照ください。
-  </para>
+  </simpara>
 
   <table>
    <title>シンボル一覧</title>
@@ -1064,11 +1064,11 @@ object(DateTimeImmutable)#1 (3) {
   </table>
 
   <note>
-   <para>
+   <simpara>
     相対的な記述は、相対的でない記述の <emphasis>後で</emphasis> 処理されます。
     このため、 "+1 week july 2008" と "july 2008 +1 week" とは同一になります。
-   </para>
-   <para>
+   </simpara>
+   <simpara>
     ただし、 "yesterday"、 "midnight"、 "today"、 "noon" そして "tomorrow"
     はこのルールの例外です。
     つまり、 "tomorrow 11:00" と "11:00 tomorrow" は異なります。
@@ -1077,8 +1077,8 @@ object(DateTimeImmutable)#1 (3) {
     2つ目の方は "2008-07-24 00:00" となります。
     このような結果になる理由は、
     これら5つの記述が現在時刻に直接影響するためです。
-   </para>
-   <para>
+   </simpara>
+   <simpara>
     "first day of" のようなキーワードは、
     相対的な書式文字列が使われるコンテクストに依存します。
     static メソッドや関数で使われた場合、
@@ -1087,7 +1087,7 @@ object(DateTimeImmutable)#1 (3) {
     <function>DateTimeImmutable::modify</function>
     で使われた場合、参照されるのは <literal>modify()</literal>
     メソッドがコールされたオブジェクトです。
-   </para>
+   </simpara>
   </note>
 
   <note>
@@ -1151,13 +1151,13 @@ object(DateTimeImmutable)#1 (3) {
      </simpara>
     </listitem>
    </orderedlist>
-   <para>
+   <simpara>
     また、書式 "<literal>ordinal</literal>
     <literal>space</literal> <literal>dayname</literal>
     <literal>space</literal> 'of' " と "'last' <literal>space</literal>
     <literal>dayname</literal> <literal>space</literal> 'of' "
     に含まれる "of" は少々特別扱いなので、注意してください。
-   </para>
+   </simpara>
    <orderedlist>
     <listitem>
      <simpara>
@@ -1197,21 +1197,21 @@ object(DateTimeImmutable)#1 (3) {
    </orderedlist>
   </note>
   <note>
-   <para>
+   <simpara>
     月数を相対指定すると、その途中に経過する月の日数を使って結果を算出します。
     たとえば "+2 month 2011-11-30" の結果は "2012-01-30" となります。
     11 月の日数は 30 日、12 月の日数は 31 日なので、
     その合計である 61 日後となるわけです。
-   </para>
+   </simpara>
   </note>
   <note>
-   <para>
+   <simpara>
     <literal>number</literal> は <emphasis>整数値</emphasis> です。
     つまり、小数値が与えられると、ドット(またはコンマ) はデリミタとして解釈されがちです。
     たとえば、<literal>'+1.5 hours'</literal> は
     <literal>'+1 hour +30 minutes'</literal> ではなく
     <literal>'+1 5 hours'</literal> のようにパースされます。
-   </para>
+   </simpara>
   </note>
 
   <sect2 role="changelog">


### PR DESCRIPTION
#430 と同種。#429 の作業中に発見した、revtag が該当コミットより先を指しているため revcheck には現れない既訳バグ。ファイルが大きく位置対応が取れないため #430 から分離した。

- `reference/datetime/formats.xml` — 28段落を `para` から `simpara` に（原文追従）
- 同ファイルの訳注2段落も `simpara` に（ja 独自の段落。上の変換により同じ `<note>` 内で `<p>` と `<span>` が混在するため）

en と ja でタグ列をアラインし、対応が取れた位置のみ変更している。訳文の変更はない。
