### PR TITLE
strncmp の既訳誤りを修正（存在しないパラメータ名）

### DIFF
--- a/reference/strings/functions/strncmp.xml
+++ b/reference/strings/functions/strncmp.xml
@@ -18,8 +18,7 @@
   </methodsynopsis>
   <para>
    この関数は <function>strcmp</function> に似ていますが、
-   各文字列から(最大)文字数(<parameter>len</parameter>)
-   を比較に使用するところが異なります。
+   各文字列から比較に使用する文字数(の上限)を指定できるところが異なります。
   </para>
   <para>
    比較は大文字小文字を区別することに注意してください。


### PR DESCRIPTION
説明文中のパラメータ名 **len** は現在のシグネチャに存在しない（実際は `length`）。原文 "you can specify the (upper limit of the) number of characters from each string to be used in the comparison" に合わせて整理。
