### PR TITLE
PHP 8.5 の言語コアドキュメントに追従

### DIFF
--- a/appendices/ini.core.xml
+++ b/appendices/ini.core.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: a52e3d27cca786940272d0ae8efc21b5d6739070 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: f011a5989304239063769239761b5c39c68af12f Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa,shimooka,mumumu -->
 
  <section xml:id="ini.core" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -445,6 +445,12 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
         <entry><constant>INI_ALL</constant></entry>
         <entry></entry>
        </row>
+       <row>
+        <entry><link linkend="ini.max-memory-limit">max_memory_limit</link></entry>
+        <entry>"-1"</entry>
+        <entry><constant>INI_SYSTEM</constant></entry>
+        <entry>PHP 8.5.0 以降で利用可能。</entry>
+       </row>
       </tbody>
      </tgroup>
     </table>
@@ -466,6 +472,28 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
         もし、使用可能メモリに制限を設けたくない場合は、
         ここに <literal>-1</literal> を指定してください。
        </para>
+
+       &ini.shorthandbytes;
+
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="ini.max-memory-limit">
+      <term>
+       <parameter>max_memory_limit</parameter>
+       <type>int</type>
+      </term>
+      <listitem>
+       <simpara>
+        PHP 8.5.0 以降で利用可能です。
+        このディレクティブは起動時にのみ設定できます。
+        <link linkend="ini.memory-limit">memory_limit</link> に対して
+        起動時または実行時に (たとえば <function>ini_set</function> 経由で)
+        設定できる値の上限を制御します。
+        <parameter>max_memory_limit</parameter> を超える値を
+        <link linkend="ini.memory-limit">memory_limit</link> に設定すると、
+        警告が発生し、値はこの上限に切り詰められます。
+        上限を設けない場合は、<literal>-1</literal> (デフォルト) を指定してください。
+       </simpara>
 
        &ini.shorthandbytes;
 
@@ -1333,6 +1361,15 @@ include_path = ".:${USER}/pear/php"
          <literal>0</literal> に設定され、結果として realpath キャッシュは <emphasis>disable</emphasis> にされます。
         </para>
        </note>
