### PR TITLE
strncasecmp の既訳誤りを修正（原文で削除済みの記述の残存）

### DIFF
--- a/reference/strings/functions/strncasecmp.xml
+++ b/reference/strings/functions/strncasecmp.xml
@@ -18,9 +18,7 @@
   </methodsynopsis>
   <para>
    この関数は、<function>strcasecmp</function> に似ていますが、
-   各文字列から比較する文字数(の上限)(<parameter>len</parameter>)
-   を指定できるという違いがあります。どちらかの文字列が
-   <parameter>len</parameter>より短い場合、その文字列の長さが比較時に使用されます。
+   各文字列から比較に使用する文字数(の上限)を指定できるという違いがあります。
   </para>
  </refsect1>
 


### PR DESCRIPTION
- 第2文「どちらかの文字列が len より短い場合、その文字列の長さが比較時に使用されます。」は、**原文が 2004 年に誤りとして削除した文の残存**（ php/doc-en@81ba6ffec0 、[PHP Bug #26940](https://bugs.php.net/bug.php?id=26940)）。実挙動とも矛盾（`strncasecmp("abc", "abcdef", 10)` は 0 ではなく負）
- 存在しないパラメータ名 **len**（実際は `length`）への言及を現行原文に合わせ整理
