### PR TITLE
language-snippetsの同期

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1,7 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: be246a268d0d5ab0b215c429cb031e70c98327ef Maintainer: takagi Status: working -->
+<!-- EN-Revision: 6a2ad3ecf9b77855446019ed2d74aa6f734d35a8 Maintainer: takagi Status: ready -->
 <!-- Credits: hirokawa,haruki,shimooka,mumumu,jdkfx -->
+
+<!--
+  ## for japanese translators - ja翻訳者向けメモ
+
+  次のパッケージはja側が未訳のためエンティティも未翻訳:
+
+  - mongodb.*
+  - trader.*
+  - rnp.*
+
+  このスニペットのStatusもこれらのパッケージの翻訳状況は考慮しなくて良い。
+  該当パッケージの翻訳に対応する際に、該当エンティティの翻訳とこのコメントを更新すること。
+-->
 
 <!ENTITY installation.enabled.disable 'この拡張モジュールはデフォルトで有効になっています。無効にしたい場合は、次のオプションを指定してコンパイルします。'>
 
@@ -11,16 +24,6 @@
 
 <!ENTITY changelog.class-constants-typed '<row xmlns="http://docbook.org/ns/docbook"><entry>8.4.0</entry><entry>
 クラス定数が型付けされるようになりました。</entry></row>'>
-
-<!ENTITY warn.deprecated.feature-5-3-0.removed-6-0-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara>この機能は PHP 5.3.0 で
-<emphasis>非推奨</emphasis>となりました。
-この機能を使用しないことを強く推奨します。</simpara></warning>'>
-
-<!ENTITY warn.deprecated.function-5-3-0.removed-6-0-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara>この関数は PHP 5.3.0 で
-<emphasis>非推奨</emphasis>となりました。
-この機能を使用しないことを強く推奨します。</simpara></warning>'>
 
 <!-- Cautions -->
 <!ENTITY caution.cryptographically-insecure '<caution xmlns="http://docbook.org/ns/docbook">
@@ -97,12 +100,6 @@ xmlns="http://docbook.org/ns/docbook"><simpara>この関数は PHP 5.3.0 で
 <!ENTITY note.funcbyref '<note xmlns="http://docbook.org/ns/docbook"><simpara>
 引数をリファレンス渡しにすると、その引数への変更がすべてこの関数の返り値に反映されます。
 PHP 7 からは、引数が値渡しされた場合には現在の値も返されるようになりました。</simpara></note>'>
-
-<!ENTITY note.funcnoparam '<note xmlns="http://docbook.org/ns/docbook"><simpara>この関数は、
-カレントスコープに依存してパラメータの詳細を決定しますので、
-5.3.0 より前のバージョンでは関数パラメータとして使用することができません。
-もし、この値を渡さなければならない場合、戻り値を変数に割り当て、
-その変数を渡してください。</simpara></note>'>
 
 <!ENTITY note.func-named-params '<note xmlns="http://docbook.org/ns/docbook"><simpara>
 PHP 8.0.0 以降における func_*() 関数ファミリは、名前付き引数に関しては、ほぼ透過的に動作するはずです。つまり、渡された全ての引数は位置を指定したかのように扱われ、引数が指定されない場合は、デフォルト値で置き換えられるということです。
@@ -242,40 +239,18 @@ URL を使用することができます。ファイル名の指定方法に関�
 <!ENTITY deprecated.function 'この関数は推奨されなくなりました。'>
 <!ENTITY removed.function 'この関数は削除されました。'>
 
-<!ENTITY warn.deprecated.feature-5-3-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara>この機能は PHP 5.3.0 で
-<emphasis>非推奨</emphasis> となりました。
-この機能を使用しないことを強く推奨します。</simpara></warning>'>
-
 <!ENTITY warn.deprecated.feature-5-3-0.removed-5-4-0 '<warning
 xmlns="http://docbook.org/ns/docbook"><simpara>この機能は PHP 5.3.0 で
 <emphasis>非推奨</emphasis>となり、
 PHP 5.4.0 で<emphasis>削除</emphasis>されました。</simpara></warning>'>
 
-<!ENTITY warn.deprecated.function-5-3-0.removed-5-4-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara>この関数は PHP 5.3.0 で
-<emphasis>非推奨</emphasis>となり、
-PHP 5.4.0 で<emphasis>削除</emphasis>されました。</simpara></warning>'>
-
-<!ENTITY warn.deprecated.feature-5-5-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara>この機能は PHP 5.5.0 で
-<emphasis>非推奨</emphasis>になります。この機能に頼らないことを強く推奨します。</simpara></warning>'>
-
 <!ENTITY warn.deprecated.feature-5-6-0 '<warning
 xmlns="http://docbook.org/ns/docbook"><simpara>この機能は PHP 5.6.0 で
-<emphasis>非推奨</emphasis>になります。この機能に頼らないことを強く推奨します。</simpara></warning>'>
-
-<!ENTITY warn.deprecated.feature-7-0-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara>この機能は PHP 7.0.0 で
 <emphasis>非推奨</emphasis>になります。この機能に頼らないことを強く推奨します。</simpara></warning>'>
 
 <!ENTITY warn.deprecated.feature-7-1-0 '<warning
 xmlns="http://docbook.org/ns/docbook"><simpara>この機能は PHP 7.1.0 で
 <emphasis>非推奨</emphasis>になります。この機能に頼らないことを強く推奨します。</simpara></warning>'>
-
-<!ENTITY warn.deprecated.function-7-1-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara>この関数は PHP 7.1.0 で
-<emphasis>非推奨</emphasis>になります。この関数に頼らないことを強く推奨します。</simpara></warning>'>
 
 <!ENTITY warn.deprecated.function-7-0-0.removed-8-0-0 '<warning
 xmlns="http://docbook.org/ns/docbook"><simpara>この関数は PHP 7.0.0 で
@@ -296,10 +271,6 @@ xmlns="http://docbook.org/ns/docbook"><simpara>この機能は PHP 7.2.0 で
 <emphasis>非推奨</emphasis> になり、PHP 8.0.0 で <emphasis>削除</emphasis>
 されました。この機能に頼らないことを強く推奨します。</simpara></warning>'>
 
-<!ENTITY warn.deprecated.function-7-2-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara>この関数は PHP 7.2.0 で
-<emphasis>非推奨</emphasis>になります。この関数に頼らないことを強く推奨します。</simpara></warning>'>
-
 <!ENTITY warn.deprecated.function-7-2-0.removed-8-0-0 '<warning
 xmlns="http://docbook.org/ns/docbook"><simpara>この関数は PHP 7.2.0 で
 <emphasis>非推奨</emphasis> になり、PHP 8.0.0 で <emphasis>削除</emphasis>
