### PR TITLE
date_sun_info の既訳誤りを修正（in degrees の直訳と送り仮名の欠落）

### DIFF
--- a/reference/datetime/functions/date-sun-info.xml
+++ b/reference/datetime/functions/date-sun-info.xml
@@ -25,7 +25,7 @@
      <term><parameter>timestamp</parameter></term>
      <listitem>
       <para>
-       Unixタイムスタンプ。
+       Unix タイムスタンプ。
       </para>
      </listitem>
     </varlistentry>
@@ -33,7 +33,7 @@
      <term><parameter>latitude</parameter></term>
      <listitem>
       <para>
-       緯度を表す度数。
+       度単位の緯度。
       </para>
      </listitem>
     </varlistentry>
@@ -41,7 +41,7 @@
      <term><parameter>longitude</parameter></term>
      <listitem>
       <para>
-       経度を表す度数。
+       度単位の経度。
       </para>
      </listitem>
     </varlistentry>
@@ -85,7 +85,7 @@
      <term><literal>civil_twilight_begin</literal></term>
      <listitem>
       <simpara>
-       日の出側の市民薄明 (夜明) が始まる時刻 (天頂角 = 96°)。
+       日の出側の市民薄明 (夜明け) が始まる時刻 (天頂角 = 96°)。
        <literal>sunrise</literal> の時刻に終了します。
       </simpara>
      </listitem> 
@@ -94,7 +94,7 @@
      <term><literal>civil_twilight_end</literal></term>
      <listitem>
       <simpara>
-       日の入り側の市民薄明 (夕暮) が終わる時刻 (天頂角 =  96°)。
+       日の入り側の市民薄明 (夕暮れ) が終わる時刻 (天頂角 = 96°)。
        <literal>sunset</literal> の時刻に始まります。
       </simpara>
      </listitem> 
@@ -138,7 +138,7 @@
    </variablelist>
   </para>
   <para> 
-   配列の要素の値は、UNIX タイムスタンプ、
+   配列の要素の値は、Unix タイムスタンプ、
    太陽がそれぞれの天頂角より一日中下にある場合の &false;、
    一日中上にある場合の &true; のいずれかです。
   </para>
@@ -242,7 +242,7 @@ never: sunset
 
   <para>
    <example>
-    <title>白夜の例(Tromsø, Norway)</title>
+    <title>白夜の例 (Tromsø, Norway)</title>
     <programlisting role="php">
 <![CDATA[
 <?php


### PR DESCRIPTION
- 原文 "Latitude / Longitude in degrees." が「緯度／経度を表す**度数**」。「度数」は角度の単位として不自然
- 「(夜明)」「(夕暮)」の送り仮名欠落
