### PR TITLE
変性の既訳誤りを修正（係りの誤り）

### DIFF
--- a/language/oop5/variance.xml
+++ b/language/oop5/variance.xml
@@ -49,9 +49,9 @@
 
   <simpara>
    共変性がどのように動作するかを示すために、
-   単純な抽象クラスの親である<varname>Animal</varname> を作ることにします。
+   単純な抽象親クラスである <varname>Animal</varname> を作ることにします。
    このクラスは子クラス <varname>Cat</varname> と <varname>Dog</varname>
-   に継承されています。
+   に継承されます。
   </simpara>
 
   <informalexample>
@@ -110,7 +110,7 @@ interface AnimalShelter
 
 class CatShelter implements AnimalShelter
 {
-    public function adopt(string $name): Cat // Animal 型を返す代わりに、Cat型を返すことができる
+    public function adopt(string $name): Cat // Animal 型を返す代わりに、Cat 型を返すことができる
     {
         return new Cat($name);
     }
@@ -118,7 +118,7 @@ class CatShelter implements AnimalShelter
 
 class DogShelter implements AnimalShelter
 {
-    public function adopt(string $name): Dog // Animal 型を返す代わりに、Dog型を返すことができる
+    public function adopt(string $name): Dog // Animal 型を返す代わりに、Dog 型を返すことができる
     {
         return new Dog($name);
     }


### PR DESCRIPTION
原文 "a simple abstract parent class, `Animal`" が「単純な**抽象クラスの親**である `Animal`」と係りが逆（正しくは抽象の親クラス）。続く "will be extended" が「継承されて**います**」で、この後にコード例が来る流れと合わない。
