### PR TITLE
install/ と PHP 8.5 関連の原文の更新に追従 (12ファイル)

### DIFF
--- a/install/fpm/configuration.xml
+++ b/install/fpm/configuration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 1f01e2a8e478c63bd6598cde09235ec027b23dd5 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 7efe863bc4b65788f652e3d9eff27941b1a74540 Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 
   <sect1 xml:id="install.fpm.configuration" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -253,6 +253,21 @@
         'ip.add.re.ss:port', 'port', '/path/to/unix/socket' 形式の構文が使えます。
         このオプションは、各プール単位で必須となります。
        </para> 
+       <warning>
+        <simpara>
+         FastCGI のエンドポイントを外部に公開すると、任意のコードを実行されてしまいます。
+         ウェブサーバーが同じホストで動いている場合は、unix ソケットを使うべきです。
+         Linux では、そのアクセス権限を
+         <link linkend="listen-owner">listen.owner</link>、
+         <literal>listen.group</literal>、<literal>listen.mode</literal> で制御できます。
+         ただし、多くの BSD 由来のシステムでは、これらのパーミッションにかかわらず接続を受け付けます。
+         tcp ソケットを使う場合は、接続を許可するアドレスを
+         <link linkend="listen-allowed-clients">listen.allowed_clients</link>
+         に列挙しなければなりません。このオプションはデフォルトでは未設定で、その場合は任意のアドレスからの接続を受け付けます。
+         コンテナ環境では、FPM サービスのポートをホスト側に公開すべきではありません。
+         同じネットワーク上のコンテナ同士は、直接通信できます。
+        </simpara>
+       </warning>
       </listitem>
      </varlistentry>
      <varlistentry xml:id="listen-backlog">
@@ -1036,6 +1051,21 @@
       </listitem>
      </varlistentry>
     </variablelist>
+    <para>
+     設定値には、環境変数の展開が使えます。
+     環境変数が未設定または null の場合にデフォルト値を設定することも、PHP 8.3.0 以降でサポートされています。
+     例:
+     <example>
+      <title>環境変数の展開を使う</title>
+      <programlisting role="ini">
+<![CDATA[
+listen = /var/run/php-fpm-${POOL_NAME}.sock
+user = ${USER_NAME:-www-data}
+group = ${USER_NAME:-www-data}
+]]>
+      </programlisting>
+     </example>
+    </para>
     <para>
      追加の環境変数を渡して、特定のプールだけで PHP の設定を更新することができます。
      そのためには、次のオプションをプール設定ファイルに追加しなければなりません。

--- a/install/ini.xml
+++ b/install/ini.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 603435cd84951fc720eded819c62ef2466d21b5c Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 5f0cb2451f24071abbfd5f42d96d9210605966b0 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: mumumu -->
 
 <chapter xml:id="configuration" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
@@ -232,7 +232,7 @@ $ PHP_INI_SCAN_DIR=/usr/local/etc/php.d: php
    </simpara>
    <simpara>
     .user.ini 形式の INI ファイルがサポートするのは、
-    モードが <constant>INI_PERDIR</constant> および
+    モードが <constant>INI_ALL</constant>、<constant>INI_PERDIR</constant> および
     <constant>INI_USER</constant> の項目のみです。
    </simpara>
    

--- a/install/pecl.xml
+++ b/install/pecl.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d1fa3096926b6cbaf9da1f831b6fe3302ae2e490 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 7b3094477569cda19b14bf61f244b60d24a5e479 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: shimooka,takagi,mumumu -->
 
  <chapter xml:id="install.pecl" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <title>PECL 拡張モジュールのインストール</title>
+  &pecl.moving.to.pie;
 
   <sect1 xml:id="install.pecl.intro">
    <title>PECL インストール入門</title>
@@ -114,6 +115,7 @@ $ svn checkout https://svn.php.net/repository/pecl/extname/trunk extname
 
  <sect1 xml:id="install.pecl.windows">
   <title>PHP 拡張モジュールの Windows へのインストール</title>
+  &pecl.moving.to.pie;
   <para>
    Windows では、PHP の拡張モジュールを読み込む方法は 2 通りあります。
    コンパイル時に PHP に組み込む方法と、DLL として読む込む方法です。
@@ -319,6 +321,7 @@ Loaded Configuration File   C:\Program Files\PHP\8.2\php.ini
 
   <sect1 xml:id="install.pecl.pear">
    <title>共有 PECL 拡張モジュールを、pecl コマンドを用いてコンパイルする</title>