+       <warning>
+        <simpara>
+         <option>open_basedir</option> は、Unix ドメインソケットへのアクセスを制限しません。
+         <function>stream_socket_client</function> や <function>fsockopen</function>
+         といった PHP のソケット関数は、<option>open_basedir</option> の設定にかかわらず、
+         Unix ソケットのパス (たとえば <filename>unix:///var/run/docker.sock</filename>)
+         に接続できます。
+        </simpara>
+       </warning>
        <caution>
         <para>
          <literal>open_basedir</literal> は、追加のセキュリティ機構でしかありません。

--- a/features/commandline.xml
+++ b/features/commandline.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 07b2f1dcff1d8beb846f5671e5f4bf2ab8d33ebf Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 14f641dc7a2eb3ab1f97062f0a74f7cdb59ae708 Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa,shimooka,mumumu -->
 <chapter xml:id="features.commandline" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>PHP をコマンドラインから使用する</title>
@@ -1689,6 +1689,16 @@ php >
     $_SERVER['PATH_INFO'] が URI の末尾にセットされます。
     見つからなかった場合はレスポンスコード 404 を返します。
   </para>
+
+  <note>
+   <simpara>
+    PHP 8.4.0 以降では、リクエストされたパスがファイルを指しているように見える
+    (最後のパスコンポーネントにピリオドが含まれる) 場合でも、
+    そのファイルが見つからなければ、上記のようにインデックスファイルを探します。
+    これより前のバージョンでは、このようなリクエストに対しては探索をスキップし、
+    すぐにレスポンスコード 404 を返していました。
+   </simpara>
+  </note>
 
   <para>
     ウェブサーバーの開始時にコマンドラインで PHP ファイルを指定すると、

--- a/language/constants.xml
+++ b/language/constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 6e885e52412ad979aa5fbb620bb84e886fc0ebe8 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 4c352e683436649edba35a3272210d8ca4cae611 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi,mumumu -->
 
  <chapter xml:id="language.constants" xmlns="http://docbook.org/ns/docbook" annotations="interactive">
@@ -21,6 +21,12 @@
     <function>define</function> 関数を使って定義された定数は、
     大文字小文字を区別しない場合がありました。
    </para>
+  </note>
+
+  <note>
+   <simpara>
+    PHP 8.5.0 以降、すでに定義されている定数を再宣言することは非推奨です。
+   </simpara>
   </note>
 
   <para>
@@ -223,6 +229,32 @@ echo ANIMALS_DEF[1] . "\n"; // 出力は "cat"
      <literal>try</literal>/<literal>catch</literal> ブロックの内部では宣言できないということです。
     </para>
    </note>
+
+   <sect2 role="changelog">
+    &reftitle.changelog;
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>8.5.0</entry>
+        <entry>
+         定数式に、型キャスト (例: <code>(int)</code> や
+         <code>(string)</code>) のサポートが追加されました。
+         また、<link linkend="functions.anonymous">クロージャ</link>
+         と <link linkend="functions.first_class_callable_syntax">第一級callable</link>
+         のサポートも追加されました。
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </sect2>
 
    <sect2 role="seealso">
     &reftitle.seealso;

--- a/language/errors/basics.xml
+++ b/language/errors/basics.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: de9c65c91ff1710d8b2d2ec955caea0162679305 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4c352e683436649edba35a3272210d8ca4cae611 Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 
 <sect1 xml:id="language.errors.basics" xmlns="http://docbook.org/ns/docbook">
@@ -80,6 +80,30 @@
    内部的にはログに書き出すかわりにメールを送るなどとすることもできます。
   </para>
  </sect2>
+
+ <sect2 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       (Maximum execution time exceeded のような) 致命的なエラーのメッセージに、
+       スタックトレースが含まれるようになりました。
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </sect2>
+
 </sect1>
  
 <!-- Keep this comment at the end of the file

--- a/language/functions.xml
+++ b/language/functions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c19f29d4fcf92c1a2d2c46d68adab31e98fcbe78 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4c352e683436649edba35a3272210d8ca4cae611 Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa,mumumu,jdkfx -->
  <chapter xml:id="language.functions" xmlns="http://docbook.org/ns/docbook" annotations="interactive">
   <title>関数</title>
@@ -1445,6 +1445,13 @@ Stack trace:
        </thead>
        <tbody>
         <row>
+         <entry>8.5.0</entry>
+         <entry>
+          定数式 (例: プロパティのデフォルト値、アトリビュートの引数、定数) で
+          クロージャを使えるようになりました。
+         </entry>
+        </row>
+        <row>
          <entry>8.3.0</entry>
          <entry>
           <link linkend="language.oop5.magic">マジックメソッド</link>
@@ -1765,6 +1772,29 @@ $obj?->prop->method(...);
      </informalexample>
     </para>
    </note>
+
+   <sect2 role="changelog">
+    &reftitle.changelog;
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>8.5.0</entry>
+        <entry>
+         定数式 (例: プロパティのデフォルト値、アトリビュートの引数、定数) で
+         第一級callableを使えるようになりました。
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </sect2>
   </sect1>
 
  </chapter>

--- a/language/oop5/changelog.xml
+++ b/language/oop5/changelog.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4fc9f9ea7ba36a383613ede343a0820f5cc46aa2 Maintainer: takagi Status: ready -->
 <!-- CREDITS: mumumu -->
 
 <sect1 xml:id="language.oop5.changelog" xmlns="http://docbook.org/ns/docbook">
@@ -19,6 +19,22 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       変更: <type>static</type> を返すメソッドを <modifier>final</modifier>
+       クラスでオーバーライドする際に、戻り値の型として <type>self</type>
+       またはそのクラス自身の型を宣言できるようになりました。
+       これ以上継承できないクラスでは、これらは <type>static</type> と同等であるためです。
+      </entry>
+     </row>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       変更: <link linkend="language.oop5.traits">トレイト</link> が、
+       親クラスより先にクラスにバインドされるようになりました。
+      </entry>
+     </row>
      <row>
       <entry>8.4.0</entry>
       <entry>

--- a/language/oop5/cloning.xml
+++ b/language/oop5/cloning.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 09c650422aec6f59dca08d1c65eaa633d391a525 Maintainer: hirokawa Status: ready -->
 <!-- Credits: mumumu -->
 
 <sect1 xml:id="language.oop5.cloning" xmlns="http://docbook.org/ns/docbook">
@@ -159,6 +159,59 @@ echo (clone $dateTime)->format('Y');
 ]]>
    </screen>
   </example>
