### PR TITLE
ssh2_sftp_realpath の訳語のゆれを修正（実パス／実際のパス）

### DIFF
--- a/reference/ssh2/functions/ssh2-sftp-realpath.xml
+++ b/reference/ssh2/functions/ssh2-sftp-realpath.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="function.ssh2-sftp-realpath" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ssh2_sftp_realpath</refname>
-  <refpurpose>指定されたパス文字列の実パスを解決する</refpurpose>
+  <refpurpose>指定されたパス文字列の実際のパスを解決する</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -16,7 +16,7 @@
   </methodsynopsis>
   <simpara>
    <parameter>filename</parameter>
-   をリモートファイルシステム上の有効な実パスに変換します。
+   をリモートファイルシステム上の有効な実際のパスに変換します。
   </simpara>
  </refsect1>
 


### PR DESCRIPTION
refpurpose と description が「実パス」、returnvalues が「実際のパス」とページ内で割れている。doc-ja で多数派の「実際のパス」に統一（`realpath` の Phar 注記の既訳とも一致）。
