### PR TITLE
クラスの基本の既訳誤りを修正（classname の欠落と原文にない注記）

### DIFF
--- a/language/oop5/basic.xml
+++ b/language/oop5/basic.xml
@@ -495,7 +495,7 @@ echo ($obj->bar)(), PHP_EOL;
    クラスは一つだけです。
   </para>
   <para>
-    継承された定数やメソッド、プロパティをオーバーライド(上書き)するには、
+    継承された定数やメソッド、プロパティをオーバーライドするには、
     親クラスで定義されているのと同じ名前でそれを再宣言します。
     しかし、親クラスでそのメソッドや定数が
     <link linkend="language.oop5.final">final</link>
@@ -671,7 +671,7 @@ Fatal error: Declaration of Extend::foo(int $a) must be compatible with Base::fo
       シグネチャ上は非互換になりません。
       しかし、こうしてしまうと
       <link linkend="functions.named-arguments">名前付き引数</link>
-      を使った時に実行時エラーになるので、おすすめできません。
+      を使った場合、実行時に <classname>Error</classname> が発生するので、おすすめできません。
      </para>
      <example>
       <title>子クラスでパラメータの名前を変更し、かつ名前付き引数を使うとエラーになる</title>


### PR DESCRIPTION
- 原文 "runtime `<classname>Error</classname>`" の classname が平文「実行時エラー」
- 「オーバーライド**(上書き)**」の括弧注記は原文になく、継承の文脈の訳語としても不適