+
+  <sect2 xml:id="language.oop5.cloning.with-properties">
+   <title>クローン作成時のプロパティの上書き</title>
+
+   <simpara>
+    PHP 8.5.0 以降、<literal>clone</literal> は関数としても使えます。
+    2 番目のパラメータ <parameter>withProperties</parameter> には、
+    プロパティ名をキー、コピーが受け取る値を値とする配列を渡します。
+    上書きされるのはそこで指定したプロパティだけで、
+    それ以外のプロパティはコピーされたときの値をそのまま保持します。
+   </simpara>
+
+   <simpara>
+    上書きは <link linkend="object.clone">__clone()</link> が実行された後に適用されます。
+    このとき、全てのプロパティのアクセス権が尊重されます。
+    <link linkend="language.oop5.properties.readonly-properties">readonly</link>
+    プロパティは、元のオブジェクトで既に値が設定されていても、
+    コピーでは更新できます。
+    このため clone 関数は、変更を加えたコピーを返すメソッドを実装するのに適しています。
+   </simpara>
+
+   <example>
+    <title>プロパティを上書きしてオブジェクトのクローンを作成する</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+class Point {
+    public function __construct(
+        public readonly int $x,
+        public readonly int $y,
+    ) {}
+
+    public function withX(int $x): static
+    {
+        return clone($this, ['x' => $x]);
+    }
+}
+
+$p = new Point(1, 2);
+$q = $p->withX(10);
+
+echo $q->x, ' ', $q->y;
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+10 2
+]]>
+    </screen>
+   </example>
+  </sect2>
 
  </sect1>
  

--- a/language/oop5/magic.xml
+++ b/language/oop5/magic.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: cf7dcffba0ab8ce14dbfd6019f2861f5a6843ed5 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: shimooka,mumumu -->
 
 <sect1 xml:id="language.oop5.magic" xmlns="http://docbook.org/ns/docbook">
@@ -585,6 +585,10 @@ object(A)#2 (2) {
     もしオブジェクトにこのメソッドが定義されていなければ、
     すべての public, protected, private プロパティを表示します。
    </para>
+   <simpara>
+    PHP 8.5.0 以降、<link linkend="object.debuginfo">__debugInfo()</link> から &null; を返すことは非推奨です。
+    代わりに空の配列を返してください。
+   </simpara>
    <example>
     <title><link linkend="object.debuginfo">__debugInfo()</link> の使用法</title>
     <programlisting role="php">

--- a/language/oop5/traits.xml
+++ b/language/oop5/traits.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4fc9f9ea7ba36a383613ede343a0820f5cc46aa2 Maintainer: takagi Status: ready -->
 <!-- CREDITS: mumumu -->
 
  <sect1 xml:id="language.oop5.traits" xmlns="http://docbook.org/ns/docbook">
@@ -72,6 +72,21 @@ Hello World!
     優先順位は現在のクラスのメンバーが最高で、その次がトレイトのメソッド、
     そしてその次にくるのが継承したメソッドとなります。
    </para>
+   <note>
+    <simpara>
+     PHP 8.5.0 以降では、トレイトは親クラスよりも先にクラスにバインドされます。
+     これより前のバージョンでは、親クラスよりも後にバインドされていました。
+     この変更は、トレイトのコピー＆ペーストのセマンティクスをより正確に反映したものです。
+     特に、トレイトと親クラスの両方が同じ名前のプロパティや定数を宣言している場合、
+     親クラスから継承した定義よりも、トレイトの定義が優先されるようになりました。
+     これより前のバージョンでは、互換性のない組み合わせとみなされ、
+     致命的なエラーが発生していました。
+     メソッドの解決は、この変更の影響を受けません。
+     詳細は
+     <link linkend="migration85.incompatible.core.trait-binding">移行ガイド</link>
+     を参照ください。
+    </simpara>
+   </note>
    <example xml:id="language.oop5.traits.precedence.examples.ex1">
     <title>優先順位の例</title>
     <para>

