### PR TITLE
language-snippets.ent を doc-en@8648d1c に追従

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 6a2ad3ecf9b77855446019ed2d74aa6f734d35a8 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 8648d1cda141537b5dbd403a0bf0e6eb8c086e9d Maintainer: takagi Status: ready -->
 <!-- Credits: hirokawa,haruki,shimooka,mumumu,jdkfx -->
 
 <!--
@@ -17,10 +17,6 @@
 -->
 
 <!ENTITY installation.enabled.disable 'この拡張モジュールはデフォルトで有効になっています。無効にしたい場合は、次のオプションを指定してコンパイルします。'>
-
-<!-- Not used in EN anymore -->
-<!ENTITY changelog.randomseed '<row xmlns="http://docbook.org/ns/docbook"><entry>4.2.0</entry><entry>
-乱数生成器が自動的にシードを生成するようになりました。</entry></row>'>
 
 <!ENTITY changelog.class-constants-typed '<row xmlns="http://docbook.org/ns/docbook"><entry>8.4.0</entry><entry>
 クラス定数が型付けされるようになりました。</entry></row>'>
@@ -90,9 +86,6 @@
 
 <!ENTITY note.extractto-windows '<note xmlns="http://docbook.org/ns/docbook"><simpara>Windows の NTFS ファイルシステムには、ファイル名で使う場合にサポートしていない文字があります。具体的には、<literal>&lt;|&gt;*?":</literal> です。末尾にドットがあるファイル名もサポートしていません。いくつかの展開ツールと異なり、このメソッドはこれらの文字をアンダースコアで置き換えませんし、そのようなファイルを展開すると失敗します。</simpara></note>'>
 
-<!ENTITY note.func-callback '<note xmlns="http://docbook.org/ns/docbook"><simpara>関数名の代わりに、オブジェクトへの
-リファレンスを格納した配列とメソッド名を指定することもできます。</simpara></note>'>
-
 <!ENTITY note.func-callback-exceptions '<note xmlns="http://docbook.org/ns/docbook"><simpara>
 <function>call_user_func</function> や <function>call_user_func_array</function> で登録されたコールバックは、
 前のコールバックからスローされた例外がキャッチされていない場合はコールされません。</simpara></note>'>
@@ -108,10 +101,11 @@ PHP 8.0.0 以降における func_*() 関数ファミリは、名前付き引数
 </simpara></note>'>
 
 <!ENTITY note.line-endings '<note xmlns="http://docbook.org/ns/docbook"><simpara>
-マッキントッシュコンピュータ上で作成されたファイルを読み込む際に、
-<literal>PHP</literal> が行末を認識できないという問題が発生した場合、
-実行時の設定オプション<link linkend="ini.auto-detect-line-endings"
->auto_detect_line_endings</link> を有効にする必要が生じるかもしれません。</simpara>
+PHP 8.1.0 より前のバージョンでは、実行時の設定オプション
+<link linkend="ini.auto-detect-line-endings">auto_detect_line_endings</link>
+を有効にすることで、Macintosh 系のシステムで作成されたファイルの行末を
+PHP に正しく認識させることができました。このオプションは PHP 8.1.0 で非推奨になりました。
+必要な場合は、代わりに <literal>"\r"</literal> の改行を手動で処理してください。</simpara>
 </note>'>
 
 <!ENTITY note.no-remote '<note xmlns="http://docbook.org/ns/docbook"><simpara>この関数では、
@@ -239,11 +233,6 @@ URL を使用することができます。ファイル名の指定方法に関�
 <!ENTITY deprecated.function 'この関数は推奨されなくなりました。'>
 <!ENTITY removed.function 'この関数は削除されました。'>
 
