### PR TITLE
setlocale の既訳誤りを修正（例のコメントの未訳）

### DIFF
--- a/reference/strings/functions/setlocale.xml
+++ b/reference/strings/functions/setlocale.xml
@@ -216,7 +216,7 @@ echo "Preferred locale for german on this system is '$loc_de'";
     <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
-/* Retrieve current setting */
+/* 現在の設定を取得する */
 $current = setlocale(LC_ALL, null);
 
 echo "Current locale '$current'";


### PR DESCRIPTION
例のコメント `/* Retrieve current setting */` が未訳のまま。同ファイルの他の例のコメントは訳出済み。