--- a/language/oop5/variance.xml
+++ b/language/oop5/variance.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4fc9f9ea7ba36a383613ede343a0820f5cc46aa2 Maintainer: mumumu Status: ready -->
 <sect1 xml:id="language.oop5.variance" xmlns="http://docbook.org/ns/docbook">
 
  <title>共変性と反変性</title>
@@ -140,6 +140,18 @@ Mavrick barks
 ]]>
    </screen>
   </informalexample>
+  <note>
+   <simpara>
+    PHP 8.5.0 以降、親クラスのメソッドが戻り値の型として <type>static</type>
+    を宣言している場合、<modifier>final</modifier>
+    クラスでそれをオーバーライドするメソッドは、代わりに戻り値の型として
+    <type>self</type> またはそのクラス自身の型を宣言できます。
+    これ以上継承できないクラスでは、これらは <type>static</type> と同等であるためです。
+    詳細は
+    <link linkend="migration85.incompatible.core.substitute-final-subclasses">移行ガイド</link>
+    を参照ください。
+   </simpara>
+  </note>
  </sect2>
 
  <sect2 xml:id="language.oop5.variance.contravariance">

--- a/language/operators/comparison.xml
+++ b/language/operators/comparison.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 62e61e543c2d2b8519952efa246ed708026cfb16 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4fc9f9ea7ba36a383613ede343a0820f5cc46aa2 Maintainer: mumumu Status: ready -->
 <sect1 xml:id="language.operators.comparison">
  <title>比較演算子</title>
  <titleabbrev>比較演算子</titleabbrev>
@@ -353,6 +353,24 @@ function standard_array_compare($op1, $op2)
    比較できない値同士を比較した場合の結果は未定義であり、
    その結果に依存すべきではありません。
   </simpara>
+  <note>
+   <simpara>
+    PHP 8.5.0 以降、比較できない <type>object</type>
+    (列挙型、<classname>CurlHandle</classname>、その他の内部クラスなど) を
+    <literal>==</literal> または <literal>!=</literal> で <type>bool</type>
+    と緩やかに比較した結果は、そのオブジェクトの代わりに <type>bool</type>
+    にキャストした値 (つまり <literal>(bool) $object</literal>)
+    を比較した結果と常に同じになります。
+    このようなオブジェクトは常に &true; にキャストされるため、
+    &true; と等しく、&false; とは等しくありません。
+    PHP 8.5.0 より前のバージョンでは、この振る舞いは boolean リテラル
+    (<literal>$object == true</literal>) と比較した場合にのみ当てはまりました。
+    変数に格納された boolean 値と比較した場合は、
+    等しいかどうかの判定結果が常に &false; でした。
+    詳細は
+    <link linkend="migration85.incompatible.core.loosely-comparing-object">移行ガイド</link>を参照ください。
+   </simpara>
+  </note>
  </sect2>
 
  <sect2 role="seealso">

--- a/language/predefined/attributes/allowdynamicproperties.xml
+++ b/language/predefined/attributes/allowdynamicproperties.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: mumumu Status: ready -->
 <reference xml:id="class.allowdynamicproperties" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>AllowDynamicProperties アトリビュート</title>
  <titleabbrev>AllowDynamicProperties</titleabbrev>
@@ -30,7 +30,7 @@
 
    <classsynopsis class="class">
     <ooclass>
-     <modifier role="attribute">#[\Attribute]</modifier>
+     <modifier role="attribute">#[\Attribute(\Attribute::TARGET_CLASS)]</modifier>
      <modifier>final</modifier>
      <classname>AllowDynamicProperties</classname>
     </ooclass>

--- a/language/predefined/attributes/attribute.xml
+++ b/language/predefined/attributes/attribute.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: mumumu Status: ready -->
 <reference xml:id="class.attribute" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>Attribute アトリビュート</title>
  <titleabbrev>Attribute</titleabbrev>