-<!ENTITY warn.deprecated.feature-5-3-0.removed-5-4-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara>この機能は PHP 5.3.0 で
-<emphasis>非推奨</emphasis>となり、
-PHP 5.4.0 で<emphasis>削除</emphasis>されました。</simpara></warning>'>
-
 <!ENTITY warn.deprecated.feature-5-6-0 '<warning
 xmlns="http://docbook.org/ns/docbook"><simpara>この機能は PHP 5.6.0 で
 <emphasis>非推奨</emphasis>になります。この機能に頼らないことを強く推奨します。</simpara></warning>'>
@@ -261,10 +250,6 @@ xmlns="http://docbook.org/ns/docbook"><simpara>この関数は PHP 7.0.0 で
 xmlns="http://docbook.org/ns/docbook"><simpara>この関数は PHP 7.1.0 で
 <emphasis>非推奨</emphasis>となり、PHP 7.2.0 で<emphasis>削除</emphasis>
 されました。この関数に頼らないことを強く推奨します。</simpara></warning>'>
-
-<!ENTITY warn.deprecated.feature-7-2-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara>この機能は PHP 7.2.0 で
-<emphasis>非推奨</emphasis>になります。この機能に頼らないことを強く推奨します。</simpara></warning>'>
 
 <!ENTITY warn.deprecated.feature-7-2-0.removed-8-0-0 '<warning
 xmlns="http://docbook.org/ns/docbook"><simpara>この機能は PHP 7.2.0 で
@@ -284,10 +269,6 @@ xmlns="http://docbook.org/ns/docbook"><simpara>この機能は PHP 7.3.0 で
 xmlns="http://docbook.org/ns/docbook"><simpara>この関数は PHP 7.3.0 で
 <emphasis>非推奨</emphasis> になり、PHP 8.0.0 で <emphasis>削除</emphasis>
 されました。この関数に頼らないことを強く推奨します。</simpara></warning>'>
-
-<!ENTITY warn.deprecated.function-7-4-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara>この関数は PHP 7.4.0 で
-<emphasis>非推奨</emphasis>になります。この関数に頼らないことを強く推奨します。</simpara></warning>'>
 
 <!ENTITY warn.deprecated.function-7-4-0.removed-8-0-0 '<warning
 xmlns="http://docbook.org/ns/docbook"><simpara>この関数は PHP 7.4.0 で
@@ -340,10 +321,6 @@ xmlns="http://docbook.org/ns/docbook"><simpara>この関数は PHP 8.5.0 で
 <!ENTITY warn.deprecated.alias-5-4-0 '<warning xmlns="http://docbook.org/ns/docbook">
 <simpara>このエイリアスは PHP 5.4.0 で <emphasis>非推奨</emphasis> となりました。
 このエイリアスを使用しないことを強く推奨します。</simpara></warning>'>
-
-<!ENTITY warn.deprecated.alias-5-3-0.removed-7-0-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
-このエイリアスは PHP 5.3.0 で <emphasis>非推奨</emphasis> となり、
-PHP 7.0.0 で <emphasis>削除</emphasis> されました。</simpara></warning>'>
 
 <!ENTITY warn.removed.function-7-0-0 '<warning
 xmlns="http://docbook.org/ns/docbook"><simpara>この機能は
@@ -451,10 +428,6 @@ xmlns="http://docbook.org/ns/docbook"><simpara>この関数は PHP 8.1.0 で
 <!ENTITY example.outputs '<simpara xmlns="http://docbook.org/ns/docbook">上の例の出力は以下となります。</simpara>'>
 
 <!ENTITY example.outputs.5 '<simpara xmlns="http://docbook.org/ns/docbook">上の例の PHP 5 での出力は、このようになります。</simpara>'>
-
-<!ENTITY example.outputs.53 '<simpara xmlns="http://docbook.org/ns/docbook">上の例の PHP 5.3 での出力は、このようになります。</simpara>'>
-
-<!ENTITY example.outputs.54 '<simpara xmlns="http://docbook.org/ns/docbook">上の例の PHP 5.4 での出力は、このようになります。</simpara>'>
 
 <!ENTITY example.outputs.55 '<simpara xmlns="http://docbook.org/ns/docbook">上の例の PHP 5.5 での出力は、このようになります。</simpara>'>
 
