### PR TITLE
language/predefined を doc-en@029f19d に追従

### DIFF
--- a/language/predefined/arrayaccess.xml
+++ b/language/predefined/arrayaccess.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: satoruyoshida Status: ready -->
+<!-- EN-Revision: 029f19dbc090e4d249a23c0ab087d47059b37adc Maintainer: satoruyoshida Status: ready -->
 <!-- Credits: mumumu -->
 <reference xml:id="class.arrayaccess" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,9 +11,9 @@
 
   <section xml:id="arrayaccess.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     配列としてオブジェクトにアクセスするための機能のインターフェイスです。
-   </para>
+   </simpara>
   </section>
 
   <section xml:id="arrayaccess.synopsis">

--- a/language/predefined/iterator.xml
+++ b/language/predefined/iterator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: satoruyoshida Status: ready -->
+<!-- EN-Revision: 029f19dbc090e4d249a23c0ab087d47059b37adc Maintainer: satoruyoshida Status: ready -->
 <!-- Credits: mumumu -->
 <reference xml:id="class.iterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -37,10 +37,10 @@
   
   <section xml:id="iterator.iterators">
    <title>定義済みのイテレータ</title>
-   <para>
+   <simpara>
     PHP には多くのイテレータがあらかじめ用意されており、日々の作業に使えます。その一覧は
     <link linkend="spl.iterators">SPL イテレータ</link> を参照ください。
-   </para>
+   </simpara>
   </section>
 
   <section xml:id="iterator.examples">

--- a/language/predefined/serializable.xml
+++ b/language/predefined/serializable.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: satoruyoshida Status: ready -->
+<!-- EN-Revision: 029f19dbc090e4d249a23c0ab087d47059b37adc Maintainer: satoruyoshida Status: ready -->
 <reference xml:id="class.serializable" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>Serializable インターフェイス</title>
@@ -14,17 +14,17 @@
     独自のシリアライズ用のインターフェイスです。
    </para>
 
-   <para>
+   <simpara>
     このインターフェイスを実装したクラスは
     <link linkend="object.sleep">__sleep()</link> や
     <link linkend="object.wakeup">__wakeup()</link> をサポートしなくなります。
-    シリアライズが必要な場合には、自動的に serialize メソッドがコールされます。
-    このメソッドは __destruct() を実行しません。また、
+    シリアライズが必要な場合には、自動的に <methodname>serialize</methodname> メソッドがコールされます。
+    このメソッドは <methodname>__destruct</methodname> を実行しません。また、
     メソッド内で明示的に書かない限りは一切の副作用を及ぼしません。
-    アンシリアライズされるときにはそのクラスが自動的に検知し、__construct()
-    メソッドのかわりに適切な unserialize() メソッドがコンストラクタとしてコールされます。
-    標準のコンストラクタを実行させたい場合は、unserialize() メソッドの中でそれをコールします。
-   </para>
+    アンシリアライズされるときにはそのクラスが自動的に検知し、<methodname>__construct</methodname>
+    メソッドのかわりに適切な <methodname>unserialize</methodname> メソッドがコンストラクタとしてコールされます。
+    必要であれば、<methodname>unserialize</methodname> メソッドの中からコンストラクタをコールできます。
+   </simpara>
 
    <warning>
     <para>

--- a/language/predefined/stdclass.xml
+++ b/language/predefined/stdclass.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 77325b622f91355b118e8f3bc9ff940e8201f55d Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 029f19dbc090e4d249a23c0ab087d47059b37adc Maintainer: mumumu Status: ready -->
 
 <reference xml:id="class.stdclass" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -15,7 +15,7 @@
     動的なプロパティが使える、汎用的な空のクラスです。
    </para>
 
-   <para>
+   <simpara>
     このクラスのインスタンスは、
     <link linkend="language.oop5.basic.new">new</link>
     演算子や、
@@ -27,7 +27,7 @@
     <function>mysqli_fetch_object</function>,
     <methodname>PDOStatement::fetchObject</methodname>
     が挙げられます。
-   </para>
+   </simpara>
 
    <para>
     マジックメソッド
@@ -37,13 +37,13 @@
     よって、<code>#[\AllowDynamicProperties]</code> アトリビュートは必要ありません。
    </para>
 
-   <para>
+   <simpara>
     PHP には全てのクラスの親となる基底クラスの概念がないため、
     このクラスは基底クラスではありません。
     ただ、<classname>stdClass</classname>
     を継承させることで、
     動的なプロパティの機能を持ったカスタムクラスを結果的に作ることはできます。
-   </para>
+   </simpara>
   </section>
 
   <section xml:id="stdclass.synopsis">