@@ -309,18 +280,10 @@ xmlns="http://docbook.org/ns/docbook"><simpara>この関数は PHP 7.2.0 で
 xmlns="http://docbook.org/ns/docbook"><simpara>この機能は PHP 7.3.0 で
 <emphasis>非推奨</emphasis>になります。この機能に頼らないことを強く推奨します。</simpara></warning>'>
 
-<!ENTITY warn.deprecated.function-7-3-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara>この関数は PHP 7.3.0 で
-<emphasis>非推奨</emphasis>になります。この関数に頼らないことを強く推奨します。</simpara></warning>'>
-
 <!ENTITY warn.deprecated.function-7-3-0.removed-8-0-0 '<warning
 xmlns="http://docbook.org/ns/docbook"><simpara>この関数は PHP 7.3.0 で
 <emphasis>非推奨</emphasis> になり、PHP 8.0.0 で <emphasis>削除</emphasis>
 されました。この関数に頼らないことを強く推奨します。</simpara></warning>'>
-
-<!ENTITY warn.deprecated.feature-7-4-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara>この機能は PHP 7.4.0 で
-<emphasis>非推奨</emphasis>になります。この機能に頼らないことを強く推奨します。</simpara></warning>'>
 
 <!ENTITY warn.deprecated.function-7-4-0 '<warning
 xmlns="http://docbook.org/ns/docbook"><simpara>この関数は PHP 7.4.0 で
@@ -359,10 +322,6 @@ xmlns="http://docbook.org/ns/docbook"><simpara>この機能は PHP 8.3.0 で
 xmlns="http://docbook.org/ns/docbook"><simpara>この関数は PHP 8.3.0 で
 <emphasis>非推奨</emphasis>になります。この関数に頼らないことを強く推奨します。</simpara></warning>'>
 
-<!ENTITY warn.deprecated.feature-8-4-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara>この機能は PHP 8.4.0 で
-<emphasis>非推奨</emphasis>になります。この機能に頼らないことを強く推奨します。</simpara></warning>'>
-
 <!ENTITY warn.deprecated.function-8-4-0 '<warning
 xmlns="http://docbook.org/ns/docbook"><simpara>この関数は PHP 8.4.0 で
 <emphasis>非推奨</emphasis>になります。この関数に頼らないことを強く推奨します。</simpara></warning>'>
@@ -378,51 +337,12 @@ xmlns="http://docbook.org/ns/docbook"><simpara>この関数は PHP 8.5.0 で
 <!ENTITY removed.php.future 'この非推奨の機能は、<emphasis xmlns="http://docbook.org/ns/docbook">きっと</emphasis>
 将来 <emphasis xmlns="http://docbook.org/ns/docbook">削除</emphasis> されるでしょう。'>
 
-<!ENTITY warn.deprecated.function.removed-5-3-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
-この関数は <emphasis>非推奨</emphasis> であり、PHP 5.3.0 で <emphasis>削除</emphasis> されます。</simpara></warning>'>
-
-<!ENTITY warn.deprecated.function.removed-5-5-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara>この関数は
-<emphasis>非推奨</emphasis> であり、PHP 5.5.0 で <emphasis>削除</emphasis> されます。</simpara></warning>'>
-
-<!ENTITY warn.deprecated.alias-5-3-0 '<warning xmlns="http://docbook.org/ns/docbook">
-<simpara>このエイリアスは PHP 5.3.0 で <emphasis>非推奨</emphasis> となりました。
-このエイリアスを使用しないことを強く推奨します。</simpara></warning>'>
-
-<!ENTITY warn.deprecated.func-5-4-0 '<warning xmlns="http://docbook.org/ns/docbook">
-<simpara>この関数は、PHP 5.4.0 以降では<emphasis>非推奨</emphasis>となりました。
-この関数は決して使わないようにしましょう。</simpara></warning>'>
-
 <!ENTITY warn.deprecated.alias-5-4-0 '<warning xmlns="http://docbook.org/ns/docbook">
 <simpara>このエイリアスは PHP 5.4.0 で <emphasis>非推奨</emphasis> となりました。
 このエイリアスを使用しないことを強く推奨します。</simpara></warning>'>
 
-<!ENTITY warn.deprecated.func-5-5-0 '<warning xmlns="http://docbook.org/ns/docbook">
-<simpara>この関数は PHP 5.5.0 で <emphasis>非推奨</emphasis> となりました。
-この関数に頼らないことを強く推奨します。</simpara></warning>'>
-
-<!ENTITY warn.deprecated.feature-5-5-0.removed-7-0-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara>この機能は PHP 5.5.0 で <emphasis>非推奨</emphasis> となり、
-PHP 7.0.0 で <emphasis>削除</emphasis> されました。</simpara></warning>'>
-
-<!ENTITY warn.deprecated.function-5-5-0.removed-7-0-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara>この関数は PHP 5.5.0 で <emphasis>非推奨</emphasis> となり、
-PHP 7.0.0 で <emphasis>削除</emphasis> されました。</simpara></warning>'>
-
-<!ENTITY warn.deprecated.function-5-3-0.removed-7-0-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara>この関数は PHP 5.3.0 で <emphasis>非推奨</emphasis> となり、
-PHP 7.0.0 で <emphasis>削除</emphasis> されました。</simpara></warning>'>
-
-<!ENTITY warn.deprecated.function-4-1-0.removed-7-0-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara>この関数は PHP 4.1.0 で <emphasis>非推奨</emphasis> となり、
-PHP 7.0.0 で <emphasis>削除</emphasis> されました。</simpara></warning>'>
-
 <!ENTITY warn.deprecated.alias-5-3-0.removed-7-0-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
 このエイリアスは PHP 5.3.0 で <emphasis>非推奨</emphasis> となり、
-PHP 7.0.0 で <emphasis>削除</emphasis> されました。</simpara></warning>'>
-
-<!ENTITY warn.deprecated.feature-5-6-0.removed-7-0-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara>この機能は PHP 5.6.0 で <emphasis>非推奨</emphasis> となり、
 PHP 7.0.0 で <emphasis>削除</emphasis> されました。</simpara></warning>'>
 
 <!ENTITY warn.removed.function-7-0-0 '<warning
@@ -484,14 +404,6 @@ PHP では、<literal>https://</literal> ラッパーでストリームをオー
 あなたが <literal>ssl://</literal> ソケットを作成するために  <function>fsockopen</function> を使用している場合、
 自らこの警告を検出し、抑制する必要があります。</simpara></warning>'>
 