+   &pecl.moving.to.pie;
    <simpara>
     PECL を用いると、共有 PECL 拡張モジュールを容易に作成することができます。
     以下のように <link xlink:href="&url.php.pear.cli;">pecl コマンド</link> を用います。
@@ -364,6 +367,7 @@ $ pecl install extname-0.1
 
   <sect1 xml:id="install.pecl.phpize">
    <title>phpize で共有 PECL 拡張モジュールをコンパイルする方法</title>
+   &pecl.moving.to.pie;
    <simpara>
     時には <command>pecl</command> インストーラを使用するという選択肢が使えない場合もあります。
     たとえばファイアウォールの内部で作業をしている場合がそうですし、
@@ -414,7 +418,7 @@ $ make
   <title>
    <command>php-config</command>
   </title>
-  
+  &pecl.moving.to.pie;
   <para>
    <command>php-config</command> はシンプルなシェルスクリプトで、
    インストールされている PHP の設定情報を取得します。
@@ -520,6 +524,7 @@ Options:
 
   <sect1 xml:id="install.pecl.static">
    <title>PECL 拡張モジュールを PHP に静的に組み込む</title>
+   &pecl.moving.to.pie;
    <simpara>
     PECL 拡張モジュールを PHP に静的に組み込みたいと思うこともあるでしょう。
     そのためには、拡張モジュールのソースを <filename>/path/to/php/src/dir/ext/</filename>

--- a/install/unix/debian.xml
+++ b/install/unix/debian.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 2d91caad93e275542dfdc1a99a6fc8a0ed030108 Maintainer: takagi Status: ready -->
 <!-- CREDITS: haruki -->
 <sect1 xml:id="install.unix.debian" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Debian GNU/Linux および関連ディストリビューションのパッケージからのインストール</title>
@@ -19,7 +19,7 @@
  <sect2 xml:id="install.unix.debian.apt">
   <title>APT の使用</title>
    <simpara>
-    まず、Apache 2 と統合する場合は
+    まず、Apache httpd 2 と統合する場合は
     <literal>libapache2-mod-php</literal>、PEAR を使う場合は
     <literal>php-pear</literal> などの関連パッケージが必要となることを知っておきましょう。
    </simpara>
@@ -28,7 +28,7 @@
     これは、<command>apt update</command> コマンドで行います。
    </simpara>
    <example xml:id="install.unix.debian.apt.example">
