### PR TITLE
PDOStatement::getAttribute の既訳誤りを修正（逆接による係りのねじれ）

### DIFF
--- a/reference/pdo/pdostatement/getattribute.xml
+++ b/reference/pdo/pdostatement/getattribute.xml
@@ -17,8 +17,8 @@
   </methodsynopsis>
 
   <para>
-   文の属性を取得します。現時点で共通の属性は存在しませんが、
-   ドライバ固有の属性のみ存在します。
+   文の属性を取得します。現時点で共通の属性は存在せず、
+   ドライバ固有の属性のみ存在します:
    <itemizedlist>
     <listitem><simpara><literal>PDO::ATTR_CURSOR_NAME</literal>
      (Firebird と ODBC 固有):


### PR DESCRIPTION
原文 "Currently, no generic attributes exist but only driver specific:" が「存在しません**が**、〜のみ存在します」と逆接で繋がれ、係りがねじれている。
