### PR TITLE
crypt の既訳誤りを修正（salt の説明の因果の逆転ほか）

### DIFF
--- a/reference/strings/functions/crypt.xml
+++ b/reference/strings/functions/crypt.xml
@@ -20,7 +20,7 @@
    <methodparam><type>string</type><parameter>salt</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>crypt</function> 文字列のハッシュを返します。
+   <function>crypt</function> は、文字列のハッシュを返します。
    Unix 標準の <abbrev>DES</abbrev> ベースのアルゴリズムか、
    代替のアルゴリズムを使用します。
    <function>password_verify</function> は
@@ -33,11 +33,11 @@
    パラメータは必須ではありませんでした。ただ、これを省略すると
    <function>crypt</function>
    が作るハッシュが弱いものになってしまっていました。
-   このパラメータを省略した場合には、E_NOTICE が発生していました。
+   このパラメータを省略した場合には、<constant>E_NOTICE</constant> が発生していました。
    十分に強い salt を指定して、セキュリティを確保しましょう。
   </para>
   <para>
-   <function>password_hash</function> は、強力なハッシュを使い、強力なソルトを生成して、それを複数回自動的に適用します。
+   <function>password_hash</function> は、強力なハッシュを使い、強力な salt を生成して、それを複数回自動的に適用します。
    <function>password_hash</function> は <function>crypt</function> のシンプルなラッパーであり、既存のパスワードハッシュと互換性があります。
    <function>password_hash</function> を使うことを推奨します。
   </para>
@@ -50,7 +50,7 @@
   </simpara>
   <para>
    標準の DES ベースの場合、<function>crypt</function>
-   は出力の最初の 2 文字を salt として使用します。また、
+   は salt を出力の最初の 2 文字として返します。また、
    <parameter>string</parameter> の最初の 8 文字しか使用しません。
    つまり、最初の 8 文字が同じである長い文字列は、
    同じ salt を使う限り同じ結果となります。


### PR DESCRIPTION
- 原文 "returns the salt as the first two characters of the output" が「出力の最初の 2 文字を salt として**使用します**」と因果が逆
- 冒頭の「`crypt` 文字列のハッシュを返します」が助詞欠落で非文
- `<constant>E_NOTICE</constant>` が平文