@@ -27,7 +27,7 @@
 
    <classsynopsis class="class">
     <ooclass>
-     <modifier role="attribute">#[\Attribute]</modifier>
+     <modifier role="attribute">#[\Attribute(\Attribute::TARGET_CLASS)]</modifier>
      <modifier>final</modifier>
      <classname>Attribute</classname>
     </ooclass>
@@ -186,6 +186,12 @@
        <entry>8.5.0</entry>
        <entry>
         <constant>Attribute::TARGET_CONSTANT</constant> が追加されました。
+        抽象クラス、列挙型、インターフェイス、トレイトに
+        <code>#[\Attribute]</code> を適用すると、
+        コンパイル時にエラーが発生するようになりました。
+        これより前のバージョンでは、このエラーは
+        <methodname>ReflectionAttribute::newInstance</methodname>
+        がコールされたタイミングで、実行時にのみ報告されていました。
        </entry>
       </row>
      </tbody>

--- a/language/predefined/attributes/delayedtargetvalidation.xml
+++ b/language/predefined/attributes/delayedtargetvalidation.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: efda0bb311990257715bd3a41ab2b04769ce2e4e Maintainer: KentarouTakeda Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: KentarouTakeda Status: ready -->
 <reference xml:id="class.delayedtargetvalidation" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>DelayedTargetValidation アトリビュート</title>
  <titleabbrev>DelayedTargetValidation</titleabbrev>
@@ -31,7 +31,7 @@
 
    <classsynopsis class="class">
     <ooclass>
-     <modifier role="attribute">#[\Attribute]</modifier>
+     <modifier role="attribute">#[\Attribute(\Attribute::TARGET_ALL)]</modifier>
      <modifier>final</modifier>
      <classname>DelayedTargetValidation</classname>
     </ooclass>

--- a/language/predefined/attributes/deprecated.xml
+++ b/language/predefined/attributes/deprecated.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: KentarouTakeda Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: KentarouTakeda Status: ready -->
 <!-- CREDITS: KentarouTakeda -->
 <reference xml:id="class.deprecated" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>Deprecated アトリビュート</title>
@@ -14,6 +14,10 @@
     このアトリビュートは、機能を非推奨としてマークします。
     マークされた機能を使用すると、<constant>E_USER_DEPRECATED</constant> エラーが発生します。
    </simpara>
+   <simpara>
+    PHP 8.5.0 以降、このアトリビュートはトレイトや、
+    クラスの外部で宣言されたコンパイル時定数にも適用できます。
+   </simpara>
   </section>
 
   <section xml:id="deprecated.synopsis">
@@ -21,7 +25,7 @@
 
    <classsynopsis class="class">
     <ooclass>
-     <modifier role="attribute">#[\Attribute]</modifier>
+     <modifier role="attribute">#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_FUNCTION | \Attribute::TARGET_CLASS_CONSTANT | \Attribute::TARGET_CONSTANT | \Attribute::TARGET_CLASS)]</modifier>
      <modifier>final</modifier>
      <classname>Deprecated</classname>
     </ooclass>
@@ -101,6 +105,31 @@ This is unsafe
 ]]>
     </screen>
    </informalexample>
+  </section>
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.5.0</entry>
+       <entry>
+        <classname>Deprecated</classname> は、トレイトや、
+        クラスの外部で宣言されたコンパイル時定数にも適用できるようになりました。
+        後者は、新しい適用対象 <constant>Attribute::TARGET_CONSTANT</constant>
+        によって可能になりました。
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
   <section xml:id="deprecated.seealso">

--- a/language/predefined/attributes/nodiscard.xml
+++ b/language/predefined/attributes/nodiscard.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: KentarouTakeda Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: KentarouTakeda Status: ready -->
 <reference xml:id="class.nodiscard" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>NoDiscard アトリビュート</title>
  <titleabbrev>NoDiscard</titleabbrev>
@@ -48,7 +48,7 @@
 
    <classsynopsis class="class">
     <ooclass>
-     <modifier role="attribute">#[\Attribute]</modifier>
+     <modifier role="attribute">#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_FUNCTION)]</modifier>
      <modifier>final</modifier>
      <classname>NoDiscard</classname>
     </ooclass>

