### PR TITLE
bcadd の既訳誤りを修正（ValueError の条件のパラメータ名の重複）

### DIFF
--- a/reference/bc/functions/bcadd.xml
+++ b/reference/bc/functions/bcadd.xml
@@ -64,13 +64,12 @@
   </para>
  </refsect1>
  
- <!-- to be translated -->
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
    この関数は、以下の場合に <exceptionname>ValueError</exceptionname> をスローします:
    <simplelist>
-    <member><parameter>num1</parameter> もしくは <parameter>num1</parameter> が、BCMath で有効でない数値形式の文字列である場合</member>
+    <member><parameter>num1</parameter> もしくは <parameter>num2</parameter> が、BCMath で有効でない数値形式の文字列である場合</member>
     <member><parameter>scale</parameter> が範囲外の値である場合</member>
    </simplelist>
   </para>


### PR DESCRIPTION
errors の列挙で原文 "`num1` or `num2`" が「`num1` もしくは **`num1`**」と同じパラメータ名の重複になっており、`num2` の条件が読めない。訳出済みのセクションに残っていた `<!-- to be translated -->` マーカーも削除。
