### PR TITLE
オブジェクトの反復処理の既訳誤りを修正（関係節の訳抜け）

### DIFF
--- a/language/oop5/iterations.xml
+++ b/language/oop5/iterations.xml
@@ -9,7 +9,7 @@
   PHP は、たとえば &foreach; 命令などによる反復処理を可能とするように、
   オブジェクトを定義する手段を提供します。
   デフォルトで、
-  全ての <link linkend="language.oop5.visibility">アクセス権限がある</link>
+  全ての <link linkend="language.oop5.visibility">アクセス権がある</link>
   プロパティは、反復処理に使用することができます。
  </simpara>
 
@@ -68,7 +68,7 @@ private => private var
 
  <para>
   出力からわかるように、
-  &foreach; による反復処理がすべての
+  &foreach; による反復処理は、アクセスできるすべての
   <link linkend="language.oop5.visibility">アクセス権がある</link>
   プロパティについて行われています。
  </para>


### PR DESCRIPTION
原文 "iterated through all of the visible properties **that could be accessed**" の関係節が訳抜け。
