### PR TITLE
CI: use the shared check-structure.php from doc-base

### DIFF
--- a/.github/workflows/check-xml.yml
+++ b/.github/workflows/check-xml.yml
@@ -1,0 +1,58 @@
+# https://docs.github.com/en/actions
+# Checks that the block skeleton of the .xml files changed in a PR stays a mirror
+# of doc-en. Each file is compared to doc-en at the revision it declares to mirror
+# (EN-Revision), so a lagging file does not raise a false positive. The script
+# emits its own ::error annotations.
+#
+# The script is the one from doc-base, shared by all translations, and no longer
+# a copy local to this repository.
+
+name: "Structure"
+
+on:
+  pull_request:
+    branches: ["master"]
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  structure:
+    name: "Check XML"
+    runs-on: ubuntu-24.04
+    steps:
+      # ja/, en/ and doc-base/ side by side: this is the layout expected by
+      # the doc-base scripts, the same as the one the build workflow uses. The
+      # explicit ref takes the real head of the pull request, not the merge commit
+      # actions/checkout builds by default: that one has master as its second
+      # parent, so the diff below would also list every file landed on master
+      # since the last push of the PR.
+
+      - name: "Checkout translation"
+        uses: actions/checkout@v4
+        with:
+          path: ja
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: "Checkout php/doc-en"
+        uses: actions/checkout@v4
+        with:
+          path: en
+          repository: php/doc-en
+          fetch-depth: 0
+
+      - name: "Checkout php/doc-base"
+        uses: actions/checkout@v4
+        with:
+          path: doc-base
+          repository: php/doc-base
+
+      - name: "Check structure"
+        run: |
+          BASE="${{ github.event.pull_request.base.sha }}"
+          git -C ja fetch --no-tags --depth=1 origin "$BASE"
+          git -C ja diff --name-only "$BASE"...HEAD -- '*.xml' \
+            | php8.3 doc-base/scripts/translation/check-structure.php \
+                --lang=ja --github

--- a/.github/workflows/check-xml.yml
+++ b/.github/workflows/check-xml.yml
@@ -30,21 +30,21 @@ jobs:
       # since the last push of the PR.
 
       - name: "Checkout translation"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           path: ja
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: "Checkout php/doc-en"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           path: en
           repository: php/doc-en
           fetch-depth: 0
 
       - name: "Checkout php/doc-base"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           path: doc-base
           repository: php/doc-base


### PR DESCRIPTION
Replaces the local copy of `check-structure.php` with the shared one from php/doc-base (merged in php/doc-base#342), so that every translation runs the same version.

The workflow now checks out the translation, `en` and `doc-base` side by side, the layout the doc-base scripts expect and the one the build workflow already uses.