@@ -1209,6 +1182,22 @@ $font = 'SomeFont';
  </entry>
 </row>'>
 
+<!ENTITY mbstring.errors.encoding-invalid '<para xmlns="http://docbook.org/ns/docbook">
+ PHP 8.0.0 以降では、<parameter>encoding</parameter> に不正なエンコーディングが渡された場合、
+ <exceptionname>ValueError</exceptionname> がスローされます。
+ これより前のバージョンでは、代わりに <constant>E_WARNING</constant> が発生していました。
+</para>'>
+
+<!ENTITY mbstring.changelog.encoding-invalid '<row xmlns="http://docbook.org/ns/docbook">
+ <entry>8.0.0</entry>
+ <entry>
+  <parameter>encoding</parameter> に不正なエンコーディングが渡された場合、
+  <exceptionname>ValueError</exceptionname> をスローするようになりました。
+  これより前のバージョンでは、<constant>E_WARNING</constant> が発生し、
+  &false; を返していました。
+ </entry>
+</row>'>
+
 <!-- mcrypt notes -->
 
 <!ENTITY mcrypt.parameter.cipher '<simpara xmlns="http://docbook.org/ns/docbook"><constant>MCRYPT_暗号名</constant> 定数のいずれか、
@@ -1428,10 +1417,6 @@ STREAM モードのいくつかのアルゴリズムの初期化の際に使用�
 有効なタイムゾーンが設定されていない場合に <constant>E_WARNING</constant>
 を発生させます。
 <function>date_default_timezone_set</function> も参照ください。</simpara>'>
-
-<!ENTITY date.timezone.errors.changelog '<row xmlns="http://docbook.org/ns/docbook"><entry>5.1.0</entry><entry><simpara>
-タイムゾーンがおかしい場合に <constant>E_STRICT</constant> や
-<constant>E_NOTICE</constant> が発生するようになりました。</simpara></entry></row>'>
 
 <!ENTITY date.timestamp.description '
 <varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>timestamp</parameter></term><listitem><simpara>
@@ -1941,8 +1926,6 @@ linkend="ini.open-basedir">open_basedir</link> の設定に依存します。</s
 
 <!-- Common pieces in partintro-sections -->
 <!ENTITY no.config '<simpara xmlns="http://docbook.org/ns/docbook">この拡張モジュールは、&php.ini; に設定ディレクティブを定義しません。</simpara>'>
-<!ENTITY no.resource '<simpara xmlns="http://docbook.org/ns/docbook">リソース型は定義されていません。</simpara>'>
-<!ENTITY no.constants '<simpara xmlns="http://docbook.org/ns/docbook">定数は定義されていません。</simpara>'>
 <!ENTITY no.requirement '<simpara xmlns="http://docbook.org/ns/docbook">外部ライブラリは必要ありません。</simpara>'>
 <!ENTITY no.install '<simpara xmlns="http://docbook.org/ns/docbook">PHP コアに含まれるため、
 追加のインストール無しで使用できます。</simpara>'>
@@ -2022,15 +2005,16 @@ PECL 拡張モジュールのインストール</link> という章にありま�
 この拡張モジュールは &link.pecl; レポジトリに移動
 されており、以下のバージョン以降 PHP にバンドルされなくなっています。 PHP '>
 
-<!ENTITY pecl.moving.to.pie '<note xmlns="http://docbook.org/ns/docbook">
+<!ENTITY pecl.moving.to.pie '<warning xmlns="http://docbook.org/ns/docbook">
  <simpara>
