### PR TITLE
SimpleXMLElement::rewind / next / valid の既訳誤りを修正（警告の訳抜け）

### DIFF
--- a/reference/simplexml/simplexmlelement/next.xml
+++ b/reference/simplexml/simplexmlelement/next.xml
@@ -13,6 +13,15 @@
    <modifier>public</modifier> <type>void</type><methodname>SimpleXMLElement::next</methodname>
    <void/>
   </methodsynopsis>
+
+  <warning>
+   <simpara>
+    PHP 8.0 より前のバージョンでは、
+    <methodname>SimpleXMLElement::next</methodname> は
+    サブクラスの <classname>SimpleXMLIterator</classname> でのみ宣言されていました。
+   </simpara>
+  </warning>
+
   <para>
    このメソッドは、<classname>SimpleXMLElement</classname> を次の要素に移動します。
   </para>

--- a/reference/simplexml/simplexmlelement/rewind.xml
+++ b/reference/simplexml/simplexmlelement/rewind.xml
@@ -13,6 +13,15 @@
    <modifier>public</modifier> <type>void</type><methodname>SimpleXMLElement::rewind</methodname>
    <void/>
   </methodsynopsis>
+
+  <warning>
+   <simpara>
+    PHP 8.0 より前のバージョンでは、
+    <methodname>SimpleXMLElement::rewind</methodname> は
+    サブクラスの <classname>SimpleXMLIterator</classname> でのみ宣言されていました。
+   </simpara>
+  </warning>
+
   <para>
    このメソッドは、<classname>SimpleXMLElement</classname> を最初の要素に巻き戻します。
   </para>

--- a/reference/simplexml/simplexmlelement/valid.xml
+++ b/reference/simplexml/simplexmlelement/valid.xml
@@ -13,6 +13,15 @@
    <modifier>public</modifier> <type>bool</type><methodname>SimpleXMLElement::valid</methodname>
    <void/>
   </methodsynopsis>
+
+  <warning>
+   <simpara>
+    PHP 8.0 より前のバージョンでは、
+    <methodname>SimpleXMLElement::valid</methodname> は
+    サブクラスの <classname>SimpleXMLIterator</classname> でのみ宣言されていました。
+   </simpara>
+  </warning>
+
   <para>
    このメソッドは、現在の要素が
    <methodname>SimpleXMLElement::rewind</methodname> あるいは


### PR DESCRIPTION
3 ページとも、原文の警告 "**Prior to PHP 8.0, `SimpleXMLElement::rewind` was only declared on the subclass `SimpleXMLIterator`.**"（メソッド名は各ページ）が訳抜け。同じ原文を持つ hasChildren などの既訳と同形で追加。
