### PR TITLE
date_sun_info の既訳誤りを修正（日の出の天頂角ほか）

### DIFF
--- a/reference/datetime/functions/date-sun-info.xml
+++ b/reference/datetime/functions/date-sun-info.xml
@@ -60,7 +60,7 @@
      <term><literal>sunrise</literal></term>
      <listitem>
       <simpara>
-       日の出のタイムスタンプ (天頂角 = 90°50' )
+       日の出のタイムスタンプ (天頂角 = 90°35')。
       </simpara>
      </listitem> 
     </varlistentry>
@@ -68,7 +68,7 @@
      <term><literal>sunset</literal></term>
      <listitem>
       <simpara>
-       日の入りのタイムスタンプ (天頂角 = 90°35' )
+       日の入りのタイムスタンプ (天頂角 = 90°35')。
       </simpara>
      </listitem> 
     </varlistentry>
@@ -138,9 +138,9 @@
    </variablelist>
   </para>
   <para> 
-   配列の要素の値は、UNIXタイムスタンプ、または
-   太陽が天頂より一日中下にある場合、&false; です。
-   また、一日中天頂より上にある場合、 &true; です。
+   配列の要素の値は、UNIX タイムスタンプ、
+   太陽がそれぞれの天頂角より一日中下にある場合の &false;、
+   一日中上にある場合の &true; のいずれかです。
   </para>
  </refsect1>
 
@@ -159,8 +159,8 @@
       <row>
        <entry>7.2.0</entry>
        <entry>
-        ローカルの昼ではなく、
-        夜中に関する計算結果が修正されました。
+        計算が、現地の正午ではなく、
+        現地の真夜中を基準に行われるように修正されました。
         これによって、結果が少し変わります。
        </entry>
       </row>


### PR DESCRIPTION
- `sunrise` の天頂角「**90°50'**」は転記ミス（原文は 90°35'。php-src の実装も sunrise / sunset とも高度 -35'/60 で、同リストの sunset は正しい）
- "below/above the **respective** zenith" の respective が訳抜けで「天頂（天頂点）より下」と誤読される文に
- changelog の "local **noon**" の訳「ローカルの**昼**」は誤訳（正: 現地の正午）
