### PR TITLE
setlocale の既訳誤りを修正（削除済み語句の残存と decimal の誤訳）

### DIFF
--- a/reference/strings/functions/setlocale.xml
+++ b/reference/strings/functions/setlocale.xml
@@ -49,7 +49,7 @@
      <term><parameter>category</parameter></term>
      <listitem>
       <para>
-       <parameter>category</parameter>は、名前付きの定数(または文字列)であり、
+       <parameter>category</parameter>は、名前付きの定数であり、
        ロケール設定により影響を受ける関数のカテゴリを指定します。
        <itemizedlist>
         <listitem>
@@ -74,7 +74,7 @@
         </listitem>
         <listitem>
          <simpara>
-          <constant>LC_NUMERIC</constant> 数字の区切り文字用(<function>localeconv</function>
+          <constant>LC_NUMERIC</constant> 小数点の区切り文字用(<function>localeconv</function>
           も参照ください)
          </simpara>
         </listitem>


### PR DESCRIPTION
- `category` 説明の「**(または文字列)**」は、原文で削除済みの "(or string)"（ php/doc-en@16fbede5b5 ）の残存
- `LC_NUMERIC` の "for **decimal** separator" の訳「**数字**の区切り文字用」は誤訳（正: 小数点の区切り文字用）
