### PR TITLE
マジックメソッドの既訳誤りを修正（「メソッド」と「メソッド名」の取り違え）

### DIFF
--- a/language/oop5/magic.xml
+++ b/language/oop5/magic.xml
@@ -12,7 +12,7 @@
   </simpara>
   <caution>
    <simpara>
-    <literal>__</literal> で始まる全てのメソッドは、
+    <literal>__</literal> で始まる全てのメソッド名は、
     PHP によって予約されています。
     よって、PHP の動作を上書きするのでなければ、
     このようなメソッド名を使うことは推奨されません。


### PR DESCRIPTION
caution の「`__` で始まる全ての**メソッド**は、PHP によって予約されています」。原文は "All method names starting with `__` are reserved" で、予約されているのは名前。同じ caution の次の文では「メソッド名」と訳している。
