### PR TITLE
mysqli_stmt::result_metadata の既訳誤りを修正（戻り値説明の訳抜け）

### DIFF
--- a/reference/mysqli/mysqli_stmt/result-metadata.xml
+++ b/reference/mysqli/mysqli_stmt/result-metadata.xml
@@ -77,6 +77,7 @@
   &reftitle.returnvalues;
   <simpara>
    結果のオブジェクトを返します。エラー時には &false; を返します。
+   ステートメントが結果セットを生成しない場合も、&false; を返します。
   </simpara>
  </refsect1>
 


### PR DESCRIPTION
戻り値説明の原文 2 文目 "**If the statement does not produce a result set, &false; is returned as well.**" が訳抜け。
