### PR TITLE
string 型の既訳誤りを修正（原文で削除済みの語句の残存）

### DIFF
--- a/language/types/string.xml
+++ b/language/types/string.xml
@@ -290,7 +290,7 @@ Parse error: Invalid body indentation level (expecting an indentation level of a
    <simpara>
     終端ID をインデントする場合、
     インデントに使う文字として、タブまたはスペースが使えます。
-    しかし、終端ID、および (終端ID までの)文字列の本体どちらであっても、
+    しかし、終端ID、および文字列の本体どちらであっても、
     インデントする際にタブとスペースを混ぜては
     <emphasis>いけません</emphasis>。
     混ぜた場合、


### PR DESCRIPTION
ヒアドキュメントのインデントの説明に、原文が php/doc-en@7132d8833a で削除した "(up to the closing identifier)" に対応する「(終端ID までの)」が残存。
