### PR TITLE
language/control-structures を doc-en@e674990 に追従

### DIFF
--- a/language/control-structures/do-while.xml
+++ b/language/control-structures/do-while.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: takagi Status: ready -->
+<!-- EN-Revision: e674990649cd2b111b8dd1175a7a1befcc621635 Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 
 <sect1 xml:id="control-structures.do.while" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/language/control-structures/elseif.xml
+++ b/language/control-structures/elseif.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: takagi Status: ready -->
+<!-- EN-Revision: e674990649cd2b111b8dd1175a7a1befcc621635 Maintainer: takagi Status: ready -->
 
 <sect1 xml:id="control-structures.elseif" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>elseif/else if</title>

--- a/language/control-structures/for.xml
+++ b/language/control-structures/for.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: takagi Status: ready -->
+<!-- EN-Revision: e674990649cd2b111b8dd1175a7a1befcc621635 Maintainer: takagi Status: ready -->
 
 <sect1 xml:id="control-structures.for" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>for</title>

--- a/language/control-structures/foreach.xml
+++ b/language/control-structures/foreach.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: e674990649cd2b111b8dd1175a7a1befcc621635 Maintainer: mumumu Status: ready -->
 <sect1 xml:id="control-structures.foreach" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>foreach</title>
  <?phpdoc print-version-for="foreach"?>

--- a/language/control-structures/include-once.xml
+++ b/language/control-structures/include-once.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 89d80c92a1154a2903fff371f0d056bf2ac8ba27 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: e674990649cd2b111b8dd1175a7a1befcc621635 Maintainer: takagi Status: ready -->
 
 <sect1 xml:id="function.include-once" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>include_once</title>
  <?phpdoc print-version-for="include_once"?>
- <para>
+ <simpara>
   <literal>include_once</literal> 式は、スクリプトの実行時に指定
   したファイルを読み込み評価します。この動作は
   <function>include</function> 式と似ていますが、ファイルからのコー
   ドが既に読み込まれている場合は、再度読み込まれずに include_once は
   &true; を返すという点のみが異なります。その名が示す通り、ファイルは一度しか読み込まれません。
- </para>
+ </simpara>
  <para>
   <literal>include_once</literal> は、スクリプトの実行時に同じファイ
   ルが複数回読み込まれ、評価される可能性がある場合に、関数の再定義や

--- a/language/control-structures/include.xml
+++ b/language/control-structures/include.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: takagi Status: ready -->
+<!-- EN-Revision: e674990649cd2b111b8dd1175a7a1befcc621635 Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 
 <sect1 xml:id="function.include" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -162,7 +162,7 @@ include 'http://www.example.com/file.php?foo=1&bar=2';
  </para>
  <warning>
   <title>セキュリティの警告</title>
-  <para>
+  <simpara>
    リモートファイルはリモートサーバー上で実行されます（ファイルの拡張子や
    リモートサーバーが PHP の実行を許可しているかどうかに依存します）が、
    有効な PHP スクリプトである必要があります。なぜならそれはローカル
@@ -170,7 +170,7 @@ include 'http://www.example.com/file.php?foo=1&bar=2';
    ほしいだけならば、<function>readfile</function> を使用するほうがよい
    でしょう。そうでなければ、リモートスクリプトが有効な期待通りのコードを
    生成していることを確認するため、注意を払うことが必要になります。
-  </para>
+  </simpara>
  </warning>
  <para>
   <link linkend="features.remote-files">リモートファイル</link>,
@@ -258,7 +258,7 @@ echo $bar; // 1が出力されます
   ファイルが読み込めなかった場合、&false; が返され、
   <constant>E_WARNING</constant> が発生します。
  </simpara>
- <para>
+ <simpara>
   読み込まれるファイルで定義された関数がある場合、
   これらは、<function>return</function> の前後によらず
   メインファイルで使用できます。
@@ -267,7 +267,7 @@ echo $bar; // 1が出力されます
   ファイルが読み込み済みであるかどうかを調べ、
   読み込まれるファイルの内容を条件分岐で返すかわりに
   <function>include_once</function> を使用することを推奨します。
- </para>
+ </simpara>
  <simpara>
   PHP ファイルの内容を変数に "include する" もうひとつの方法は、
   <link linkend="ref.outcontrol">出力制御関数</link>

--- a/language/control-structures/match.xml
+++ b/language/control-structures/match.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: e674990649cd2b111b8dd1175a7a1befcc621635 Maintainer: mumumu Status: ready -->
 
 <sect1 xml:id="control-structures.match" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>match</title>
@@ -144,10 +144,10 @@ $result = match ($x) {
   </informalexample>
  </para>
 
- <para>
+ <simpara>
   <literal>match</literal> 式の分岐は、複数の式をカンマ区切りで含めても構いません。
   これは論理ORであり、複数の分岐の右辺を同じにする場合の短縮記法です。
- </para>
+ </simpara>
  <para>
   <informalexample>
    <programlisting role="php" annotations="non-interactive">
@@ -189,12 +189,12 @@ $expressionResult = match ($condition) {
   </note>
  </para>
 
- <para>
+ <simpara>
   <literal>match</literal> 式は、全ての場合を網羅していなければいけません。
   制約式がどの分岐でも処理できなかった場合、
   <classname>UnhandledMatchError</classname> がスローされます。
 
- </para>
+ </simpara>
 
  <example>
   <title>処理されない match 式の例</title>

--- a/language/control-structures/switch.xml
+++ b/language/control-structures/switch.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: takagi Status: ready -->
+<!-- EN-Revision: e674990649cd2b111b8dd1175a7a1befcc621635 Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 
 <sect1 xml:id="control-structures.switch" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>switch</title>
  <?phpdoc print-version-for="switch"?>
  <simpara>
-  <literal>switch</literal>文は、同じ式を用いてIF文を並べたのに似ています。
-  同じ変数を異なる値と比較し、値に応じて異なったコードを実行したいと
-  思うことがしばしばあるかと思います。
-  <literal>switch</literal>文は、まさにこのためにあるのです。
+  <literal>switch</literal>文は、同じ式を用いて<literal>if</literal>文を並べたのに似ています。
+  同じ変数や式を多くの異なる値と比較し、どの値に等しいかによって
+  異なったコードを実行する必要がある場合は、
+  <literal>switch</literal>文を使うほうが便利で読みやすいことが多いでしょう。
  </simpara>
  <note>
   <simpara>
@@ -23,11 +23,11 @@
   </simpara>
  </note>
  <note>
-  <para>
+  <simpara>
    switch/case が行うのは、
    <link linkend="types.comparisions-loose">緩やかな比較</link>
    であることに注意しましょう。
-  </para>
+  </simpara>
  </note>
 
  <para>


### PR DESCRIPTION
原文の文法の誤りを修正した php/doc-en@e674990 (Fix grammar in control structures [#5750](https://github.com/php/doc-en/pull/5750)) への追従。

原文側の変更の大半は冠詞・前置詞・句読点の修正で、訳文に影響しない。訳文に反映したのは次の 2 点。

- `switch.xml` — 冒頭の説明の結論が「switch 文はまさにこのためにある」から「switch 文のほうが便利で読みやすいことが多い」に書き換わった
- `include.xml` / `include-once.xml` / `match.xml` / `switch.xml` — `<para>` が `<simpara>` に変わった

## 翻訳内容

### language/control-structures（8件）

- do-while.xml
- elseif.xml
- for.xml
- foreach.xml
- include-once.xml
- include.xml
- match.xml
- switch.xml

すべて php/doc-en@e674990