-  PHP Installer for Extensions (<acronym>PIE</acronym>) は、PECL を非推奨にする新しいツールです。
-  拡張モジュールをインストールする用途には、PIE を推奨します。
+  PECL は非推奨です。
+  PHP Installer for Extensions (<acronym>PIE</acronym>) は PECL を置き換えるものです。
+  拡張モジュールのインストールには PIE を使うことを推奨します。
   詳しい情報は、
   <link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://github.com/php/pie">https://github.com/php/pie</link>
   を参照ください。
  </simpara>
-</note>'>
+</warning>'>
 
 <!ENTITY warn.pecl.unmaintained '<warning xmlns="http://docbook.org/ns/docbook">
  <simpara>この拡張モジュールは、<emphasis>メンテナンスされていません</emphasis>。</simpara>
@@ -2093,6 +2077,44 @@ PECL 拡張モジュールのインストール</link> という章にありま�
   これより前のバージョンでは、&resource; を返していました。
  </entry>
 </row>'>
+
+<!-- SNMP entities -->
+
+<!ENTITY snmp.changelog.auth-protocol-sha2 '<row xmlns="http://docbook.org/ns/docbook">
+ <entry>8.1.0</entry>
+ <entry>
+  Net-SNMP ライブラリがサポートしている場合に、認証プロトコルが
+  <literal>"SHA256"</literal> と <literal>"SHA512"</literal>
+  を受け付けるようになりました。
+ </entry>
+</row>'>
+
+<!ENTITY snmp.changelog.privacy-protocol-aes '<row xmlns="http://docbook.org/ns/docbook">
+ <entry>8.6.0</entry>
+ <entry>
+  Net-SNMP ライブラリがサポートしている場合に、プライバシープロトコルが
+  <literal>"AES192"</literal>、<literal>"AES192C"</literal>、
+  <literal>"AES256"</literal>、<literal>"AES256C"</literal>
+  を受け付けるようになりました。
+ </entry>
+</row>'>
+
+<!ENTITY snmp.parameter.security-name '<simpara xmlns="http://docbook.org/ns/docbook">セキュリティ名。通常はユーザー名のようなものです。</simpara>'>
+
+<!ENTITY snmp.parameter.security-level '<simpara xmlns="http://docbook.org/ns/docbook">セキュリティレベル。<literal>"noAuthNoPriv"</literal>、
+<literal>"authNoPriv"</literal>、<literal>"authPriv"</literal> のいずれかです。</simpara>'>
+
+<!ENTITY snmp.parameter.auth-protocol '<simpara xmlns="http://docbook.org/ns/docbook">認証プロトコル。<literal>"MD5"</literal>、<literal>"SHA"</literal>、
+<literal>"SHA256"</literal>、<literal>"SHA512"</literal> のいずれかです。</simpara>'>
+
+<!ENTITY snmp.parameter.auth-passphrase '<simpara xmlns="http://docbook.org/ns/docbook">認証パスフレーズ。</simpara>'>
+
+<!ENTITY snmp.parameter.privacy-protocol '<simpara xmlns="http://docbook.org/ns/docbook">プライバシープロトコル。<literal>"DES"</literal>、
+あるいは <literal>"AES"</literal>（<literal>"AES128"</literal> としても受け付けられます）です。
+<literal>"AES192"</literal>、<literal>"AES192C"</literal>、<literal>"AES256"</literal>、<literal>"AES256C"</literal> は、
+Net-SNMP ライブラリがサポートしている場合に受け付けられます。</simpara>'>
+
+<!ENTITY snmp.parameter.privacy-passphrase '<simpara xmlns="http://docbook.org/ns/docbook">プライバシーパスフレーズ。</simpara>'>
 
 <!-- Common pieces for reference part END -->
 
@@ -2255,13 +2277,6 @@ xattr はデフォルトでユーザー名前空間で処理を行いますが�
 </warning>'>
 
 <!-- Snippets for the installation section -->