--- a/language/predefined/attributes/override.xml
+++ b/language/predefined/attributes/override.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: mumumu Status: ready -->
 <reference xml:id="class.override" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>Override アトリビュート</title>
  <titleabbrev>Override</titleabbrev>
@@ -31,7 +31,7 @@
 
    <classsynopsis class="class">
     <ooclass>
-     <modifier role="attribute">#[\Attribute]</modifier>
+     <modifier role="attribute">#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]</modifier>
      <modifier>final</modifier>
      <classname>Override</classname>
     </ooclass>

--- a/language/predefined/attributes/returntypewillchange.xml
+++ b/language/predefined/attributes/returntypewillchange.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 52e88759354dd18104d8c067780be9f582f20136 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: mumumu Status: ready -->
 <reference xml:id="class.returntypewillchange" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>ReturnTypeWillChange アトリビュート</title>
  <titleabbrev>ReturnTypeWillChange</titleabbrev>
@@ -58,7 +58,7 @@
 
    <classsynopsis class="class">
     <ooclass>
-     <modifier role="attribute">#[\Attribute]</modifier>
+     <modifier role="attribute">#[\Attribute(\Attribute::TARGET_METHOD)]</modifier>
      <modifier>final</modifier>
      <classname>ReturnTypeWillChange</classname>
     </ooclass>

--- a/language/predefined/attributes/sensitiveparameter.xml
+++ b/language/predefined/attributes/sensitiveparameter.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: mumumu Status: ready -->
 <reference xml:id="class.sensitiveparameter" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>SensitiveParameter アトリビュート</title>
  <titleabbrev>SensitiveParameter</titleabbrev>
@@ -21,7 +21,7 @@
 
    <classsynopsis class="class">
     <ooclass>
-     <modifier role="attribute">#[\Attribute]</modifier>
+     <modifier role="attribute">#[\Attribute(\Attribute::TARGET_PARAMETER)]</modifier>
      <modifier>final</modifier>
      <classname>SensitiveParameter</classname>
     </ooclass>

--- a/language/predefined/closure/bind.xml
+++ b/language/predefined/closure/bind.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9c74079f12d67cabb52c124d761f48275417d7eb Maintainer: takagi Status: ready -->
+<!-- EN-Revision: cf7dcffba0ab8ce14dbfd6019f2861f5a6843ed5 Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 
 <refentry xml:id="closure.bind" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -32,30 +32,30 @@
    <varlistentry>
     <term><parameter>closure</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       バインドする無名関数。
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>newThis</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       指定した無名関数をバインドするオブジェクト。クロージャのバインドを解除するには
       &null; を指定します。
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>newScope</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       クロージャを関連づけるクラススコープ、あるいは 'static' で現在のスコープを維持します。
       オブジェクトを渡した場合は、そのオブジェクトの型をその代わりに使います。
       これは、バインドしたオブジェクトの protected メソッドや private
       メソッドのアクセス権を決めます。
       このパラメータに、内部クラスのオブジェクトを渡すことはできません。
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -63,10 +63,34 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    新しい <classname>Closure</classname> オブジェクトを返します。
    失敗した場合は &null; を返します。
-  </para>
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       インスタンスを static なクロージャにバインドすることや、
+       互換性のないクラス階層間でメソッドをバインドすることは、非推奨になりました
+       (これらの場合は、既に <constant>E_WARNING</constant> が発生していました)。
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/language/predefined/closure/bindto.xml
+++ b/language/predefined/closure/bindto.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c62ef37e0d58067b393a6cf3a14aefed90bc0bff Maintainer: takagi Status: ready -->
+<!-- EN-Revision: cf7dcffba0ab8ce14dbfd6019f2861f5a6843ed5 Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 
 <refentry xml:id="closure.bindto" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -88,6 +88,30 @@
    新しい <classname>Closure</classname> オブジェクトを返します。
    失敗した場合に &null; を返します。
   </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       インスタンスを static なクロージャにバインドすることや、
