### PR TITLE
スコープ定義演算子の既訳誤りを修正（列挙の非文と係りの誤り）

### DIFF
--- a/language/oop5/paamayim-nekudotayim.xml
+++ b/language/oop5/paamayim-nekudotayim.xml
@@ -9,10 +9,10 @@
  <para>
   スコープ定義演算子 (またの名を Paamayim Nekudotayim)、
   平たく言うと「ダブルコロン」は、トークンのひとつです。
-  <link linkend="language.oop5.constants">定数</link>
+  クラスまたはその親クラスの
+  <link linkend="language.oop5.constants">定数</link>、
   <link linkend="language.oop5.static">static</link> プロパティ、
-  クラスの <link linkend="language.oop5.static">static</link> メソッド、
-  や親クラスのそれにアクセスできます。
+  <link linkend="language.oop5.static">static</link> メソッドにアクセスできます。
   さらに、static メソッドやプロパティは
   <link linkend="language.oop5.late-static-bindings">遅延静的束縛 (Late Static Bindings)</link>
   経由でオーバーライドできます。


### PR DESCRIPTION
- 冒頭の段落が「定数」直後の読点欠落と「static メソッド **、や** 親クラスの」の衍字で非文
- 原文 "of **a class or one of its parents**" は 3 項目すべてに係るが、既訳では static メソッドのみに係る形