-<!ENTITY warn.undocumented.class '
-<warning xmlns="http://docbook.org/ns/docbook">
- <simpara>
-  このクラスは、現在のところ詳細な情報はありません。プロパティとメソッドのリストのみが記述されています。
- </simpara>
-</warning>
-'>
-
 <!ENTITY warn.undocumented.func '<warning xmlns="http://docbook.org/ns/docbook"><simpara>この関数は、
 現在のところ詳細な情報はありません。引数のリストのみが
 記述されています。</simpara></warning>'>
@@ -500,64 +412,6 @@ PHP では、<literal>https://</literal> ラッパーでストリームをオー
 <!-- Deprecation and removal warnings designed for use with a list of
      alternatives. See en/reference/regex/functions/ereg.xml and
      en/reference/regex/reference.xml for examples of these in action. -->
-
-<!ENTITY warn.deprecated.function.4-1-0.removed.7-0-0.alternatives '
-<simpara xmlns="http://docbook.org/ns/docbook">
- この関数は PHP 4.1.0 で <emphasis>非推奨</emphasis> となり、
- PHP 7.0.0 で <emphasis>削除</emphasis> されました。
-</simpara>
-<simpara xmlns="http://docbook.org/ns/docbook">
- この関数の代替として、これらが使えます。
-</simpara>
-'>
-
-<!ENTITY warn.deprecated.feature.5-3-0.removed.7-0-0.alternatives '
-<simpara xmlns="http://docbook.org/ns/docbook">
- この機能は PHP 5.3.0 で <emphasis>非推奨</emphasis> となり、
- PHP 7.0.0 で <emphasis>削除</emphasis> されました。
-</simpara>
-<simpara xmlns="http://docbook.org/ns/docbook">
- この機能の代替として、これらが使えます。
-</simpara>
-'>
-
-<!ENTITY warn.deprecated.function.5-3-0.removed.7-0-0.alternatives '
-<simpara xmlns="http://docbook.org/ns/docbook">
- この関数は PHP 5.3.0 で <emphasis>非推奨</emphasis> となり、
- PHP 7.0.0 で <emphasis>削除</emphasis> されました。
-</simpara>
-<simpara xmlns="http://docbook.org/ns/docbook">
- この関数の代替として、これらが使えます。
-</simpara>
-'>
-
-<!ENTITY warn.deprecated.function.5-5-0.removed.7-0-0.alternatives '
-<simpara xmlns="http://docbook.org/ns/docbook">
- この関数は PHP 5.5.0 で <emphasis>非推奨</emphasis> となり、
- PHP 7.0.0 で <emphasis>削除</emphasis> されました。
-</simpara>
-<simpara xmlns="http://docbook.org/ns/docbook">
- この関数の代替として、これらが使えます。
-</simpara>
-'>
-
-<!ENTITY warn.removed.feature.7-0-0.alternatives '
-<simpara xmlns="http://docbook.org/ns/docbook">
- この機能は PHP 7.0.0 で <emphasis>削除</emphasis> されました。
-</simpara>
-<simpara xmlns="http://docbook.org/ns/docbook">
- この機能の代替として、これらが使えます。
-</simpara>
-'>
-
-<!ENTITY warn.removed.function.7-0-0.alternatives '
-<simpara xmlns="http://docbook.org/ns/docbook">
- この関数は PHP 7.0.0 で <emphasis>削除</emphasis> されました。
-</simpara>
-<simpara xmlns="http://docbook.org/ns/docbook">
- この関数の代替として、これらが使えます。
-</simpara>
-'>
 
 <!ENTITY warn.deprecated.feature.7-1-0.removed.7-2-0.alternatives '
 <simpara xmlns="http://docbook.org/ns/docbook">
@@ -591,8 +445,6 @@ xmlns="http://docbook.org/ns/docbook"><simpara>この関数は PHP 8.1.0 で
 
 <!ENTITY version.exists.asof 'これが使えるようになった PHP のバージョンは '>
 
-<!ENTITY version.trunk.changelog '将来のバージョン'>
-
 <!ENTITY no.function.parameters '<simpara xmlns="http://docbook.org/ns/docbook">この関数にはパラメータはありません。</simpara>'>
 
 <!ENTITY example.outputs '<simpara xmlns="http://docbook.org/ns/docbook">上の例の出力は以下となります。</simpara>'>
@@ -612,8 +464,6 @@ xmlns="http://docbook.org/ns/docbook"><simpara>この関数は PHP 8.1.0 で
 <!ENTITY example.outputs.70 '<simpara xmlns="http://docbook.org/ns/docbook">上の例の PHP 7.0 での出力は、このようになります。</simpara>'>
 
 <!ENTITY example.outputs.71 '<simpara xmlns="http://docbook.org/ns/docbook">上の例の PHP 7.1 での出力は、このようになります。</simpara>'>
-
-<!ENTITY example.outputs.72 '<simpara xmlns="http://docbook.org/ns/docbook">上の例の PHP 7.2 での出力は、このようになります。</simpara>'>
 
 <!ENTITY example.outputs.73 '<simpara xmlns="http://docbook.org/ns/docbook">上の例の PHP 7.3 での出力は、このようになります。</simpara>'>
 
@@ -637,8 +487,6 @@ xmlns="http://docbook.org/ns/docbook"><simpara>この関数は PHP 8.1.0 で
 
 <!ENTITY example.outputs.84.similar '<simpara xmlns="http://docbook.org/ns/docbook">上の例の PHP 8.4 での出力は、たとえば以下のようになります。:</simpara>'>
 
-<!ENTITY example.outputs.85 '<simpara xmlns="http://docbook.org/ns/docbook">上の例の PHP 8.5 での出力は、このようになります。:</simpara>'>
-
 <!ENTITY example.outputs.85.similar '<simpara xmlns="http://docbook.org/ns/docbook">上の例の PHP 8.5 での出力は、たとえば以下のようになります。:</simpara>'>
 
 <!ENTITY example.outputs.32bit '<simpara xmlns="http://docbook.org/ns/docbook">上の例の 32 ビットマシンでの出力は、このようになります。</simpara>'>
@@ -649,10 +497,6 @@ xmlns="http://docbook.org/ns/docbook"><simpara>この関数は PHP 8.1.0 で
 たとえば以下のようになります。</simpara>'>
 
 <!ENTITY examples.outputs '<simpara xmlns="http://docbook.org/ns/docbook">上の例の出力は以下となります。</simpara>'>
-
-<!ENTITY examples.outputs.32bit '<simpara xmlns="http://docbook.org/ns/docbook">上の例の 32 ビットマシンでの出力は、このようになります。</simpara>'>
-
-<!ENTITY examples.outputs.64bit '<simpara xmlns="http://docbook.org/ns/docbook">上の例の 64 ビットマシンでの出力は、このようになります。</simpara>'>
 
 <!ENTITY examples.outputs.similar '<simpara xmlns="http://docbook.org/ns/docbook">上の例の出力は、
 たとえば以下のようになります。</simpara>'>