-<!ENTITY warn.apache2.compat '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
-Apache2 の MPM マルチスレッドモードを実運用環境で使用することは推奨されません。
-代わりに prefork MPM を使ってください。これは Apache 2.0 および 2.2
-におけるデフォルトの MPM です。prefork MPM を使う理由については、
-<link linkend="faq.installation.apache2">マルチスレッド版 MPM の Apache2</link>の
-FAQ エントリを参照してください。</simpara></warning>'>
-
 <!ENTITY note.apache.slashes '<note xmlns="http://docbook.org/ns/docbook"><simpara>Windows 上で
 Apache 設定ファイルにパスの値を追加する際、例えば
 <filename>c:\directory\file.ext</filename> に含まれるすべてのバックスラッシュは
@@ -4562,6 +4577,37 @@ xmlns="http://docbook.org/ns/docbook"><simpara>この関数は、PECL uopz 5.0.0
     <link linkend="context.ssl.verify-peer-name"><parameter>verify_peer_name</parameter></link>
     を &false; にすれば無効化できます。
    </simpara>
+'>
+
+<!-- Sodium -->
+<!ENTITY sodium.changelog.aes256gcm-aarch64 '
+  <informaltable xmlns="http://docbook.org/ns/docbook">
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       この関数は、aarch64 でも定義されるようになりました。
+       これより前のバージョンでは、x86 と x86_64 でのみ定義されていました。
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+'>
+
+<!-- readline -->
+<!ENTITY readline.system-callback-support '
+  <simpara xmlns="http://docbook.org/ns/docbook">
+   この関数は、PHP のビルドに使われた readline ライブラリがこの機能をサポートしている
+   場合にのみ使用できます。Windows では使用できません。
+  </simpara>
 '>
 
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
## 翻訳内容

### 新規エンティティの追加（12 件）

複数ページに手書きでコピーされていた記述が、原文で共有スニペットに切り出されました。

- SNMPv3 のセキュリティパラメータ 6 件と changelog 2 件（`snmp.parameter.*` / `snmp.changelog.*`）
- mbstring に不正なエンコーディングを渡した場合の `ValueError` 2 件（`mbstring.errors.encoding-invalid` / `mbstring.changelog.encoding-invalid`）
- sodium の AES-256-GCM が PHP 8.4.0 で aarch64 でも定義されるようになった旨の changelog（`sodium.changelog.aes256gcm-aarch64`）
- readline の関数がビルド時の readline ライブラリ次第で使えない旨の注記（`readline.system-callback-support`）

訳語は `ja/reference/snmp/` や `ja/reference/mbstring/` の既訳に合わせています。

### 既存エンティティの書き換え（2 件）

- `note.line-endings` — `auto_detect_line_endings` が PHP 8.1.0 で非推奨になったため、原文が「有効にすると解決するかもしれない」から「8.1.0 より前は有効にできた。必要なら `"\r"` を手動で処理する」に書き換えられました
- `pecl.moving.to.pie` — 原文が `<note>` から `<warning>` になり、「PECL を非推奨にする新しいツール」から「PECL は非推奨。PIE が置き換える」に変わりました

### 削除（12 件）

原文で使われなくなったエンティティです。ja ツリーからの参照はありません。

`changelog.randomseed` / `date.timezone.errors.changelog` / `example.outputs.53` / `example.outputs.54` / `no.constants` / `no.resource` / `note.func-callback` / `warn.apache2.compat` / `warn.deprecated.alias-5-3-0.removed-7-0-0` / `warn.deprecated.feature-5-3-0.removed-5-4-0` / `warn.deprecated.feature-7-2-0` / `warn.deprecated.function-7-4-0`

### 追従した原文のコミット

1. php/doc-en@7b30944775
2. php/doc-en@de78d65ef7
3. php/doc-en@fd1f9d8512
4. php/doc-en@4c85baa92d
5. php/doc-en@9e5166dc6a
6. php/doc-en@8465ca6ec4
7. php/doc-en@1ab1069cdd
8. php/doc-en@8648d1cda1
