### PR TITLE
str_repeat の既訳誤りを修正（助詞の重複）

### DIFF
--- a/reference/strings/functions/str-repeat.xml
+++ b/reference/strings/functions/str-repeat.xml
@@ -17,7 +17,7 @@
   </methodsynopsis>
   <para>
    <parameter>string</parameter> を
-   <parameter>times</parameter> 回を繰り返した文字列を返します。
+   <parameter>times</parameter> 回繰り返した文字列を返します。
   </para>
  </refsect1>
 
@@ -42,7 +42,7 @@
       <para>
        <parameter>times</parameter> は 0 以上でなければなりません。
        <parameter>times</parameter> が
-       0 に設定された場合、この関数は空文字を返します。
+       0 に設定された場合、この関数は空文字列を返します。
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
「`times` 回**を**繰り返した文字列を返します」の助詞重複で非文。