+       互換性のないクラス階層間でメソッドをバインドすることは、非推奨になりました
+       (これらの場合は、既に <constant>E_WARNING</constant> が発生していました)。
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/language/types/callable.xml
+++ b/language/types/callable.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 4c352e683436649edba35a3272210d8ca4cae611 Maintainer: mumumu Status: ready -->
 
 <sect1 xml:id="language.types.callable">
  <title>コールバック / Callable</title>
@@ -171,6 +171,8 @@ print implode(' ', $new_numbers);
    callable はスコープに依存する場合があり、
    直接呼び出せない可能性がある点です。
    <classname>Closure</classname> が、callable を作成する望ましい方法です。
+   PHP 8.5.0 以降、<classname>Closure</classname> は
+   <type>callable</type> の真の部分型です。
   </simpara>
 
   <note>

--- a/language/types/integer.xml
+++ b/language/types/integer.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4fc9f9ea7ba36a383613ede343a0820f5cc46aa2 Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa,shimooka,mumumu -->
 <sect1 xml:id="language.types.integer">
  <title>整数</title>
@@ -211,18 +211,22 @@ var_dump(intval(8.1)); // PHP 8.1.0 より前でもあとでも、8
     </programlisting>
    </example>
     
-   <para>
+   <simpara>
     float が整数の範囲 (通常は、32 ビットプラットフォームでは <literal>+/- 2.15e+9 =
     2^31</literal>、64 ビットプラットフォームでは <literal>+/- 9.22e+18 = 2^63</literal>
     ) を越える場合、結果は undefined となります。これは、
     その float が正しい整数の結果を得るために十分な精度を得られなかったからです。
-    この場合、警告も通知も発生しません!
-   </para>
+    PHP 8.5.0 以降では、<type>int</type> として表現できない float を
+    <type>int</type> にキャストすると <constant>E_WARNING</constant> が発生します。
+    PHP 8.5.0 より前のバージョンでは、エラーは全く発生していませんでした。
+   </simpara>
 
    <note>
-    <para>
+    <simpara>
      <literal>NaN</literal>, <literal>Inf</literal>, <literal>-Inf</literal> を <type>int</type> にキャストした結果は、常にゼロとなります。
-    </para>
+     PHP 8.5.0 以降では、これらを <type>int</type> にキャストすると <constant>E_WARNING</constant> が発生します。
+     <constant>NAN</constant> を他の型にキャストした場合も、同様に警告が発生します。
+    </simpara>
    </note>
     
    <warning>


### PR DESCRIPTION
PHP 8.5 のドキュメント一式が doc-en に入ったため、language/ と appendices/ の 23 ファイルを追従しました。

追従した doc-en のコミット:

- php/doc-en@4c352e6 — Document the PHP 8.5 core language features (#5824)
- php/doc-en@cf7dcff — Document the PHP 8.5 core deprecations and the max_memory_limit INI setting (#5823)
- php/doc-en@4fc9f9e — Document the PHP 8.5 backward incompatible changes (#5837)
- php/doc-en@8dc5bef — Define attribute signatures (#5631)
- php/doc-en@2594e1b — Document clone(), the new #[\Deprecated] targets and hrtime() on macOS (#5839)
- php/doc-en@09c6504 — cloning: visibility applies to all properties, readonly is orthogonal (#5854)
- php/doc-en@f011a59 — docs(open_basedir): warn that Unix domain sockets are not restricted (#5846)
- php/doc-en@14f641d — cli: Document built-in server index lookup for file-like paths (8.4.0) (#5782)

## ファイル

### language/predefined/attributes (8)

- attribute.xml
- deprecated.xml
- allowdynamicproperties.xml
- delayedtargetvalidation.xml
- nodiscard.xml
- override.xml
- returntypewillchange.xml
- sensitiveparameter.xml

### language/oop5 (5)

- changelog.xml
- cloning.xml
- magic.xml
- traits.xml
- variance.xml

### language/predefined/closure (2)

- bind.xml
- bindto.xml

### language/types (2)

- callable.xml
- integer.xml

### その他 (6)

- appendices/ini.core.xml
- features/commandline.xml
- language/constants.xml
- language/errors/basics.xml
- language/functions.xml
- language/operators/comparison.xml
