### PR TITLE
ltrim の既訳誤りを修正（パラメータ説明の未訳）

### DIFF
--- a/reference/strings/functions/ltrim.xml
+++ b/reference/strings/functions/ltrim.xml
@@ -32,7 +32,7 @@
     <term><parameter>string</parameter></term>
     <listitem>
      <simpara>
-      The input string.
+      入力文字列。
      </simpara>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
`string` パラメータの説明が **"The input string." のまま未訳**。同じ原文を持つ rtrim の既訳と同形の「入力文字列。」を充当。
