### PR TITLE
localeconv の既訳誤りを修正（fractional digits の誤訳）

### DIFF
--- a/reference/strings/constants.xml
+++ b/reference/strings/constants.xml
@@ -995,7 +995,7 @@
    </term>
    <listitem>
     <simpara>
-     国際的な方法で表現する際の小数点以下の桁数
+     通貨を国際形式で表記する際の小数点以下の桁数
     </simpara>
    </listitem>
   </varlistentry>
@@ -1006,7 +1006,7 @@
    </term>
    <listitem>
     <simpara>
-     地域的な方法で表現する際の小数点以下の桁数
+     通貨を現地形式で表記する際の小数点以下の桁数
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/strings/functions/localeconv.xml
+++ b/reference/strings/functions/localeconv.xml
@@ -81,11 +81,11 @@
       </row>
       <row>
        <entry>int_frac_digits</entry>
-       <entry>国際分割桁</entry>
+       <entry>国際的な方法で表現する際の小数点以下の桁数</entry>
       </row>
       <row>
        <entry>frac_digits</entry>
-       <entry>ローカルな分割桁</entry>
+       <entry>地域的な方法で表現する際の小数点以下の桁数</entry>
       </row>
       <row>
        <entry>p_cs_precedes</entry>

--- a/reference/strings/functions/localeconv.xml
+++ b/reference/strings/functions/localeconv.xml
@@ -81,11 +81,11 @@
       </row>
       <row>
        <entry>int_frac_digits</entry>
-       <entry>国際的な方法で表現する際の小数点以下の桁数</entry>
+       <entry>通貨を国際形式で表記する際の小数点以下の桁数</entry>
       </row>
       <row>
        <entry>frac_digits</entry>
-       <entry>地域的な方法で表現する際の小数点以下の桁数</entry>
+       <entry>通貨を現地形式で表記する際の小数点以下の桁数</entry>
       </row>
       <row>
        <entry>p_cs_precedes</entry>

--- a/reference/strings/functions/nl-langinfo.xml
+++ b/reference/strings/functions/nl-langinfo.xml
@@ -147,11 +147,11 @@
           </row>
           <row>
            <entry><constant>INT_FRAC_DIGITS</constant></entry>
-           <entry>国際的な方法で表現する際の小数点以下の桁数</entry>
+           <entry>通貨を国際形式で表記する際の小数点以下の桁数</entry>
           </row>
           <row>
            <entry><constant>FRAC_DIGITS</constant></entry>
-           <entry>地域的な方法で表現する際の小数点以下の桁数</entry>
+           <entry>通貨を現地形式で表記する際の小数点以下の桁数</entry>
           </row>
           <row>
            <entry><constant>P_CS_PRECEDES</constant></entry>


### PR DESCRIPTION
"International/Local **fractional digits**" の訳「**国際分割桁**」「**ローカルな分割桁**」は誤訳。

当初は nl-langinfo・strings/constants の既訳「国際的な／地域的な方法で表現する際の小数点以下の桁数」に合わせたが、この既訳自体が表記対象（通貨）を欠いて分かりづらいため、姉妹の 2 ファイルも含めて「**通貨を国際形式で／現地形式で表記する際の小数点以下の桁数**」に統一した（`int_frac_digits` は ISO 4217 の国際形式、`frac_digits` は通貨記号による現地形式の通貨表記の意）。