--- a/language/predefined/traversable.xml
+++ b/language/predefined/traversable.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c62ef37e0d58067b393a6cf3a14aefed90bc0bff Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 029f19dbc090e4d249a23c0ab087d47059b37adc Maintainer: takagi Status: ready -->
 <reference xml:id="class.traversable" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title><interfacename>Traversable</interfacename> インターフェイス</title>

--- a/language/predefined/valueerror.xml
+++ b/language/predefined/valueerror.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 029f19dbc090e4d249a23c0ab087d47059b37adc Maintainer: mumumu Status: ready -->
 <reference xml:id="class.valueerror" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>ValueError</title>
  <titleabbrev>ValueError</titleabbrev>
@@ -9,12 +9,12 @@
 
   <section xml:id="valueerror.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     <classname>ValueError</classname> は、
     引数の型は正しいものの、値が正しくない場合にスローされます。
     たとえば、関数は正の整数を期待しているのに負の値を渡したり、
     空でない文字列/配列を期待しているのに空の値を渡したりした場合です。
-  </para>
+   </simpara>
   </section>
 
   <section xml:id="valueerror.synopsis">

--- a/language/predefined/weakmap.xml
+++ b/language/predefined/weakmap.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 029f19dbc090e4d249a23c0ab087d47059b37adc Maintainer: mumumu Status: ready -->
 <reference xml:id="class.weakmap" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>WeakMap クラス</title>
@@ -10,7 +10,7 @@
 
   <section xml:id="weakmap.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     <classname>WeakMap</classname> は、
     オブジェクトをキーとして受け入れるマップ(辞書)です。
     <classname>SplObjectStorage</classname> と似ていますが、
@@ -23,7 +23,7 @@
     <classname>WeakMap</classname> の用途は、
     長く生き残る必要がないオブジェクトから派生した、
     データのキャッシュを作ることです。
-   </para>
+   </simpara>
    <para>
     <classname>WeakMap</classname> は
     <interfacename>ArrayAccess</interfacename>,
@@ -65,7 +65,7 @@
    &reftitle.examples;
    <para>
     <example>
-     <title><classname>Weakmap</classname> の使い方の例</title>
+     <title><classname>WeakMap</classname> の使い方の例</title>
      <programlisting role="php">
       <![CDATA[
 <?php

--- a/language/predefined/weakreference.xml
+++ b/language/predefined/weakreference.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 029f19dbc090e4d249a23c0ab087d47059b37adc Maintainer: mumumu Status: ready -->
 <reference xml:id="class.weakreference" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>WeakReference クラス</title>
@@ -10,14 +10,14 @@
 
   <section xml:id="weakreference.intro">
    &reftitle.intro;
-   <para>
-    弱い参照により、オブジェクトが破棄されるのを妨げないオブジェクトへの参照を保持することが可能です。
+   <simpara>
+    弱い参照により、オブジェクトが破棄されるのを妨げることなく、そのオブジェクトへの参照を保持することが可能です。
     この機能は、キャッシュのようなデータ構造を実装するのに役立ちます。
     元のオブジェクトが破棄されている場合、<methodname>WeakReference::get</methodname>
     メソッドを呼び出すと &null; を返します。
     元のオブジェクトは、<link linkend="features.gc.refcounting-basics">refcount</link> が 0 になると破棄されます。
     弱い参照を作成しても、参照されているオブジェクトの <literal>refcount</literal> は増加しません。
-   </para>
+   </simpara>
    <simpara>
     <classname>WeakReference</classname> クラスはシリアライズできません。
    </simpara>


### PR DESCRIPTION
原文の文法の誤りを修正した php/doc-en@029f19d (Fix grammar in predefined [#5755](https://github.com/php/doc-en/pull/5755)) への追従。

原文側の変更の大半は冠詞・ハイフン・句読点の修正で、訳文に影響しない。訳文に反映したのは次の 4 点。

- `serializable.xml` — 末尾の説明が「標準のコンストラクタを実行させたい場合は unserialize メソッドの中でそれをコールする」から「必要であれば unserialize メソッドの中からコンストラクタをコールできる」に書き換わった。あわせて本文中のメソッド名に `<methodname>` が付いた
- `weakmap.xml` — 例の見出しのクラス名の誤記 `Weakmap` が `WeakMap` に修正された
- `weakreference.xml` — 弱い参照の説明が `a reference to an object which does not prevent the object from being destroyed` から `a reference to an object without preventing the object from being destroyed` に変わり、係り受けが明確になった
- 全 8 ファイル — `<para>` が `<simpara>` に変わった

## 翻訳内容

### language/predefined（8件）

- arrayaccess.xml
- iterator.xml
- serializable.xml
- stdclass.xml
- traversable.xml
- valueerror.xml
- weakmap.xml
- weakreference.xml

すべて php/doc-en@029f19d