@@ -768,11 +612,6 @@ $compareFunc = static function ($item1, $item2) {
 <!ENTITY info.function.alias 'この関数は次の関数のエイリアスです。'>
 
 <!ENTITY info.method.alias 'このメソッドは次のメソッドのエイリアスです。'>
-
-<!ENTITY info.function.alias.deprecated
-'<simpara xmlns="http://docbook.org/ns/docbook">この関数エイリアスは非推奨であり、下位互換性維持のために残されています。
-今後、PHP から削除される可能性がありますので、この関数を使用しないことを推奨します。
-</simpara>'>
 
 <!ENTITY ext.windows.path.dll 'この拡張モジュールを動作させるには、
 Windows システムの <envar xmlns="http://docbook.org/ns/docbook">PATH</envar> が通った場所に
@@ -899,21 +738,7 @@ DLL ファイルを PHP のフォルダから Windows のシステムディレ�
  </listitem>
 </varlistentry>'>
 
-<!ENTITY openssl.param.key '<varlistentry xmlns="http://docbook.org/ns/docbook">
- <term><parameter>key</parameter></term>
- <listitem>
-  <simpara>
-   使用できる値の一覧は <link
-    linkend="openssl.certparams">公開/秘密鍵パラメータ</link> を参照ください。
-  </simpara>
- </listitem>
-</varlistentry>'>
-
 <!-- Image (GD) Notes -->
-<!ENTITY note.config.t1lib '<note xmlns="http://docbook.org/ns/docbook"><simpara> この関数は、PHP が
-<option role="configure">--with-t1lib</option>
-を指定してコンパイルされている場合のみ使用可能です。</simpara></note>'>
-
 <!ENTITY note.freetype '<note xmlns="http://docbook.org/ns/docbook"><simpara>この関数は、PHP が FreeType サポート
 (<option role="configure">--with-freetype-dir=DIR</option>)
 を有効にしてコンパイルされている場合のみ使用可能です。
@@ -1018,10 +843,6 @@ $font = 'SomeFont';
     <function>imagetypes</function> の戻り値として用います。
 </simpara>'>
 
-<!ENTITY gd.changlog.t1lib '<row xmlns="http://docbook.org/ns/docbook">
-    <entry>7.0.0</entry><entry>PHP から T1Lib サポートが削除されたため、この関数は削除されました。</entry>
-</row>'>
-
 <!ENTITY gd.constants.color '<simpara xmlns="http://docbook.org/ns/docbook">
     <function>imagecolorallocate</function> や
     <function>imagecolorallocatealpha</function>
@@ -1089,10 +910,6 @@ $font = 'SomeFont';
 なので、明示的に空の文字列を指定することを推奨します。デフォルト値は、PHP 9.0
 以降の将来のバージョンで変更予定です。
 </simpara></warning>'>
-
-<!-- DBM notes -->
-
-<!ENTITY dbm.dbm-identifier.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>dbm_identifier</parameter></term><listitem><simpara><function>dbmopen</function> が返す DBM リンク識別子。</simpara></listitem></varlistentry>'>
 
 <!-- JSON notes -->
 
@@ -1236,8 +1053,6 @@ $font = 'SomeFont';
 <!ENTITY imap.imap-parameter.imap '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>imap</parameter></term><listitem><simpara><classname>IMAP\Connection</classname> クラスのインスタンス。</simpara></listitem></varlistentry>'>
 
 <!-- Deprecated -->
-<!ENTITY imap.imap-stream.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>imap</parameter></term><listitem><simpara><function>imap_open</function> が返す IMAP ストリーム。</simpara></listitem></varlistentry>'>
-
 <!ENTITY imap.pattern '<simpara xmlns="http://docbook.org/ns/docbook">検索を開始するメールボックスの階層を指定します。</simpara>
 <simpara xmlns="http://docbook.org/ns/docbook"><parameter xmlns="http://docbook.org/ns/docbook">pattern</parameter> の中で使用できる特別な文字として
 &apos;<literal>*</literal>&apos; および &apos;<literal>&#37;</literal>&apos; があります。
@@ -1398,11 +1213,6 @@ $font = 'SomeFont';
 <!ENTITY mcrypt.parameter.cipher '<simpara xmlns="http://docbook.org/ns/docbook"><constant>MCRYPT_暗号名</constant> 定数のいずれか、
 あるいはアルゴリズム名をあらわす文字列。</simpara>'>
 
-<!ENTITY mcrypt.parameter.iv '<simpara xmlns="http://docbook.org/ns/docbook">CBC, CFB, OFB モードおよび
-STREAM モードのいくつかのアルゴリズムの初期化の際に使用されます。
-アルゴリズムで必要とする IV を指定しない場合、この関数は警告を発生し、
-すべてのバイトを "<literal>\0</literal>" に設定した IV を使用します。</simpara>'>
-
 <!ENTITY mcrypt.parameter.iv.strict '<simpara xmlns="http://docbook.org/ns/docbook">CBC, CFB, OFB モードおよび
 STREAM モードのいくつかのアルゴリズムの初期化の際に使用されます。
 指定した IV のサイズがそのモードでサポートされていない場合、
@@ -1411,10 +1221,6 @@ STREAM モードのいくつかのアルゴリズムの初期化の際に使用�
 
 <!ENTITY mcrypt.parameter.mode '<simpara xmlns="http://docbook.org/ns/docbook">定数 <constant>MCRYPT_MODE_モード名</constant>、あるいは文字列
 "ecb", "cbc", "cfb", "ofb", "nofb" ,"stream" のいずれか。</simpara>'>
-
-<!-- MCVE notes -->
-
-<!ENTITY mcve.conn.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>conn</parameter></term><listitem><simpara><function>m_initengine</function> が返す MCVE_CONN リソース。</simpara></listitem></varlistentry>'>
 
 <!-- memcached notes -->
 
@@ -1534,8 +1340,6 @@ STREAM モードのいくつかのアルゴリズムの初期化の際に使用�
 
 <!ENTITY gearman.parameter.workload 'シリアライズしたデータ。'>
 
-<!ENTITY gearman.parameter.data '作業を完了させるために必要となる追加データ。'>
-
 <!ENTITY gearman.parameter.context 'タスクに関連づけるアプリケーションコンテキスト。'>
 
 <!ENTITY gearman.parameter.unique 'タスクを特定するために用いる一意な ID。'>
@@ -1618,12 +1422,6 @@ STREAM モードのいくつかのアルゴリズムの初期化の際に使用�
  <literal>Australia/Perth</literal> を使うということです。
 </simpara>'>
 
-<!ENTITY date.timezone.abbrev-volatile '<simpara xmlns="http://docbook.org/ns/docbook">
-これらの略称は、変化しやすいものだと考えておく必要があります。つまり、
-timezonedb のリリースによって変わる可能性があるので、略称に依存するべきではありません。
-タイムゾーンの略章は使わないことを強く推奨します。
-</simpara>'>
-
 <!ENTITY date.timezone.errors.description '<simpara xmlns="http://docbook.org/ns/docbook">
 すべての日付/時刻関数は、
 有効なタイムゾーンが設定されていない場合に <constant>E_WARNING</constant>
@@ -1653,12 +1451,7 @@ object</parameter></term><listitem><simpara>手続き型のみ: <function>date_c
 この関数は、このオブジェクトを変更します。</simpara></listitem></varlistentry>'>
 
 <!ENTITY date.datetimezone.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>object</parameter></term><listitem><simpara>手続き型のみ: <function>timezone_open</function> が返す <classname>DateTimeZone</classname> オブジェクト</simpara></listitem></varlistentry>'>
-
-<!ENTITY date.datetime.return.modifiedobjectorfalseforfailure
-'メソッドチェインに使う、変更された <classname xmlns="http://docbook.org/ns/docbook">DateTime</classname> オブジェクトを返します。&return.falseforfailure;。'>
 <!ENTITY date.datetime.return.modifiedobject 'メソッドチェインに使う、変更された <classname xmlns="http://docbook.org/ns/docbook">DateTime</classname> オブジェクトを返します。'>
-<!ENTITY date.datetimeimmutable.return.modifiedobjectorfalseforfailure
-'変更されたデータを持つ、新しい <classname xmlns="http://docbook.org/ns/docbook">DateTimeImmutable</classname> オブジェクトを返します。&return.falseforfailure;.'>
 <!ENTITY date.datetimeimmutable.return.modifiedobject '変更されたデータを持つ、新しい <classname xmlns="http://docbook.org/ns/docbook">DateTimeImmutable</classname> オブジェクトを返します。'>
 
 <!ENTITY date.timezone.dbversion 'このリストの元になっているのは、タイムゾーンデータベース バージョン'>
@@ -1674,8 +1467,6 @@ object</parameter></term><listitem><simpara>手続き型のみ: <function>date_c
 <!ENTITY date.timezone.indian 'インド'>
 <!ENTITY date.timezone.pacific '太平洋'>
 <!ENTITY date.timezone.others 'その他'>
-<!ENTITY date.timezone.abbreviations '略称'>
-
 <!ENTITY date.formats '有効な書式については <link xmlns="http://docbook.org/ns/docbook" linkend="datetime.formats">日付と時刻の書式</link> で説明しています。'>
 <!ENTITY date.formats.parameter '日付/時刻 文字列。&date.formats;'>
 
@@ -1926,9 +1717,6 @@ object</parameter></term><listitem><simpara>手続き型のみ: <function>date_c
 
 <!ENTITY gnupg.fingerprint '<simpara xmlns="http://docbook.org/ns/docbook">フィンガープリントキー。</simpara>'>
 
-<!-- HaruDoc -->
-<!ENTITY haru.error '<simpara xmlns="http://docbook.org/ns/docbook">エラー時に <classname>HaruException</classname> をスローします。</simpara>'>
-
 <!-- ODBC -->
 <!ENTITY odbc.connection.id '<simpara xmlns="http://docbook.org/ns/docbook">ODBC 接続オブジェクト。詳細は
 <function>odbc_connect</function> を参照ください。</simpara>'>
@@ -2162,8 +1950,6 @@ linkend="ini.open-basedir">open_basedir</link> の設定に依存します。</s
 <!ENTITY ini.descriptions.title '<simpara xmlns="http://docbook.org/ns/docbook">以下に設定ディレクティブに関する
 簡単な説明を示します。</simpara>'>
 
-<!-- Common pieces for reference part BEGIN-->
-
 <!-- Used in reference/$extname/ini.xml -->
 <!ENTITY extension.runtime '<simpara xmlns="http://docbook.org/ns/docbook">
 &php.ini; の設定により動作が変化します。
@@ -2182,13 +1968,6 @@ linkend="ini.open-basedir">open_basedir</link> の設定に依存します。</s
 <!-- For STANDARD Constants used in reference/$extname/constants.xml -->
 <!ENTITY extension.constants.core '<simpara xmlns="http://docbook.org/ns/docbook">
 以下の定数は、PHP コアに含まれており、常に利用可能です。
-</simpara>'>
-
-<!-- Used in reference/$extname/classes.xml -->
-<!ENTITY extension.classes '<simpara xmlns="http://docbook.org/ns/docbook">
-以下のクラスが定義されています。この拡張モジュールが
-PHP 組み込みでコンパイルされているか、実行時に動的にロードされている場合のみ
-使用可能です。
 </simpara>'>
 
 <!-- PDO entities -->
@@ -2215,8 +1994,6 @@ PHP 組み込みでコンパイルされているか、実行時に動的にロ�
 <!-- PECL entities -->
 <!ENTITY pecl.moved 'この &link.pecl; 拡張モジュールは PHP にバンドルされていません。'>
 
-<!ENTITY pecl.bundled 'この &link.pecl; 拡張モジュールは PHP にバンドルされています。'>
-
 <!ENTITY pecl.info 'この PECL 拡張モジュールをインストールする方法は、
 マニュアルの <link xmlns="http://docbook.org/ns/docbook" linkend="install.pecl">
 PECL 拡張モジュールのインストール</link> という章にあります。
@@ -2239,8 +2016,6 @@ PECL 拡張モジュールのインストール</link> という章にありま�
 <!ENTITY pecl.windows.download.avail 'この <acronym xmlns="http://docbook.org/ns/docbook">PECL</acronym>
 拡張モジュールの Windows バイナリ (<acronym xmlns="http://docbook.org/ns/docbook">DLL</acronym> ファイル)
 は、PECL のウェブサイトから取得できます。'>
-
-<!ENTITY pecl.windows.download.unbundled '&pecl.windows.download;'>
 
 <!ENTITY pecl.moved-ver '
 この拡張モジュールは &link.pecl; レポジトリに移動
@@ -2325,8 +2100,6 @@ PECL 拡張モジュールのインストール</link> という章にありま�
 するために拡張モジュールを追加でロードする必要はありません。</simpara>'>
 
 <!-- These are here as helpers for manual consistency and brievety-->
-<!ENTITY safemode '<link xmlns="http://docbook.org/ns/docbook" linkend="ini.safe-mode">セーフモード</link>'>
-
 <!ENTITY sqlsafemode '<link xmlns="http://docbook.org/ns/docbook" linkend="ini.sql.safe-mode">SQL セーフモード</link>'>
 
 <!-- CTYPE Notes -->
@@ -2404,45 +2177,12 @@ SimpleXML では、ほとんどのメソッドに反復処理を追加するた�
 これらは、<function>var_dump</function> やオブジェクトを評価する他の手段で
 見ることはできません。</simpara></note>'>
 
-<!-- SQLite Notes -->
-<!ENTITY sqlite.case-fold '<simpara xmlns="http://docbook.org/ns/docbook">
-<constant>SQLITE_ASSOC</constant> および <constant>SQLITE_BOTH</constant> で
-返されるカラム名は、設定オプション
-<link linkend="ini.sqlite.assoc-case">sqlite.assoc_case</link> の値に基づき、
-大文字小文字が変換されます。</simpara>'>
-
-<!ENTITY sqlite.decode-bin '<simpara xmlns="http://docbook.org/ns/docbook">
-<parameter>decode_binary</parameter> パラメータが &true; (デフォルト)に
-設定された場合、PHP はバイナリエンコーディングをデコードします。
-これは、<function>sqlite_escape_string</function> によりエンコードされたデータに
-適用されます。sqlite をサポートする他のアプリケーションにより
-作成されたデータベースを処理する時以外は、この値をデフォルトのままにしておくべきです。</simpara>'>
-
-<!ENTITY sqlite.no-unbuffered '<note xmlns="http://docbook.org/ns/docbook"><simpara>この関数は、
-バッファなしの結果ハンドルで使用することはできません。</simpara></note>'>
-
-<!ENTITY sqlite.param-compat '<note xmlns="http://docbook.org/ns/docbook"><simpara>
-(MySQL のような)他のデータベース拡張モジュールとの互換性のため、
-2 種類の構文がサポートされています。
-推奨されるのは最初の構文で、<parameter>dbhandle</parameter> パラメータを
-関数の最初のパラメータとするものです。</simpara></note>'>
-
-<!ENTITY sqlite.result-type '<simpara xmlns="http://docbook.org/ns/docbook">オプションの <parameter>result_type</parameter>
-パラメータには定数を指定でき、返される配列の添字を定義します。
-<constant>SQLITE_ASSOC</constant> を用いると、連想配列の添字(名前フィールド)のみが
-返されます。一方、<constant>SQLITE_NUM</constant> は、
-数値の添字(フィールド番号)のみを返します。<constant>SQLITE_BOTH</constant> は、
-連想配列の添字と数値の添字の両方を返します。
-<constant>SQLITE_BOTH</constant> がこの関数のデフォルトです。</simpara>'>
-
 <!-- Database Notes -->
 <!ENTITY database.field-case '<note xmlns="http://docbook.org/ns/docbook"><simpara>この関数により返されるフィー
 ルド名は <emphasis>大文字小文字を区別</emphasis> します。</simpara></note>'>
 
 <!ENTITY database.fetch-null '<note xmlns="http://docbook.org/ns/docbook"><simpara>この関数は、
 NULL フィールドに PHPの &null; 値を設定します。</simpara></note>'>
-
-<!-- MySQL Notes -->
 <!-- The mysql.*.description entities are used in the parameters refsect1 -->
 <!ENTITY mysql.linkid.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>link_identifier</parameter></term><listitem><simpara>MySQL 接続。指定されない場合、<function>mysql_connect</function> により直近にオープンされたリンクが指定されたと仮定されます。そのようなリンクがない場合、引数を指定せずに <function>mysql_connect</function> がコールした時と同様にリンクを確立します。リンクが見付からない、または、確立できない場合、<constant>E_WARNING</constant> レベルのエラーが生成されます。</simpara></listitem></varlistentry>'>
 
@@ -2483,14 +2223,6 @@ NULL フィールドに PHPの &null; 値を設定します。</simpara></note>'
 <link linkend="mysqlinfo.api.choosing">MySQL: API の選択</link> を参照ください。
 この関数の代替として、これらが使えます。</simpara>'>
 
-<!ENTITY mysql.alternative.note.5-5-0 '<simpara xmlns="http://docbook.org/ns/docbook">
-この関数は PHP 5.5.0 で非推奨になり、PHP 7.0.0 で
-<link linkend="book.mysql">MySQL 拡張モジュール</link> 全体とあわせて削除されました。
-<link linkend="book.mysqli">MySQLi</link> あるいは
-<link linkend="ref.pdo-mysql">PDO_MySQL</link> を使うべきです。詳細な情報は
-<link linkend="mysqlinfo.api.choosing">MySQL: API の選択</link> を参照ください。
-この関数の代替として、これらが使えます。</simpara>'>
-
 <!ENTITY mysql.close.connections.result.sets '<simpara xmlns="http://docbook.org/ns/docbook">
 持続的でない MySQL 接続や結果セットは、PHP スクリプトの実行が終了する時点で自動的に破棄されます。
 そのため、オープンした接続をクローズしたり結果セットを開放したりすることは必須ではありませんが、
@@ -2512,19 +2244,6 @@ xattr はデフォルトでユーザー名前空間で処理を行いますが�
 
 <!-- Notes for tidy -->
 <!ENTITY tidy.object '<classname xmlns="http://docbook.org/ns/docbook">Tidy</classname> オブジェクト。'>
-
-<!ENTITY tidy.conf-enc '<simpara xmlns="http://docbook.org/ns/docbook"><parameter>config</parameter>パラメータは、配列または
-文字列として指定することができます。文字列として指定した場合には設定ファイルの名前として解釈され、
-そうでない場合はオプション自体として解釈されます。各オプションに関する説明については、
-<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="&url.tidy.conf;">&url.tidy.conf;</link> を参照してください。</simpara><simpara>
-<parameter>encoding</parameter> パラメータは、文書を入力/出力する際のエンコーディングを
-設定します。<parameter>encoding</parameter> には次の値を使用可能です。
-<literal>ascii</literal>, <literal>latin0</literal>, <literal>latin1</literal>,
-<literal>raw</literal>, <literal>utf8</literal>, <literal>iso2022</literal>,
-<literal>mac</literal>, <literal>win1252</literal>, <literal>ibm858</literal>,
-<literal>utf16</literal>, <literal>utf16le</literal>,
-<literal>utf16be</literal>, <literal>big5</literal> および
-<literal>shiftjis</literal>.</simpara>'>
 <!ENTITY warn.install.third-party-support '<warning xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <simpara>
   サードパーティによるビルドは非公式であり、PHP プロジェクトによって
@@ -2649,10 +2368,6 @@ Apache 設定ファイルにパスの値を追加する際、例えば
 <!-- Imagick generic return types -->
 <!ENTITY imagick.return.success '成功した場合に &true; を返します。'>
 <!ENTITY imagick.imagick.throws 'エラー時に ImagickException をスローします。'>
-<!ENTITY imagick.imagickdraw.throws 'エラー時に ImagickDrawException をスローします。'>
-<!ENTITY imagick.imagickpixel.throws 'エラー時に ImagickPixelException をスローします。'>
-<!ENTITY imagick.imagickpixeliterator.throws 'エラー時に ImagickPixelIteratorException をスローします。'>
-
 <!-- Imagick version infos -->
 <!ENTITY imagick.method.available.0x629 'このメソッドは、ImageMagick バージョン 6.2.9 以降で Imagick をコンパイルした場合に使用可能です。'>
 <!ENTITY imagick.method.available.0x631 'このメソッドは、ImageMagick バージョン 6.3.1 以降で Imagick をコンパイルした場合に使用可能です。'>
@@ -2662,14 +2377,10 @@ Apache 設定ファイルにパスの値を追加する際、例えば
 <!ENTITY imagick.method.available.0x638 'このメソッドは、ImageMagick バージョン 6.3.8 以降で Imagick をコンパイルした場合に使用可能です。'>
 <!ENTITY imagick.method.available.0x639 'このメソッドは、ImageMagick バージョン 6.3.9 以降で Imagick をコンパイルした場合に使用可能です。'>
 <!ENTITY imagick.method.available.0x640 'このメソッドは、ImageMagick バージョン 6.4.0 以降で Imagick をコンパイルした場合に使用可能です。'>
-<!ENTITY imagick.method.available.0x641 'このメソッドは、ImageMagick バージョン 6.4.1 以降で Imagick をコンパイルした場合に使用可能です。'>
-<!ENTITY imagick.method.available.0x642 'このメソッドは、ImageMagick バージョン 6.4.2 以降で Imagick をコンパイルした場合に使用可能です。'>
-<!ENTITY imagick.method.available.0x643 'このメソッドは、ImageMagick バージョン 6.4.3 以降で Imagick をコンパイルした場合に使用可能です。'>
 <!ENTITY imagick.method.available.0x644 'このメソッドは、ImageMagick バージョン 6.4.4 以降で Imagick をコンパイルした場合に使用可能です。'>
 <!ENTITY imagick.method.available.0x645 'このメソッドは、ImageMagick バージョン 6.4.5 以降で Imagick をコンパイルした場合に使用可能です。'>
 <!ENTITY imagick.method.available.0x647 'このメソッドは、ImageMagick バージョン 6.4.7 以降で Imagick をコンパイルした場合に使用可能です。'>
 <!ENTITY imagick.method.available.0x649 'このメソッドは、ImageMagick バージョン 6.4.9 以降で Imagick をコンパイルした場合に使用可能です。'>
-<!ENTITY imagick.method.available.0x653 'このメソッドは、ImageMagick バージョン 6.5.3 以降で Imagick をコンパイルした場合に使用可能です。'>
 <!ENTITY imagick.method.available.0x657 'このメソッドは、ImageMagick バージョン 6.5.7 以降で Imagick をコンパイルした場合に使用可能です。'>
 <!ENTITY imagick.method.not.available.0x700 'このメソッドは、ImageMagick バージョン 7.0.0 以降で Imagick をコンパイルした場合には利用できません。'>
 
@@ -2791,7 +2502,6 @@ PHP 7.4 以降では <option role="configure">--with-libxml</option>、それよ
 <!ENTITY stream.bucket.return 'この関数は <classname>StreamBucket</classname> のインスタンスを返すようになりました。これより前のバージョンでは、<classname>stdClass</classname> を返していました。'>
 
 <!-- Gmagick -->
-<!ENTITY gmagick.return.success '成功した場合に &true; を返します。'>
 <!ENTITY gmagick.gmagickexception.throw 'エラー時に
 <classname xmlns="http://docbook.org/ns/docbook">GmagickException</classname> をスローします。'>
 
@@ -2845,7 +2555,6 @@ PHP 7.4 以降では <option role="configure">--with-libxml</option>、それよ
 
 <!-- Win32Service -->
 <!ENTITY win32service.false.error 'パラメータに問題がある場合は &false;、失敗した場合は <link xmlns="http://docbook.org/ns/docbook" linkend="win32service.constants.errors">Win32 エラーコード</link> を返します。'>
-<!ENTITY win32service.success.false.error '成功した場合に &true; を返します。&win32service.false.error;'>
 <!ENTITY win32service.noerror.false.error '成功した場合に <constant xmlns="http://docbook.org/ns/docbook">WIN32_NO_ERROR</constant> を返していました。&win32service.false.error;'>
 
 <!-- SNMP -->
@@ -2999,7 +2708,6 @@ xmlns="http://docbook.org/ns/docbook"><simpara xmlns="http://docbook.org/ns/docb
 <!ENTITY trader.arg.fast.ma.type 'Type of Moving Average for fast MA. <link xmlns="http://docbook.org/ns/docbook" linkend="trader.constants">TRADER_MA_TYPE_*</link> series of constants should be used.'>
 <!ENTITY trader.arg.slow.ma.type 'Type of Moving Average for slow MA. <link xmlns="http://docbook.org/ns/docbook" linkend="trader.constants">TRADER_MA_TYPE_*</link> series of constants should be used.'>
 <!ENTITY trader.arg.fastd.ma.type 'Type of Moving Average for Fast-D. <link xmlns="http://docbook.org/ns/docbook" linkend="trader.constants">TRADER_MA_TYPE_*</link> series of constants should be used.'>
-<!ENTITY trader.arg.fastk.ma.type 'Type of Moving Average for Fast-K. <link xmlns="http://docbook.org/ns/docbook" linkend="trader.constants">TRADER_MA_TYPE_*</link> series of constants should be used.'>
 <!ENTITY trader.arg.slowd.ma.type 'Type of Moving Average for Slow-D. <link xmlns="http://docbook.org/ns/docbook" linkend="trader.constants">TRADER_MA_TYPE_*</link> series of constants should be used.'>
 <!ENTITY trader.arg.slowk.ma.type 'Type of Moving Average for Slow-K. <link xmlns="http://docbook.org/ns/docbook" linkend="trader.constants">TRADER_MA_TYPE_*</link> series of constants should be used.'>
 <!ENTITY trader.arg.signal.ma.type 'Type of Moving Average for signal line. <link xmlns="http://docbook.org/ns/docbook" linkend="trader.constants">TRADER_MA_TYPE_*</link> series of constants should be used.'>
@@ -3707,8 +3415,6 @@ local: {
 <!ENTITY mongodb.throws.unacknowledged '<member xmlns="http://docbook.org/ns/docbook">Throws <classname>MongoDB\Driver\Exception\LogicException</classname> if the write was not acknowledged.</member>'>
 
 <!-- Not used in EN anymore -->
-<!ENTITY mongodb.note.queryable-encryption-preview ''>
-
 <!ENTITY mongodb.note.decimal128 '
    <note xmlns="http://docbook.org/ns/docbook">
     <simpara>
@@ -4422,16 +4128,6 @@ local: {
  </entry>
 </row>'>
 
-<!ENTITY strings.changelog.encoding '
- <row xmlns="http://docbook.org/ns/docbook">
-  <entry>5.6.0</entry>
-  <entry>
-   <parameter>encoding</parameter> パラメータのデフォルト値が、
-   <link linkend="ini.default-charset">default_charset</link> の設定値に変わりました。
-  </entry>
- </row>
-'>
-
 <!ENTITY strings.changelog.ascii-case-conversion '
  <row xmlns="http://docbook.org/ns/docbook">
   <entry>8.2.0</entry>
@@ -4649,28 +4345,6 @@ local: {
    両者が等しければ <literal>0</literal> を返します。
    返却される値の絶対値に、特に意味はありません。
   </simpara>
-'>
-
-<!-- filter snippets -->
-<!-- TODO: Remove -->
-<!ENTITY filter.param.filter '
- <varlistentry xmlns="http://docbook.org/ns/docbook">
-  <term><parameter>filter</parameter></term>
-  <listitem>
-   <simpara>
-    適用するフィルタ。
-    <constant>FILTER_VALIDATE_<replaceable>*</replaceable></constant> 定数の一つを用いた検証フィルタ、
-    <constant>FILTER_SANITIZE_<replaceable>*</replaceable></constant> 定数の一つを用いた除去フィルタ、
-    <constant>FILTER_UNSAFE_RAW</constant>、
-    <constant>FILTER_CALLBACK</constant> を用いたカスタムフィルタのいずれかを指定できます。
-   </simpara>
-   <simpara>
-    デフォルトの値は <constant>FILTER_DEFAULT</constant> で、
-    これは <constant>FILTER_UNSAFE_RAW</constant> のエイリアスです。
-    結果的に、デフォルトでは何もフィルタリングをしません。
-   </simpara>
-  </listitem>
- </varlistentry>
 '>
 
 <!-- csprng snippets -->

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -395,10 +395,11 @@ CGI モードで公開したサーバーは、いくつかの脆弱性の標的�
 </warning>
 '>
 
-<!ENTITY warn.ssl-non-standard '<warning xmlns="http://docbook.org/ns/docbook"><simpara>IIS のような、いくつかの標準に
-対応してない Web サーバーは、PHP に警告を発生させるような手順でデータを送信します。
-このようなサーバーを使用する場合は、<link linkend="ini.error-reporting">
-error_reporting</link> を警告を発生しないレベルまで小さくする必要があります。
+<!ENTITY warn.ssl-non-standard '<warning xmlns="http://docbook.org/ns/docbook"><simpara>SSL を使う場合、Microsoft IIS は
+<literal>close_notify</literal> を送信せずに接続を閉じるため、プロトコルに違反します。
+PHP は、データの終端に達した時点でこれを "SSL: Fatal Protocol Error" として報告します。
+これを回避するには、<link linkend="ini.error-reporting">
+error_reporting</link> の値を警告を含まないレベルまで下げる必要があります。
 PHP では、<literal>https://</literal> ラッパーでストリームをオープンする際に
 バグがある IIS サーバーソフトウエアを検出することができ、この警告を抑制することができます。
 あなたが <literal>ssl://</literal> ソケットを作成するために  <function>fsockopen</function> を使用している場合、
@@ -1568,7 +1569,7 @@ object</parameter></term><listitem><simpara>手続き型のみ: <function>date_c
 
 <!-- Dom entities -->
 <!ENTITY dom.parameter.options '<simpara xmlns="http://docbook.org/ns/docbook">
-  <link linkend="libxml.constants">追加の Libxml パラメータ</link> を、ビット演算子の <literal>OR</literal> で指定します。
+  <link linkend="libxml.constants">libxml オプション定数</link>を、<link linkend="language.operators.bitwise">ビット演算子の <literal>OR</literal></link> で組み合わせた値。
 </simpara>'>
 
 <!ENTITY dom.parameter.compliant.options '&dom.parameter.options;
@@ -1939,7 +1940,7 @@ linkend="ini.open-basedir">open_basedir</link> の設定に依存します。</s
 言語構造のため、<link linkend="functions.variable-functions">可変関数</link> や <link linkend="functions.named-arguments">名前付き引数</link> を用いてコールすることはできません。</simpara></note>'>
 
 <!-- Common pieces in partintro-sections -->
-<!ENTITY no.config '<simpara xmlns="http://docbook.org/ns/docbook">設定ディレクティブは定義されていません。</simpara>'>
+<!ENTITY no.config '<simpara xmlns="http://docbook.org/ns/docbook">この拡張モジュールは、&php.ini; に設定ディレクティブを定義しません。</simpara>'>
 <!ENTITY no.resource '<simpara xmlns="http://docbook.org/ns/docbook">リソース型は定義されていません。</simpara>'>
 <!ENTITY no.constants '<simpara xmlns="http://docbook.org/ns/docbook">定数は定義されていません。</simpara>'>
 <!ENTITY no.requirement '<simpara xmlns="http://docbook.org/ns/docbook">外部ライブラリは必要ありません。</simpara>'>
@@ -3936,17 +3937,17 @@ local: {
          汎用フォーマット
         </simpara>
         <simpara>
-         P を精度を表す、ゼロでない値とします。
-         精度が省略された場合、Pの値は6です。
-         精度に0を指定した場合、Pの値は1になります。
-         この場合、 <literal>E</literal> 指定子の変換結果は、
-         X乗になります。
+         P を、精度が 0 でなければその精度、
+         精度が省略された場合は 6、
+         精度に 0 を指定した場合は 1 とします。
+         そして、<literal>E</literal> 指定子で変換した場合の指数を
+         X とします:
         </simpara>
         <simpara>
-         P > X ≥ −4 の場合、<literal>E</literal>
-         指定子の変換結果となり、精度は、P − (X + 1) になります。
-         そうでない場合、<literal>e</literal> 指定子の変換結果となり、
-         精度は、P - 1 になります。
+         P > X ≥ −4 の場合、<literal>f</literal>
+         指定子による変換となり、精度は、P − (X + 1) になります。
+         そうでない場合、<literal>e</literal> 指定子による変換となり、
+         精度は、P − 1 になります。
         </simpara>
        </entry>
       </row>


### PR DESCRIPTION
- 次の変更へ追従
  - php/doc-en#5625
  - php/doc-en#5736
- Statusを更新
  - mongodbなど意図して翻訳を行っていないパッケージのスニペット未翻訳をコメントに残す
  - それを前提に Status を ready に更新 → revcheckで未訳が検出される