### PR TITLE
strpbrk の既訳誤りを修正（refpurpose の誤訳）

### DIFF
--- a/reference/strings/functions/strpbrk.xml
+++ b/reference/strings/functions/strpbrk.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="function.strpbrk" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>strpbrk</refname>
-  <refpurpose>文字列の中から任意の文字を探す</refpurpose>
+  <refpurpose>文字列の中から指定した文字のいずれかを探す</refpurpose>
  </refnamediv>
  
  <refsect1 role="description">


### PR DESCRIPTION
refpurpose「文字列の中から**任意の**文字を探す」が arbitrary の意に読める。原文は "Search a string for any of a set of characters" で、本文の既訳「`characters` に含まれる文字のいずれかを探します」とも食い違う。
