### PR TITLE
resource 型の既訳誤りを修正（旧原文の訳の残存）

### DIFF
--- a/language/types/resource.xml
+++ b/language/types/resource.xml
@@ -27,21 +27,21 @@
  </sect2>
 
  <sect2 xml:id="language.types.resource.self-destruct">
-  <title>リソースの開放</title>
+  <title>リソースの解放</title>
   
   <simpara>
    Zend エンジンの一部であるリファレンスカウンティングシステムのおかげで、
-   ある &resource; がもう参照されなくなった場合に (Java と全く同様に)、
-   そのリソースは自動的に削除されます。この場合、このリソースが作成した
-   全てのリソースは、ガベージコレクタにより開放されます。
-   このため、free_result 関数を用いて手動でメモリを開放する必要が生じるのはまれです。
+   どこからも参照されなくなった &resource; は自動的に検出され、
+   ガベージコレクタによって解放されます。
+   このため、手動でメモリを解放する必要が生じるのはまれです。
   </simpara>
 
   <note>
    <simpara>
-    持続的データベース接続は特別で、ガベージコレクタにより破棄されません。
-    <link linkend="features.persistent-connections">持続的接続</link>
-    も参照ください。
+    持続的データベース接続は、このルールの例外です。
+    これらは、ガベージコレクタによって破棄<emphasis>されません</emphasis>。
+    詳細は <link linkend="features.persistent-connections">持続的接続</link>
+    を参照ください。
    </simpara>
   </note>
   


### PR DESCRIPTION
- 「リソースの解放」節の本文が古い原文の訳のまま残存。「**(Java と全く同様に)**」「**このリソースが作成した全てのリソース**」「**free_result 関数**」はいずれも現行原文に存在しない。現行原文に合わせて再訳
- note の "They are `<emphasis>not</emphasis>` destroyed..." の emphasis をミラー
- 節タイトルの誤字「**開放**」→「解放」
