### PR TITLE
array_fill の既訳誤りを修正（リンク先の誤り）

### DIFF
--- a/reference/array/functions/array-fill.xml
+++ b/reference/array/functions/array-fill.xml
@@ -43,7 +43,7 @@
        PHP 8.0.0 以降のバージョンでは、
        <parameter>start_index</parameter> が負の場合でも、
        インデックスの値が通常通りインクリメントされるようになっています。
-       (<link linkend="function.array-fill.example.basic">例</link>を参照ください)。
+       (<link linkend="function.array-fill.example.negative-start-index">例</link>を参照ください)。
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
負の `start_index` の説明から張られたリンクが**基本の例**（`function.array-fill.example.basic`）を指す誤り。原文は負の例 `function.array-fill.example.negative-start-index` を指す。