-    <title>Debian で Apache 2 と組み合わせるインストール例</title>
+    <title>Debian で Apache httpd 2 と組み合わせるインストール例</title>
     <programlisting role="shell">
 <![CDATA[
 # apt install php-common libapache2-mod-php php-cli
@@ -36,15 +36,15 @@
     </programlisting>
    </example>
    <simpara>
-    APT により、Apache 2 用の PHP モジュールとその依存モジュールが自動的にインストールされます。
-    インストール中に Apache を再起動する旨が表示されなかった場合は、手動で再起動する必要があります。
+    APT により、Apache httpd 2 用の PHP モジュールとその依存パッケージがすべて自動的にインストールされ、
+    有効化されます。変更を有効にするには、Apache httpd を再起動する必要があります。
+    たとえば、次のようにします。
    </simpara>
    <example xml:id="install.unix.debian.apt.example2">
-    <title>PHP インストール後に Apache を停止・起動させる</title>
+    <title>PHP インストール後に Apache httpd を再起動する</title>
     <programlisting role="shell">
 <![CDATA[
-# /etc/init.d/apache2 stop
-# /etc/init.d/apache2 start
+# systemctl restart apache2
 ]]>
     </programlisting>
    </example>
@@ -87,11 +87,12 @@
    </example>
    <simpara>
     APT は自動的に、
-    <filename>/etc/php/7.4/php.ini</filename> や
-    <filename>/etc/php/7.4/conf.d/*.ini</filename>
+    <filename>/etc/php/8.x/apache2/php.ini</filename> や
+    <filename>/etc/php/8.x/cli/php.ini</filename>、
+    <filename>/etc/php/8.x/mods-available/*.ini</filename>
     などの &php.ini; に適切な行を追加し、<literal>extension=foo.so</literal>
-    といった内容が書き込まれます。しかし、これらの変更を有効にするにはウェブサーバー
-    (Apache など) を再起動しなければなりません。
+    といった内容が書き込まれます。しかし、これらの変更を有効にするには
+    ウェブサーバーを再起動しなければなりません。
    </simpara>
  </sect2>
  <sect2 xml:id="install.unix.debian.faq">

--- a/install/unix/dnf.xml
+++ b/install/unix/dnf.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: zonuexe Status: ready -->
+<!-- EN-Revision: 88d5409cd9668b28ecb879522750807322a816dd Maintainer: zonuexe Status: ready -->
 <sect1 xml:id="install.unix.dnf" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>DNF を使用する GNU/Linux ディストリビューションでのパッケージからのインストール</title>
  <simpara>
@@ -27,7 +27,7 @@
    <title>DNF インストールの例</title>
    <programlisting role="shell">
 <![CDATA[
-# dnf install php php-common
+# dnf install php php-common php-fpm
 ]]>
    </programlisting>
   </example>
@@ -36,7 +36,7 @@
    変更を有効化するには、以下のようなコマンドでサーバーの再起動が必要になる場合があります。
   </simpara>
   <example xml:id="install.unix.dnf.example2">
-   <title>Restarting Apache once PHP is installed</title>
+   <title>PHP のインストール後に Apache httpd を再起動する</title>
    <programlisting role="shell">
 <![CDATA[
 # sudo systemctl restart httpd
@@ -81,10 +81,10 @@
    </programlisting>
   </example>
   <simpara>
-   DNF は、<filename>/etc/php/8.3/php.ini</filename>、<filename>/etc/php/8.3/conf.d/*.ini</filename>
+   DNF は、<filename>/etc/php.ini</filename>、<filename>/etc/php.d/*.ini</filename>
    などのさまざまな &php.ini; 関連ファイルに適切な行を自動的に追加し、
    拡張モジュールに応じて <literal>extension=foo.so</literal> のようなエントリを追加します。
-   ただし、これらの変更の有効化するには、Web サーバー (Apache など) を再起動しなければなりません。
+   ただし、これらの変更を有効化するには、Web サーバーと PHP-FPM を再起動しなければなりません。
   </simpara>
  </sect2>
 </sect1>

--- a/install/unix/source.xml
+++ b/install/unix/source.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 1c9fb12650addc936f5a0d5d1edc42cd32e9c765 Maintainer: zonuexe Status: ready -->
+<!-- EN-Revision: e07f764c8e4234d1195536ffed2eaf19c849ce50 Maintainer: zonuexe Status: ready -->
 <sect1 xml:id="install.unix.source" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Unix および macOS システムでのソースコードからのインストール</title>
  <para>

--- a/reference/array/functions/list.xml
+++ b/reference/array/functions/list.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: eaec4ab10a65c4515ee2fb899d06e89bae3754b0 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 4fc9f9ea7ba36a383613ede343a0820f5cc46aa2 Maintainer: hirokawa Status: ready -->
 <!-- Credits: mumumu -->
 
 <refentry xml:id="function.list" xmlns="http://docbook.org/ns/docbook">
@@ -95,6 +95,13 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.5.0</entry>
+       <entry>
+        配列でない値 (&null; を除く) を分解すると、
+        <constant>E_WARNING</constant> が発生するようになりました。
+       </entry>
+      </row>
       <row>
        <entry>7.3.0</entry>
        <entry>

--- a/reference/funchand/functions/register-tick-function.xml
+++ b/reference/funchand/functions/register-tick-function.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 689cf3b5aebc4ff00c6fe52b46bdfbf3460c338c Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4fc9f9ea7ba36a383613ede343a0820f5cc46aa2 Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa,mumumu -->
 <refentry xml:id="function.register-tick-function" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -50,6 +50,38 @@
   <para>
    &return.success;
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       tick ハンドラが無効化されるタイミングが、
+       リクエストのシャットダウン処理のより後の段階に移りました。
+       すべてのシャットダウン関数とデストラクタが実行され、
+       出力ハンドラがクリーンアップされた後に無効化されます。
+       これより前のバージョンでは、
+       リクエストのシャットダウン処理の一番最初に無効化されていたため、
+       シャットダウン関数やデストラクタ、出力処理の中では
+       tick 関数がコールされませんでした。
+       詳細は
+       <link linkend="migration85.incompatible.core.tick-handlers">移行ガイド</link>
+       を参照ください。
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/outcontrol/functions/ob-get-status.xml
+++ b/reference/outcontrol/functions/ob-get-status.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: af7044e82ac0abe745ce3dfe2169e69a7e8e342f Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 1ebafd8a44786824396f95102576426462835869 Maintainer: mumumu Status: ready -->
 <refentry xml:id="function.ob-get-status" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ob_get_status</refname>
@@ -113,7 +113,15 @@
     <seglistitem>
      <seg>buffer_size</seg>
      <seg>
-      出力バッファのサイズ(バイト単位)
+      現在確保されている出力バッファのサイズ(バイト単位)。
+      <parameter>chunk_size</parameter> がデフォルトの場合は
+      <literal>16384</literal> バイトから、
+      <parameter>chunk_size</parameter> を指定した場合は
+      その値を <literal>4096</literal> の倍数に切り上げたサイズから始まります。
+      バッファリングされる出力が増えるにつれて、
+      <literal>4096</literal> の倍数ずつ大きくなります。
+      これはバッファ内のデータ量ではありません
+      (<literal>buffer_used</literal> を参照下さい)。
      </seg>
     </seglistitem>
     <seglistitem>

--- a/reference/outcontrol/functions/ob-start.xml
+++ b/reference/outcontrol/functions/ob-start.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e58094c4537a9ac89a6a0a7e64a4256d63e05514 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: cf7dcffba0ab8ce14dbfd6019f2861f5a6843ed5 Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa,mumumu -->
 <refentry xml:id="function.ob-start" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -116,14 +116,21 @@
     <varlistentry>
      <term><parameter>chunk_size</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        オプションのパラメータ <parameter>chunk_size</parameter> が渡された場合、
        バッファの長さが <parameter>chunk_size</parameter> バイト以上になる出力があった後で、
        バッファがフラッシュされます。
        デフォルト値は <literal>0</literal> で、これはバッファがオフになるまで
        すべての出力がバッファリングされることを意味します。
+       <literal>1</literal> を指定した場合は、出力操作のたびにバッファがフラッシュされ、
+       実質的にバッファリングが無効になります。
+       <parameter>chunk_size</parameter> は、<function>ob_get_status</function>
+       が返すバッファの初期サイズも決定します。
+       <literal>0</literal> の場合は <literal>16384</literal> バイトになり、
+       それ以外の場合は <parameter>chunk_size</parameter> を
+       <literal>4096</literal> の倍数に切り上げた値になります。
        詳細は <xref linkend="outcontrol.buffer-size"/> を参照ください。
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
@@ -192,6 +199,31 @@
   <para>
    &return.success;
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       ユーザー定義の出力ハンドラのコールバック内で
+       (たとえば <function>echo</function> などを使って) 出力しようとすることは、
+       非推奨になりました。
+       非推奨の警告は、ハンドラをバイパスして直接出力されます。
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/spl/arrayiterator/construct.xml
+++ b/reference/spl/arrayiterator/construct.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d51166ca16fda8e766849505b84f9306ef443f71 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4fc9f9ea7ba36a383613ede343a0820f5cc46aa2 Maintainer: takagi Status: ready -->
 <refentry xml:id="arrayiterator.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ArrayIterator::__construct</refname>
@@ -29,9 +29,10 @@
     <varlistentry>
      <term><parameter>array</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        反復処理をする配列あるいはオブジェクト。
-      </para>
+       PHP 8.5.0 以降、オブジェクトを渡すことは非推奨です。
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
@@ -47,13 +48,51 @@
   </para>
  </refsect1>
 
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   PHP 8.5.0 以降、<parameter>array</parameter> が列挙型の場合に
+   <exceptionname>InvalidArgumentException</exceptionname> をスローします。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       <parameter>array</parameter> に列挙型を渡すと
+       <exceptionname>InvalidArgumentException</exceptionname>
+       をスローするようになりました。
+      </entry>
+     </row>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       <parameter>array</parameter> にオブジェクトを渡すことは非推奨になりました。
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><methodname>ArrayIterator::getArrayCopy</methodname></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><methodname>ArrayIterator::getArrayCopy</methodname></member>
+   <member><methodname>ArrayIterator::setFlags</methodname></member>
+   <member><methodname>ArrayObject::__construct</methodname></member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/spl/arrayobject/construct.xml
+++ b/reference/spl/arrayobject/construct.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c142be811735a5542c8a2e4c4ed2f81e8cc3acc6 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 4fc9f9ea7ba36a383613ede343a0820f5cc46aa2 Maintainer: takagi Status: ready -->
 <!-- CREDITS: shimooka -->
 <refentry xml:id="arrayobject.construct" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -19,6 +19,14 @@
   <para>
    新規配列オブジェクトを生成します。
   </para>
+  <warning>
+   <simpara>
+    PHP 8.5.0 以降、<parameter>array</parameter> パラメータに列挙型を渡すと
+    <exceptionname>InvalidArgumentException</exceptionname> をスローします。
+    列挙型の <literal>$name</literal> や <literal>$value</literal>
+    プロパティを変更すると、PHP エンジンの想定を壊す可能性があるからです。
+   </simpara>
+  </warning>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -28,10 +36,11 @@
     <varlistentry>
      <term><parameter>array</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        <parameter>array</parameter> には、
-       配列あるいはオブジェクトを指定することができます。
-      </para>
+       配列あるいはオブジェクトを指定することができますが、
+       PHP 8.5.0 以降、オブジェクトを渡すことは非推奨です。
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
@@ -56,6 +65,44 @@
     </varlistentry>
    </variablelist>
   </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   PHP 8.5.0 以降、<parameter>array</parameter> が列挙型の場合に
+   <exceptionname>InvalidArgumentException</exceptionname> をスローします。
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       <parameter>array</parameter> に列挙型を渡すと
+       <exceptionname>InvalidArgumentException</exceptionname>
+       をスローするようになりました。
+      </entry>
+     </row>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       <parameter>array</parameter> にオブジェクトを渡すことは非推奨になりました。
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">
@@ -102,11 +149,11 @@ object(ArrayObject)#1 (1) {
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><methodname>ArrayObject::setflags</methodname></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><methodname>ArrayObject::setFlags</methodname></member>
+   <member><methodname>ArrayObject::getArrayCopy</methodname></member>
+   <member><methodname>ArrayIterator::__construct</methodname></member>
+  </simplelist>
  </refsect1>
 
 </refentry>


### PR DESCRIPTION
## 翻訳内容

### PHP 8.5 の後方互換性のない変更（4件）

php/doc-en@4fc9f9ea7b (php/doc-en#5837) が追加した errors / changelog の訳出。

- reference/spl/arrayobject/construct.xml
- reference/spl/arrayiterator/construct.xml
- reference/funchand/functions/register-tick-function.xml
- reference/array/functions/list.xml

### 出力バッファ（2件）

php/doc-en@1ebafd8a44 (php/doc-en#5260) の `buffer_size` / `chunk_size` の説明と、php/doc-en@cf7dcffba0 (php/doc-en#5823) が追加した PHP 8.5 の非推奨の訳出。

- reference/outcontrol/functions/ob-start.xml — php/doc-en@1ebafd8a44, php/doc-en@cf7dcffba0
- reference/outcontrol/functions/ob-get-status.xml — php/doc-en@1ebafd8a44

### install（6件）

- install/fpm/configuration.xml — php/doc-en@7cd12cc82b (php/doc-en#5181), php/doc-en@7efe863bc4 (php/doc-en#5263)
- install/unix/debian.xml — php/doc-en@2d91caad93 (php/doc-en#5744)
- install/unix/dnf.xml — php/doc-en@88d5409cd9 (php/doc-en#5745)
- install/pecl.xml — php/doc-en@7b30944775 (php/doc-en#5622)
- install/ini.xml — php/doc-en@5f0cb2451f (php/doc-en#4779)
- install/unix/source.xml — php/doc-en@e07f764c8e (php/doc-en#5761)

## その他

- `install/unix/debian.xml` の APT の段落には、原文のどのリビジョンにも対応しない訳文（「インストール中に Apache を再起動する旨が表示されなかった場合は、手動で再起動する必要があります。」）が残っていました。原文側で当該 simpara が全行変更されたため、訳抜けだった 2 文（`and then activate it` / `For example:`）とあわせて訳し直しています。
- `install/unix/dnf.xml` の example2 のタイトルは未訳で残っていたため訳出しました。
- `install/unix/source.xml` は原文の変更が英文法の修正（`was been run` → `has been run`）のみで、既訳が既に正しい意味を表しているため EN-Revision だけを更新しています。
- php/doc-en@cf7dcffba0 は `language/operators/increment.xml` も変更していますが、このファイルは本 PR に含めていません。同コミットが追加した「8.5.0 以降は deprecation warning を出す」の一文は、同じ `<warning>` 内で原文が現在形・上限なしのまま残している "This feature is soft-deprecated as of PHP 8.3.0." と衝突しており、ja 側はこの soft-deprecated を「`E_DEPRECATED` は発生しないものの」と開いて訳しているため、追従すると同一 `<simpara>` 内で矛盾する記述になります。原文側の修正が先と判断しました。
