### PR TITLE
autoload の既訳誤りを修正（コード例の構文エラー）

### DIFF
--- a/language/oop5/autoload.xml
+++ b/language/oop5/autoload.xml
@@ -104,7 +104,7 @@ Fatal error: Interface 'ITest' not found in ...
 <?php
 require __DIR__ . '/vendor/autoload.php';
 
-$uuid = new Ramsey\Uuid\Uuid::uuid7();
+$uuid = Ramsey\Uuid\Uuid::uuid7();
 
 echo "Generated new UUID -> ", $uuid->toString(), "\n";
 ?>


### PR DESCRIPTION
コード例の `new Ramsey\Uuid\Uuid::uuid7()` は静的メソッド呼び出しに **new** が付いたパースエラー。原文のコードに new は無く、doc-ja 側の混入。
