### PR TITLE
null 型の既訳誤りを修正（主語の取り違え）

### DIFF
--- a/language/types/null.xml
+++ b/language/types/null.xml
@@ -10,8 +10,8 @@
  </para>
 
  <simpara>
-  未定義、そして <function>unset</function>
-  された値は、値 &null; に解決されます。
+  未定義の変数、および <function>unset</function> された変数は、
+  値 &null; に解決されます。
  </simpara>
   
  <sect2 xml:id="language.types.null.syntax">


### PR DESCRIPTION
原文 "Undefined and unset **variables** resolve to the value null." の主語は**変数**。既訳「未定義、そして unset された**値**は、値 null に解決されます」は主語を「値」と取り違え、「値が値に解決される」の同語反復。
