### PR TITLE
language/types・language/oop5 を原文の文法修正に追従

### DIFF
--- a/language/oop5/anonymous.xml
+++ b/language/oop5/anonymous.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d6f54016d62904cfd8200604aadd5e3f0d9bad97 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: takagi Status: ready -->
 
 <sect1 xml:id="language.oop5.anonymous" xmlns="http://docbook.org/ns/docbook">
  <title>無名クラス</title>
@@ -155,10 +155,10 @@ if (get_class(anonymous_class()) === get_class(anonymous_class())) {
  </informalexample>
 
  <note>
-  <para>
+  <simpara>
    無名クラスには内部的な名前が付けられていることに注意しましょう。これは次の例で確認できます。
    ただこれは細部の実装上の話なので、この名前に依存するコードを書いてはいけません。
-  </para>
+  </simpara>
   <informalexample>
    <programlisting role="php">
 <![CDATA[

--- a/language/oop5/autoload.xml
+++ b/language/oop5/autoload.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c1f37a6c270aadbbb3da56a3973ffd62197adf2b Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: hirokawa Status: ready -->
 <!-- Credits: mumumu -->
 
  <sect1 xml:id="language.oop5.autoload" xmlns="http://docbook.org/ns/docbook">
@@ -11,19 +11,19 @@
   最大の問題は、各スクリプトの先頭に、必要な読み込みを行う長いリストを
   記述する必要があることです(各クラスについて一つ)。
  </para>
- <para>
+ <simpara>
   <function>spl_autoload_register</function> 関数を使うと、
   任意の数のオートローダーを登録でき、
   クラスやインターフェイスが定義されていなくても自動的に読み込めるようになります。
   オートローダーを登録すれば、PHPがエラーで止まる前にクラスをロードする最後の
   チャンスが与えられます。
- </para>
+ </simpara>
  <para>
    クラスに類似した言語構造は、同じやり方でオートロードできます。
    これには、クラス、インターフェイス、トレイト、列挙型が含まれます。
  </para>
  <caution>
-  <para>
+  <simpara>
    PHP 8.0.0 より前のバージョンでは、
    <function>__autoload</function> 関数でもクラスやインターフェイスのオートロードが可能でした。
    しかし、この関数は
@@ -31,7 +31,7 @@
    そのため、<function>__autoload</function>
    関数は PHP 7.2.0 で推奨されなくなり、
    PHP 8.0.0 で削除されました。
-  </para>
+  </simpara>
  </caution>
  <note>
    <para>

--- a/language/oop5/changelog.xml
+++ b/language/oop5/changelog.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: takagi Status: ready -->
 <!-- CREDITS: mumumu -->
 
 <sect1 xml:id="language.oop5.changelog" xmlns="http://docbook.org/ns/docbook">

--- a/language/oop5/cloning.xml
+++ b/language/oop5/cloning.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 28529d3539b850e870e3aa97570f4db0e53daa03 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: hirokawa Status: ready -->
 <!-- Credits: mumumu -->
 
 <sect1 xml:id="language.oop5.cloning" xmlns="http://docbook.org/ns/docbook">
  <title>オブジェクトのクローン作成</title>
  
- <para>
+ <simpara>
   オブジェクトのコピーを作成する際、そのプロパティも全て二重化することが、
   常に望ましい動作であるわけではありません。
   コピーコンストラクタが必要となる例として、
@@ -20,7 +20,7 @@
   保持しており、親オブジェクトをコピーする際に、そのコピーが独立したオブジェクトの
   コピーを有するように、そのオブジェクトのインスタンスを新たに作成したい場合が
   考えられます。
- </para>
+ </simpara>
  
  <para>
   オブジェクトのコピーは、<emphasis>clone</emphasis> キーワード (これは、そのオブジェクトの
@@ -46,12 +46,12 @@ $copy_of_object = clone $object;
    <void/>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    クローンの作成が完了すると、
    <link linkend="object.clone">__clone()</link> メソッドが定義された場合、新規の作成されたオブジェクトの
    <link linkend="object.clone">__clone()</link> メソッドがコールされるため、この中で、プロパティに
    必要な変更を行うことができます。
- </para>
+ </simpara>
  
  <example>
   <title>オブジェクトのクローン作成</title>

--- a/language/oop5/constants.xml
+++ b/language/oop5/constants.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 922b4b5aeb327d78ea1bb4b932e5db2e9a03ffc5 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: mumumu Status: ready -->
 <sect1 xml:id="language.oop5.constants" xmlns="http://docbook.org/ns/docbook">
  <title>クラス定数</title>
- <para>
-  値が変更できない <link linkend="language.constants">定数</link> をクラス内に定義することができます。
+ <simpara>
+  <link linkend="language.constants">定数</link> をクラス内に定義することができます。
   クラス定数のデフォルトのアクセス範囲は <literal>public</literal> です。
- </para>
+ </simpara>
  <note>
   <para>
    クラス定数は、子クラスで再定義することもできます。

--- a/language/oop5/decon.xml
+++ b/language/oop5/decon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 82fc6a1c8670b96f1bd2b40932b6eb19929f4f6f Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: shimooka,mumumu -->
 
 <sect1 xml:id="language.oop5.decon" xmlns="http://docbook.org/ns/docbook">
@@ -170,13 +170,13 @@ class Point {
      </para>
     </note>
     <note>
-     <para>
+     <simpara>
       PHP のエンジンが曖昧になってしまうため、
       オブジェクトのプロパティは、<type>callable</type> 型にすることは出来ません。
       そのため、昇格させる引数も <type>callable</type> 型にはできません。
       しかし、それ以外の
       <link linkend="language.types.declarations">型宣言</link> は許されています。
-     </para>
+     </simpara>
     </note>
     <note>
      <para>
@@ -385,7 +385,7 @@ $obj = new MyDestructableClass();
      デストラクタが自身のオブジェクトへの新しい参照を作成した場合、参照カウントが再びゼロになったときや
      シャットダウンシーケンス中に、再度呼び出されることはありません。
     </para>
-    <para>
+    <simpara>
      PHP 8.4.0 以降、 <link linkend="features.gc.collecting-cycles">ガベージサイクルの収集</link> が
      <link linkend="language.fibers">ファイバー</link>の実行中に発生した場合、
      回収がスケジュールされたオブジェクトのデストラクタは、 <literal>gc_destructor_fiber</literal>と呼ばれる
@@ -394,7 +394,7 @@ $obj = new MyDestructableClass();
      中断された <literal>gc_destructor_fiber</literal> はガベージコレクタによって参照されなくなり、
      他の参照がなければ回収される可能性があります。
      デストラクタが中断されたオブジェクトは、デストラクタが復帰するかファイバー自体が回収されるまで回収されません。
-    </para>
+    </simpara>
    </note>
    <note>
     <para>

--- a/language/oop5/inheritance.xml
+++ b/language/oop5/inheritance.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: df78bd1d232f2cd8df673accf5ba0e280695639b Maintainer: takagi Status: ready -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: takagi Status: ready -->
  <sect1 xml:id="language.oop5.inheritance" xmlns="http://docbook.org/ns/docbook">
   <title>オブジェクトの継承</title>
   <para>
@@ -33,7 +33,7 @@
    コンストラクタを無効にする方法として <literal>private final</literal>
    が用いられるからです。
   </para>
-  <para>
+  <simpara>
    メソッドやプロパティ、そして定数の
    <link linkend="language.oop5.visibility">アクセス権</link>
    に関するルールは、子クラスで緩めることが可能です。
@@ -47,7 +47,7 @@
    コンストラクタのアクセス権は厳しくすることができます。
    たとえば、親クラスの <literal>public</literal> なコンストラクタは、
    子クラスで <literal>private</literal> としてマークできます。
-  </para>
+  </simpara>
 
   <note>
    <para>

--- a/language/oop5/interfaces.xml
+++ b/language/oop5/interfaces.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 565bd8b6cf2cae44ae2bc54ef6dbe6ee70ddfefd Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: shimooka,takagi,mumumu -->
 
 <sect1 xml:id="language.oop5.interfaces" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/language/oop5/iterations.xml
+++ b/language/oop5/iterations.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 1fb0ef23d7be0d8ecd9604fce16ee1e0842c6ef6 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa,shimooka,mumumu -->
 
 <sect1 xml:id="language.oop5.iterations" xmlns="http://docbook.org/ns/docbook">
  <title>オブジェクトの反復処理</title>
- <para>
+ <simpara>
   PHP は、たとえば &foreach; 命令などによる反復処理を可能とするように、
   オブジェクトを定義する手段を提供します。
   デフォルトで、
   全ての <link linkend="language.oop5.visibility">アクセス権限がある</link>
   プロパティは、反復処理に使用することができます。
- </para>
+ </simpara>
 
  <example>
   <title>単純なオブジェクトの反復の例</title>

--- a/language/oop5/late-static-bindings.xml
+++ b/language/oop5/late-static-bindings.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 009f215fc983eeded6161676bcffdd8cf3b6b080 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: takagi Status: ready -->
  <sect1 xml:id="language.oop5.late-static-bindings" xmlns="http://docbook.org/ns/docbook">
   <title>遅延静的束縛 (Late Static Bindings)</title>
-  <para>
+  <simpara>
    PHP には、遅延静的束縛と呼ばれる機能が搭載されています。
    これを使用すると、静的継承のコンテキストで呼び出し元のクラスを参照できるようになります。
-  </para>
+  </simpara>
 
   <para>
    より正確に言うと、遅延静的束縛は直近の "非転送コール" のクラス名を保存します。

--- a/language/oop5/magic.xml
+++ b/language/oop5/magic.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 8f51247cb4631b29686f867bd904dfe5b2678074 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: shimooka,mumumu -->
 
 <sect1 xml:id="language.oop5.magic" xmlns="http://docbook.org/ns/docbook">
  <title>マジックメソッド</title>
- <para>
+ <simpara>
    マジックメソッドは、
    ある動作がオブジェクトに対して行われた場合に、
    PHP のデフォルトの動作を上書きする特別なメソッドです。
-  </para>
+  </simpara>
   <caution>
    <simpara>
     <literal>__</literal> で始まる全てのメソッドは、
@@ -568,7 +568,7 @@ object(A)#2 (2) {
     </simpara>
     <simpara>
      エクスポートしたオブジェクトをインポートする際に、
-     __set_state() を実装するクラスのものだけをインポートさせるようにするのは、プログラマーの責務となります。
+     <methodname>__set_state</methodname> を実装するクラスのものだけをインポートさせるようにするのは、プログラマーの責務となります。
     </simpara>
    </note>
   </sect2>

--- a/language/oop5/object-comparison.xml
+++ b/language/oop5/object-comparison.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: a9edd62d087ab1eb6292c795b7256e14ff9f1234 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: shimooka,mumumu -->
 <sect1 xml:id="language.oop5.object-comparison" xmlns="http://docbook.org/ns/docbook">
  <title>オブジェクトの比較</title>
@@ -97,10 +97,10 @@ o1 !== o2 : TRUE
     </example>
    </para>
    <note>
-    <para>
+    <simpara>
      拡張モジュール内では、自前で作成したオブジェクトの
      (<literal>==</literal> による) 比較方法を独自に定義することができます。
-    </para>
+    </simpara>
    </note>
   </sect1>
 

--- a/language/oop5/paamayim-nekudotayim.xml
+++ b/language/oop5/paamayim-nekudotayim.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e2f2172bf114599926878017ab2dce356956fa9e Maintainer: takagi Status: ready -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa -->
 
 <sect1 xml:id="language.oop5.paamayim-nekudotayim" xmlns="http://docbook.org/ns/docbook">
@@ -89,7 +89,7 @@ OtherClass::doubleColon();
   </programlisting>
  </example>
 
- <para>
+ <simpara>
   拡張されたクラスが親クラスのメソッドの定義をオーバーライドする際、
   PHPは親クラスのメソッドをコールしません。
   親クラスのメソッドをコールするかしないかは、
@@ -99,7 +99,7 @@ OtherClass::doubleColon();
   linkend="language.oop5.overloading">オーバーロード</link>, そして <link
   linkend="language.oop5.magic">マジック</link> メソッドの定義にも
   適用されます。
- </para>
+ </simpara>
 
  <example>
   <title>親クラスのメソッドをコールする</title>

--- a/language/oop5/properties.xml
+++ b/language/oop5/properties.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 801e7a15e8c9ee2d16966487dc9058d992450b46 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: takagi Status: ready -->
 <!-- CREDITS: mumumu -->
 
  <sect1 xml:id="language.oop5.properties" xmlns="http://docbook.org/ns/docbook">
@@ -25,10 +25,10 @@
    初期値は <link linkend="language.constants">定数</link> 値でなければなりません。
   </para>
   <note>
-   <para>
+   <simpara>
     クラスのプロパティを宣言する古い方法として、
     アクセス権などのキーワードの代わりに <literal>var</literal> キーワードを使う書き方があります。
-   </para>
+   </simpara>
   </note>
   <note>
    <simpara>
@@ -174,7 +174,7 @@ class Shape
 
 $triangle = new Shape();
 $triangle->setName("triangle");
-$triangle->setNumberofSides(3);
+$triangle->setNumberOfSides(3);
 var_dump($triangle->getName());
 var_dump($triangle->getNumberOfSides());
 

--- a/language/oop5/property-hooks.xml
+++ b/language/oop5/property-hooks.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: KentarouTakeda Status: ready -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: KentarouTakeda Status: ready -->
 <sect1 xml:id="language.oop5.property-hooks" xmlns="http://docbook.org/ns/docbook">
  <title>プロパティフック</title>
 

--- a/language/oop5/references.xml
+++ b/language/oop5/references.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: a9edd62d087ab1eb6292c795b7256e14ff9f1234 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: takagi Status: ready -->
  <sect1 xml:id="language.oop5.references" xmlns="http://docbook.org/ns/docbook">
   <title>オブジェクトと参照</title>
-  <para>
+  <simpara>
    PHP でのオブジェクト指向プログラミングのポイントとしてよく言われるのは
    「オブジェクトはデフォルトでは参照渡しとなります」ということです。
    しかし、正確には少し異なります。
    この節では、いくつかの例を用いてその誤解をといていきます。
-  </para>
+  </simpara>
 
   <para>
    PHP の参照は一種のエイリアスで、ふたつの異なる変数に同じ値を書き込めるものです。

--- a/language/oop5/serialization.xml
+++ b/language/oop5/serialization.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 <!-- TODO Rewrite to remove usage of "you" and talk about __serialize/_unserialize -->
-<!-- EN-Revision: 70f392045a26b176f206013f00fa14b86440efd1 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: takagi Status: ready -->
  <sect1 xml:id="language.oop5.serialization" xmlns="http://docbook.org/ns/docbook">
   <title>オブジェクトのシリアライズ - セッション内でのオブジェクト</title>
   <titleabbrev>オブジェクトのシリアライズ</titleabbrev>
@@ -16,7 +16,7 @@
    クラス名のみが保存されます。
   </para>
   
-  <para>
+  <simpara>
    オブジェクトを <function>unserialize</function> するには、
    そのオブジェクトのクラスが定義されている必要があります。
    A クラスのオブジェクトをシリアライズしたのなら、
@@ -25,7 +25,7 @@
    まずそのファイル内にクラス A の定義が存在しなければなりません。
    これを実現するには、たとえばクラス A の定義を別ファイルに書き出してそれを
    include したり <function>spl_autoload_register</function> 関数を使ったりします。
-  </para>
+  </simpara>
   
   <informalexample>
    <programlisting role="php">
@@ -65,14 +65,14 @@
    </programlisting>
   </informalexample>
   
-  <para>
+  <simpara>
    アプリケーション内でオブジェクトをシリアライズして再利用する場合のお勧めは、
    そのクラスの定義をアプリケーション全体で include することです。
    クラスの定義が存在しなければオブジェクトの復元に失敗してしまいます。
    その場合、PHP は <classname>__PHP_Incomplete_Class_Name</classname>
    クラスのオブジェクトを返します。このオブジェクトにはメソッドは一切なく、
    使い道がなくなってしまいます。
-  </para>
+  </simpara>
   
   <para>
    つまり、もし上の例の <varname>$a</varname> を

--- a/language/oop5/traits.xml
+++ b/language/oop5/traits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c1f37a6c270aadbbb3da56a3973ffd62197adf2b Maintainer: takagi Status: ready -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: takagi Status: ready -->
 <!-- CREDITS: mumumu -->
 
  <sect1 xml:id="language.oop5.traits" xmlns="http://docbook.org/ns/docbook">
@@ -209,12 +209,12 @@ Hello World!
    </para>
    <example xml:id="language.oop5.traits.conflict.ex1">
     <title>衝突の解決</title>
-    <para>
+    <simpara>
       この例では、Talker がトレイト A と B を使います。
       A と B には同じ名前のメソッドがあるので、
       smallTalk はトレイト B を使って
       bigTalk はトレイト A を使うように定義します。
-    </para>
+    </simpara>
     <para>
       Aliased_Talker は、<literal>as</literal>
       演算子を使って B の bigTalk の実装に

--- a/language/oop5/variance.xml
+++ b/language/oop5/variance.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 2e7c00fd314a708ecbd495ef7cc9ae8c8462c33c Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: mumumu Status: ready -->
 <sect1 xml:id="language.oop5.variance" xmlns="http://docbook.org/ns/docbook">
 
  <title>共変性と反変性</title>
@@ -47,12 +47,12 @@
  <sect2 xml:id="language.oop5.variance.covariance">
   <title>共変性</title>
 
-  <para>
+  <simpara>
    共変性がどのように動作するかを示すために、
    単純な抽象クラスの親である<varname>Animal</varname> を作ることにします。
    このクラスは子クラス <varname>Cat</varname> と <varname>Dog</varname>
    に継承されています。
-  </para>
+  </simpara>
 
   <informalexample>
    <programlisting role="php">

--- a/language/types/array.xml
+++ b/language/types/array.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa,shimooka,mumumu -->
 <sect1 xml:id="language.types.array">
  <title>配列</title>
@@ -494,7 +494,7 @@ $arr[] = <replaceable>value</replaceable>;
 // <replaceable>value</replaceable> の型は、何でもかまいません。
    </synopsis>
    
-   <para>
+   <simpara>
     <varname>$arr</varname> がまだ存在しない場合、
     あるいは &null; や &false; に設定されている場合は、
     新しく配列を作成します。
@@ -506,7 +506,7 @@ $arr[] = <replaceable>value</replaceable>;
     <link linkend="language.types.string.substr">文字列アクセス演算子</link>
     を表してしまうからです。
     変数を初期化するときには、直接代入するほうがよいでしょう。
-   </para>
+   </simpara>
    <note>
     <simpara>
      PHP 7.1.0 以降では、文字列に空のインデックス演算子を適用すると
@@ -1082,7 +1082,7 @@ $error_descriptions[8] = "This is just an informal notice";
    は、<literal>array($scalarValue)</literal> と全く同じです。
   </para>
   
-  <para>
+  <simpara>
    <type>object</type>を配列にする場合には、配列の要素として
    オブジェクトの属性 (メンバ変数) を持つ配列を得ることになります。
    添字はメンバ変数名となりますが、いくつか注意すべき例外があります。
@@ -1092,7 +1092,7 @@ $error_descriptions[8] = "This is just an informal notice";
    このとき、頭に追加される値の前後に <literal>NUL</literal> バイトがついてきます。
    未初期化の
    <link linkend="language.oop5.properties.typed-properties">型付きプロパティ</link> は黙って捨てられます。
-  </para>
+  </simpara>
 
   <example>
    <title>配列への変換</title>

--- a/language/types/callable.xml
+++ b/language/types/callable.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: mumumu Status: ready -->
 
 <sect1 xml:id="language.types.callable">
  <title>コールバック / Callable</title>
@@ -208,7 +208,7 @@ print implode(' ', $new_numbers);
 
   <example>
    <title>
-    <function>call_user_function</function>
+    <function>call_user_func</function>
     を使って、様々なタイプの callable を呼び出す
    </title>
    <programlisting role="php">

--- a/language/types/declarations.xml
+++ b/language/types/declarations.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 911fe79de766ef4475bf22446903667a0f3a24d3 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: mumumu Status: ready -->
 
 <sect1 xml:id="language.types.declarations">
  <title>型宣言</title>
@@ -12,13 +12,13 @@
   その型でない場合は、<classname>TypeError</classname> がスローされます。
  </para>
 
- <para>
+ <simpara>
   PHP がサポートしている単一の型それぞれを、
   ユーザーが行う型宣言の中で使うことができます。
   但し、<type>resource</type> 型を除きます。
   このページでは、それぞれの型がいつ利用可能になったかの変更履歴や、
   型宣言におけるそれらの使い方について記しています。
- </para>
+ </simpara>
 
  <note>
   <para>
@@ -226,7 +226,7 @@ function &test(): void {}
     リファレンス渡しのパラメータに対して宣言される型は、
     関数の入り口で <emphasis>だけ</emphasis> チェックされます。
     しかし、関数から返される時はチェックされません。
-    これは、変数のリファレンスについては、関数が型を変更できるということです。
+    これは、リファレンス渡しされた変数の型を関数が変更できるということです。
    </simpara>
    <example>
     <title>リファレンス渡しのパラメータに対する型宣言</title>

--- a/language/types/float.xml
+++ b/language/types/float.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e587d0655e426f97b3fcb431453da5030e743b23 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa,shimooka,mumumu -->
 <sect1 xml:id="language.types.float" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>浮動小数点数</title>
 
- <para>
+ <simpara>
   浮動小数点数 (あるいは "float", "double", "実数") は、次の構文により指定できます。
- </para>
+ </simpara>
 
  <informalexample>
   <programlisting role="php">
@@ -45,15 +45,15 @@ EXPONENT_DNUM (({LNUM} | {DNUM}) [eE][+-]? {LNUM})
  <warning xml:id="warn.float-precision">
   <title>浮動小数点数の精度</title>
 
-  <para>
+  <simpara>
    浮動小数点数の精度は有限です。
    システムに依存しますが、PHP は通常 IEEE 754 倍精度フォーマットを使います。
    この形式は、1.11e-16 のオーダーでの丸め処理で誤差が発生します。
    複雑な算術演算をすると、誤差はさらに大きくなるでしょう。そしてもちろん、
    いくつかの演算を組み合わせる場合にも誤差を考慮しなければなりません。
-  </para>
+  </simpara>
 
-  <para>
+  <simpara>
    さらに、十進数では正確な小数で表せる有理数、たとえば
    <literal>0.1</literal> や <literal>0.7</literal> は、
    二進数の浮動小数点数としては正確に表現できません。
@@ -65,14 +65,14 @@ EXPONENT_DNUM (({LNUM} | {DNUM}) [eE][+-]? {LNUM})
    <literal>8</literal> を想定していらっしゃるでしょうが、そのようにはなりません。
    これは、(この計算結果の) 内部的な値が
    <literal>7.9999999999999991118...</literal> のようになっているからです。
-  </para>
+  </simpara>
 
-  <para>
+  <simpara>
    よって、小数の最後の桁を信用してはいけませんし、
    小数を直接比較して等しいかどうかを調べてはいけません。より高い精度が必要な場合には、
    <link linkend="ref.bc">任意精度数学関数</link>または
    <link linkend="ref.gmp">gmp</link> 関数を代わりに使用してください。
-  </para>
+  </simpara>
   
   <para>
    もっと「シンプルな」説明が欲しければ、<link xlink:href="&url.floating.point.guide;">floating point guide</link>
@@ -119,17 +119,17 @@ EXPONENT_DNUM (({LNUM} | {DNUM}) [eE][+-]? {LNUM})
  <sect2 xml:id="language.types.float.comparison">
   <title>float の比較</title>
 
-  <para>
+  <simpara>
    先ほど警告したように、浮動小数点数値が等しいかどうかを比較するのには問題があります。
    これは、浮動小数点数値の内部表現形式に起因するものです。
    しかし、この制限を回避して浮動小数点数値の値を比較する方法もあります。
-  </para>
+  </simpara>
 
-  <para>
+  <simpara>
    浮動小数点数値が等しいかどうかを調べるには、比較時の丸め誤差の上界を用います。
    この値は計算機イプシロンあるいは丸め単位と呼ばれ、
    計算時に扱える最小の差分を表します。
-  </para>
+  </simpara>
   
   <para>
    <varname>$a</varname> と <varname>$b</varname> は、精度 5 桁では等しくなります。

--- a/language/types/integer.xml
+++ b/language/types/integer.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 78a11d3ca004ee937549d932e77a79c51b9777cd Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa,shimooka,mumumu -->
 <sect1 xml:id="language.types.integer">
  <title>整数</title>
@@ -30,7 +30,7 @@
    負の <type>int</type> を表すには、<link linkend="language.operators.arithmetic">負にする演算子</link>が使えます。
   </simpara>
 
-  <para>
+  <simpara>
    8 進数表記を使用する場合、数の前に <literal>0</literal> (ゼロ)
    を付ける必要があります。
    PHP 8.1.0 以降では、数の前に
@@ -39,7 +39,7 @@
    また、16 進数表記を使用するには、数の前に
    <literal>0x</literal> を付ける必要があります。
    2 進数表記を使用する場合、数の前に <literal>0b</literal> を付ける必要があります。
-  </para>
+  </simpara>
 
   <para>
    PHP 7.4.0 以降では、可読性を向上させるために整数リテラルの桁の間にアンダースコア
@@ -129,14 +129,14 @@ var_dump(PHP_INT_MAX + 1);       // 32-bit system: float(2147483648)
  <sect2 xml:id="language.types.integer.division">
   <title>整数の除算</title>
 
-  <para>
+  <simpara>
    PHP には整数の割り算を行う演算子はありません。
    整数の割り算を行うには、<function>intdiv</function> 関数を使って下さい。
    <literal>1/2</literal> は <type>
    float </type> 型の <literal>0.5</literal> になります。
    0 に近い方向の整数値に値を丸めるためにキャストを使用することができ、
    また、<function>round</function> 関数を使用することもできます。
-  </para>
+  </simpara>
 
   <example>
    <title>除算の例</title>

--- a/language/types/iterable.xml
+++ b/language/types/iterable.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e587d0655e426f97b3fcb431453da5030e743b23 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: mumumu Status: ready -->
 <sect1 xml:id="language.types.iterable">
  <title>Iterable</title>
 
- <para>
+ <simpara>
   <type>Iterable</type> は組み込みの、コンパイル時に変換される
   <literal>array|Traversable</literal> 型のエイリアスです。
   <!-- Need to improve rendering of free-standing type elements in PhD
@@ -17,7 +17,7 @@
   iterable 型は、&foreach; で繰り返し可能であり、
   <link linkend="language.generators">ジェネレータ</link>
   内で <command>yield from</command> できます。
- </para>
+ </simpara>
 
  <note>
   <para>

--- a/language/types/mixed.xml
+++ b/language/types/mixed.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 161dde4fe721309398dd324edbf02aec409f127b Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: mumumu Status: ready -->
 <sect1 xml:id="language.types.mixed">
  <title>Mixed</title>
 
@@ -19,10 +19,10 @@
   この型は、PHP 8.0.0 以降で利用可能です。
  </para>
 
- <para>
+ <simpara>
   <type>mixed</type> 型は、型理論の用語で言うと、トップ型にあたります。
   つまり、他の全ての型は、この型の部分型になります
- </para>
+ </simpara>
 
 </sect1>
 <!-- Keep this comment at the end of the file

--- a/language/types/never.xml
+++ b/language/types/never.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 161dde4fe721309398dd324edbf02aec409f127b Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: mumumu Status: ready -->
 <sect1 xml:id="language.types.never">
  <title>Never</title>
 
@@ -13,12 +13,12 @@
   よって、この型は <link linkend="language.types.type-system.composite.union">union 型</link> の一部として指定することが出来ません。
   PHP 8.1.0 以降で利用できます。
  </para>
- <para>
+ <simpara>
   <type>never</type> は、
   型理論の用語で言うと、ボトム型にあたります。
   つまり、全ての他の型の部分型であり、
   継承する際に他の戻り値の型を置き換えることができます。
- </para>
+ </simpara>
 
 </sect1>
 <!-- Keep this comment at the end of the file

--- a/language/types/null.xml
+++ b/language/types/null.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 3f1dbc451b313fb1ec8058f24c1beccf55fce316 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: mumumu Status: ready -->
 <sect1 xml:id="language.types.null">
  <title>NULL</title>
   
@@ -9,10 +9,10 @@
   つまり、単一の値 &null; しか持ちません。
  </para>
 
- <para>
+ <simpara>
   未定義、そして <function>unset</function>
   された値は、値 &null; に解決されます。
- </para>
+ </simpara>
   
  <sect2 xml:id="language.types.null.syntax">
   <title>文法</title>

--- a/language/types/numeric-strings.xml
+++ b/language/types/numeric-strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e587d0655e426f97b3fcb431453da5030e743b23 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: mumumu Status: ready -->
 
 <sect1 xml:id="language.types.numeric-strings" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>数値形式の文字列</title>
@@ -96,14 +96,14 @@ var_dump("2E1" == "020"); // true, "2E1" は 2 * (10 ^ 1), または 20
 
  <sect2 xml:id="language.types.numeric-string.prior">
   <title>PHP 8.0.0 より前の振る舞い</title>
-  <para>
+  <simpara>
    PHP 8.0.0 より前のバージョンでは、
-   <emphasis>先頭に</emphasis> ホワイトスペースがある場合にだけ、
+   <emphasis>先頭</emphasis> にしかホワイトスペースがない場合、
    文字列は数値と見なされていました。
 
    <emphasis>数値の後に</emphasis> ホワイトスペースがある場合は、
    その文字列は 先頭から始まる 数値形式の文字列とみなされていました。
-  </para>
+  </simpara>
 
   <para>
    PHP 8.0.0 より前のバージョンでは、

--- a/language/types/object.xml
+++ b/language/types/object.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e587d0655e426f97b3fcb431453da5030e743b23 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa,shimooka,mumumu -->
 <sect1 xml:id="language.types.object">
  <title>オブジェクト</title>
@@ -44,14 +44,14 @@ $bar->do_foo();
  <sect2 xml:id="language.types.object.casting">
   <title>オブジェクトへの変換</title>
   
-  <para>
+  <simpara>
    オブジェクトがオブジェクトに変換される場合はなにも修正されません。
    オブジェクト以外の型の値がオブジェクトに変換される時には、<classname>stdClass</classname> というビルトインクラス（予めPHPの内部で定義されているクラス）のインスタンスが新しく生成されます。
    その際、値が null の場合は新しいインスタンスは空となります。
    また、配列がオブジェクトに変換される場合、配列のキーと値がそれぞれオブジェクトのプロパティ名とその値となります。
    PHP 7.2.0
    より前のバージョンでは、数値のキーの場合プロパティ名によるアクセスはできなかった点に注意して下さい。
-  </para>
+  </simpara>
 
   <example>
    <title>オブジェクトにキャストする</title>

--- a/language/types/relative-class-types.xml
+++ b/language/types/relative-class-types.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 339ba3f0f4440af1f8d83e73b2c3be06b3cb2315 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: mumumu Status: ready -->
 <sect1 xml:id="language.types.relative-class-types">
  <title>クラス内での関係を示す相対型</title>
 
- <para>
+ <simpara>
   以下の型宣言は、クラスの内部でのみ使えます。
- </para>
+ </simpara>
 
  <sect2 xml:id="language.types.relative-class-types.self">
   <title><type>self</type></title>

--- a/language/types/resource.xml
+++ b/language/types/resource.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 95bdd6883b5dde9504701777ba81b3c5f15df52b Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa,shimooka,mumumu -->
 <sect1 xml:id="language.types.resource">
  <title>リソース</title>
@@ -29,13 +29,13 @@
  <sect2 xml:id="language.types.resource.self-destruct">
   <title>リソースの開放</title>
   
-  <para>
+  <simpara>
    Zend エンジンの一部であるリファレンスカウンティングシステムのおかげで、
    ある &resource; がもう参照されなくなった場合に (Java と全く同様に)、
    そのリソースは自動的に削除されます。この場合、このリソースが作成した
    全てのリソースは、ガベージコレクタにより開放されます。
    このため、free_result 関数を用いて手動でメモリを開放する必要が生じるのはまれです。
-  </para>
+  </simpara>
 
   <note>
    <simpara>

--- a/language/types/singleton.xml
+++ b/language/types/singleton.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 828980b619bb4300e196924598b6a5d398f630e4 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: mumumu Status: ready -->
 <sect1 xml:id="language.types.singleton">
  <title>シングルトン型</title>
 

--- a/language/types/string.xml
+++ b/language/types/string.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ddc2a2d0966f746b67292b6c0987ef288747e409 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa,shimooka,mumumu -->
 <sect1 xml:id="language.types.string">
  <title>文字列</title>
@@ -264,7 +264,7 @@ c
 
    <simpara>
     終端ID が、文字列のいずれかの行より奥にインデントされている場合、
-    <classname>ParseError</classname> がスローされます。
+    <exceptionname>ParseError</exceptionname> がスローされます。
    </simpara>
 
    <example>
@@ -294,7 +294,7 @@ Parse error: Invalid body indentation level (expecting an indentation level of a
     インデントする際にタブとスペースを混ぜては
     <emphasis>いけません</emphasis>。
     混ぜた場合、
-    <classname>ParseError</classname> がスローされます。
+    <exceptionname>ParseError</exceptionname> がスローされます。
 
     インデントに使う文字に制限があるのは、
     タブとスペースを混ぜてしまうと可読性が損なわれるためです。
@@ -373,11 +373,11 @@ array(2) {
      終端ID が行のはじめに見つかった場合、
      それが別の単語の一部かどうかにかかわらず、
      それが終端IDと見なされ、
-     <classname>ParseError</classname> が起きる可能性があります。
+     <exceptionname>ParseError</exceptionname> が起きます。
     </simpara>
 
     <example>
-     <title>文字列本体に 終端ID が含まれると、ParseError が起きがち</title>
+     <title>文字列本体に 終端ID が含まれると、<exceptionname>ParseError</exceptionname> が起きがち</title>
      <programlisting role="php">
 <![CDATA[
 <?php
@@ -593,7 +593,7 @@ FOOBAR;
   <sect3 xml:id="language.types.string.syntax.nowdoc">
    <title>Nowdoc</title>
    
-   <para>
+   <simpara>
     Nowdoc はヒアドキュメントと似ていますが、
     ヒアドキュメントがダブルクォートで囲んだ文字列として扱われるのに対して、
     Nowdoc はシングルクォートで囲んだ文字列として扱われます。
@@ -604,7 +604,7 @@ FOOBAR;
     <literal>&lt;![CDATA[ ]]&gt;</literal>
     (ブロック内のテキストをパースしないことを宣言する)
     と同じようなものです。
-   </para>
+   </simpara>
    
    <para>
     Nowdoc の書き方は、ヒアドキュメントと同じように
@@ -1226,12 +1226,12 @@ string(1) "b"
    これにより boolean と文字列の値を相互に変換することができます。
   </para>
 
-  <para> 
+  <simpara>
    <type>int</type> (整数) や浮動小数点数 (<type>float</type>) は
    その数値の数字として文字列に変換されます (指数の表記や浮動小数点数を含めて)。
    浮動小数点数は、指数表記
    (<literal>4.1E+6</literal>) を使用して変換されます。
-  </para>
+  </simpara>
 
   <note>
    <para>
@@ -1291,21 +1291,21 @@ string(1) "b"
   
   <title>文字列型の詳細</title>
   
-  <para>
+  <simpara>
    PHP における文字列型は、バイトの配列と整数値 (バッファ長) で実装されています。
    バイト列を文字列に変換する方法については何の情報も持っておらず、完全にプログラマ任せとなっています。
    文字列を構成する値には何の制限もありません。特に気をつけるべきなのは、
    値 <literal>0</literal> のバイト (いわゆる “NUL バイト”) を文字列内のどの部分にでも使えるという点です
    (しかし、このマニュアル上で「バイナリセーフではない」とされている一部の関数では、
    受け取った文字列をライブラリに渡すときに NUL バイト以降を無視することがあります)。
-  </para>
+  </simpara>
   <para>
    PHP の文字列型の正体を知ってしまえば、なぜ PHP には「バイト型」が存在しないのかもわかります。
    つまり、文字列型がその役割を受け持っているのです。テキスト以外のデータ、
    たとえばネットワークソケットから読み込んだ任意のデータを返す関数も、
    文字列で値を返します。
   </para>
-  <para>
+  <simpara>
    PHP が文字列に対して特定のエンコーディングを強制しないのなら、
    いったいどのようにして文字列リテラルをエンコードしているのでしょう?
    たとえば、文字列 <literal>"á"</literal> と同等なのは <literal>"\xE1"</literal> (ISO-8859-1)、
@@ -1327,7 +1327,7 @@ string(1) "b"
    しかし、状態に依存する
    (たとえば、同じバイト値が、先頭にあるときとシフト状態にあるときで違う意味になる)
    エンコーディングは、問題になる可能性があります。
-  </para>
+  </simpara>
   <para>
    もちろん、利便性を考慮すれば、テキストを操作する関数が文字列のエンコードを扱う際に
    何らかの前提に基づかざるを得ないこともあります。
@@ -1347,8 +1347,8 @@ string(1) "b"
    </listitem>
    <listitem>
     <simpara>
-     文字列のエンコーディングを受け取る関数もあります。
-     エンコーディング情報を省略したときにはデフォルトを用意していることもあるでしょう。
+     文字列のエンコーディングをパラメータとして受け取るか、
+     指定されなかった場合はデフォルトを仮定する関数もあります。
      このタイプの関数の例は、<function>htmlentities</function> や
      大半の <link linkend="book.mbstring">mbstring</link> 関数です。
     </simpara>

--- a/language/types/type-juggling.xml
+++ b/language/types/type-juggling.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 50f76f26914c5a9e61aa26f2e36c4acb362a48fd Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: mumumu Status: ready -->
 <sect1 xml:id="language.types.type-juggling">
  <title>型の相互変換</title>
 
@@ -71,7 +71,7 @@
    そうでない場合、オペランドは整数として解釈され、
    結果の型も整数になります。
    PHP 8.0.0 以降では、いずれかのオペランドが解釈できない場合、
-   <classname>TypeError</classname> がスローされます。
+   <exceptionname>TypeError</exceptionname> がスローされます。
   </simpara>
  </sect2>
 
@@ -90,7 +90,7 @@
   <simpara>
    値は文字列として解釈されます。
    文字列として解釈できない場合、
-   <classname>TypeError</classname> がスローされます。
+   <exceptionname>TypeError</exceptionname> がスローされます。
    PHP 7.4.0 より前のバージョンでは、
    <constant>E_RECOVERABLE_ERROR</constant> が発生していました。
   </simpara>
@@ -128,7 +128,7 @@
    オペランドは整数として解釈され、
    結果の型も整数になります。
    PHP 8.0.0 以降では、いずれかのオペランドが解釈できない場合、
-   <classname>TypeError</classname> がスローされます。
+   <exceptionname>TypeError</exceptionname> がスローされます。
   </simpara>
  </sect2>
 
@@ -156,7 +156,7 @@
    戻り値の型を宣言している関数から値が返される場合です。
   </simpara>
 
-  <para>
+  <simpara>
    このコンテクストでは、値はその型の値でなければなりません。
    これにはふたつ例外があります。
    ひとつめは値の型が <type>int</type> で、
@@ -168,7 +168,7 @@
    かつ型の自動変換モードが有効な場合(デフォルト)、
    スカラー型の値が別の変換可能なスカラー型に変換される可能性があることです。
    この振る舞いに関する詳細は、以下を参照ください:
-  </para>
+  </simpara>
 
   <warning>
    <simpara>
@@ -251,13 +251,13 @@
    </caution>
 
    <note>
-    <para>
+    <simpara>
      上のリストに入っていない型については、
      暗黙の型変換が行われる対象ではありません。
      特に、暗黙のうちに
      <type>null</type>, <type>false</type>, <type>true</type>
      に変換されることはありません。
-    </para>
+    </simpara>
    </note>
 
    <example>

--- a/language/types/type-system.xml
+++ b/language/types/type-system.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: mumumu Status: ready -->
 <sect1 xml:id="language.types.type-system">
  <title>型システム</title>
 
@@ -20,10 +20,10 @@
 
  <sect2 xml:id="language.types.type-system.atomic">
   <title>基本型</title>
-  <para>
+  <simpara>
    基本型の一部は言語に強く統合されている組み込み型であり、
    ユーザー定義の型として再現できません。
-  </para>
+  </simpara>
 
   <para>
    基本型の一覧は以下になります:
@@ -163,13 +163,13 @@
 
   <sect3 xml:id="language.types.type-system.composite.intersection">
    <title>交差型</title>
-   <para>
+   <simpara>
     交差型 は、宣言した複数のクラス型を(単一ではなく)
     すべて満たす値を受け入れることができます。
     交差型を構成する個別の型は、<literal>&amp;</literal> 記号で結合します。
     よって、型 <literal>T</literal>, <literal>U</literal>,
     <literal>V</literal> の交差型は <literal>T&amp;U&amp;V</literal> と書きます。
-   </para>
+   </simpara>
   </sect3>
 
   <sect3 xml:id="language.types.type-system.composite.union">
@@ -190,14 +190,14 @@
  <sect2 xml:id="language.types.type-system.alias">
   <title>型のエイリアス</title>
 
-  <para>
+  <simpara>
    PHP は型のエイリアスをふたつサポートしています。
    <type>mixed</type> と <type>iterable</type> です。
    それぞれ、
    <link linkend="language.types.type-system.composite.union">union 型</link>
    <literal>object|resource|array|string|float|int|bool|null</literal>
    と、<literal>Traversable|array</literal> に対応します。
-  </para>
+  </simpara>
 
   <note>
    <simpara>

--- a/language/types/void.xml
+++ b/language/types/void.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 50f76f26914c5a9e61aa26f2e36c4acb362a48fd Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: mumumu Status: ready -->
 <sect1 xml:id="language.types.void">
  <title>Void</title>
 


### PR DESCRIPTION
英語版の文法修正 php/doc-en#5746・php/doc-en#5728 への追従。37 ファイル。

- language/types 18件 — php/doc-en@7132d883
- language/oop5 19件 — php/doc-en@dff848b1

うち 29 件は `<para>` → `<simpara>` のマークアップ追従と EN-Revision の更新のみで
訳文が変わらないため、ファイル名を割愛した。残る 8 件は以下。

## 原文の意味が変わったもの

- types/string.xml — `may be` が外れ、終端 ID とみなされて ParseError が起きることが断定になった
- types/string.xml — `possibly` が外れ、エンコーディングをパラメータで受け取るか
  デフォルトを仮定するかの選言に再構成された
- types/declarations.xml — `the type of variable reference` →
  `the type of the variable passed by reference` で、型を変更される対象が明確化された
- types/numeric-strings.xml — `only if it had leading whitespaces` →
  `if it only had leading whitespaces` で `only` の係り先が変わった
- oop5/constants.xml — `remaining the same and unchangeable` が削除された

## 原文のマークアップ・識別子が変わったもの

- types/string.xml, types/type-juggling.xml — `<classname>` → `<exceptionname>`
- oop5/magic.xml — `__set_state()` を `<methodname>` で囲む
- types/callable.xml — 存在しない関数名 `call_user_function` の誤りを `call_user_func` に修正
- oop5/properties.xml — 存在しないメソッド名 `setNumberofSides` の誤りを `setNumberOfSides` に修正
