### PR TITLE
strripos / strrpos の既訳誤りを修正（effectively の誤訳ほか）

### DIFF
--- a/reference/strings/functions/strripos.xml
+++ b/reference/strings/functions/strripos.xml
@@ -64,9 +64,8 @@
        <parameter>needle</parameter> が最初に現れる場所を探します。
        <note>
         <para>
-         この方が、最後の <parameter>offset</parameter> バイトより前にある、
-         最後の <parameter>needle</parameter> 
-         を効率的に探せます。
+         これは実質的に、最後の <parameter>offset</parameter> バイトより前にある、
+         最後の <parameter>needle</parameter> を探すことになります。
         </para>
        </note>
       </para>
@@ -81,7 +80,7 @@
   <para>
    <parameter>needle</parameter> が見つかった位置を、
    <parameter>haystack</parameter> 文字列の先頭
-   (<parameter>offset</parameter> の値とは無関係) からの相対位置で返します。
+   (検索方向や <parameter>offset</parameter> の値とは無関係) からの相対位置で返します。
    <note>
     <simpara>
      文字列の開始位置は 0 であり、1 ではありません。
@@ -118,8 +117,8 @@
      </row>
     </thead>
     <tbody>
-     &strings.changelog.needle-empty;
      &strings.changelog.ascii-case-folding;
+     &strings.changelog.needle-empty;
      <row>
       <entry>8.0.0</entry>
       <entry>

--- a/reference/strings/functions/strrpos.xml
+++ b/reference/strings/functions/strrpos.xml
@@ -61,9 +61,8 @@
        検索を開始した箇所から <parameter>needle</parameter> が最初に現れる場所を探します。
        <note>
         <para>
-         この方が、最後の <parameter>offset</parameter> バイト、またはそれより前にある
-         最後の <parameter>needle</parameter> 
-         を効率的に探せます。
+         これは実質的に、最後の <parameter>offset</parameter> バイト、またはそれより前にある
+         最後の <parameter>needle</parameter> を探すことになります。
         </para>
        </note>
       </para>
@@ -77,7 +76,7 @@
   &reftitle.returnvalues;
   <para>
    needle が見つかった位置を、
-   <parameter>haystack</parameter> 文字列の先頭 (offset の値とは無関係) からの相対位置で返します。
+   <parameter>haystack</parameter> 文字列の先頭 (検索方向や offset の値とは無関係) からの相対位置で返します。
    <note>
     <simpara>
      文字列の開始位置は 0 であり、1 ではありません。


### PR DESCRIPTION
- 両ページ: note の原文 "This is **effectively** looking for..." の訳「**効率的に**」は誤訳（正: 実質的に）
- 両ページ: 戻り値説明の "(independent of **search direction** or offset)" は「検索方向」が訳抜け
- strripos のみ: changelog の並び順が原文のバージョン降順（8.2.0 → 8.0.0）と逆
