### PR TITLE
language/ と appendices/filters.xml の原文の更新に追従 (5ファイル)

### DIFF
--- a/appendices/filters.xml
+++ b/appendices/filters.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 3f1dbc451b313fb1ec8058f24c1beccf55fce316 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 82b5e0afeb38142e91fbba05f06b46c3129420ba Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 
 <appendix xml:id="filters" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -290,7 +290,7 @@ fclose($fp);
 
   <section xml:id="filters.compression.zlib">
    <title>zlib.deflate と zlib.inflate</title>
-   <simpara>
+   <para>
     <literal>zlib.deflate</literal> (圧縮) と
     <literal>zlib.inflate</literal> (展開) は、
     <link xlink:href="&url.rfc;1951">RFC 1951</link> で述べられている圧縮方法を
@@ -309,10 +309,123 @@ fclose($fp);
     効率は落ちますがメモリの消費量を抑えられます。値を指定しなかった際の
     <parameter>window</parameter> の初期値は、現在 <literal>15</literal> です。
  
+    <literal>zlib.deflate</literal> フィルタは
+    <literal>DEFLATE</literal>、<literal>ZLIB</literal>、<literal>GZIP</literal>
+    の 3 つの圧縮方法を実装しており、どれを使うかは
+    <parameter>window</parameter> パラメータの値で決まります。
+
+    window パラメータの下位 4 ビットは、内部で使われる「ヒストリバッファ」の
+    サイズを、2 を底とする対数で指定するもので、8 から 15 までの
+    範囲を取ります。それ以外のビットの意味は、
+    以下のとおりです。
+
+    <itemizedlist>
+     <listitem>
+      <simpara>
+       <literal>DEFLATE</literal> (<link xlink:href="&url.rfc;1951">RFC 1951</link>)
+       は、ヘッダもチェックサムも持たない生の圧縮アルゴリズムです。
+       window パラメータに -9 から -15 の範囲の値を指定した場合に、この圧縮が行われます。
+       この圧縮アルゴリズムは、<literal>zlib.deflate</literal> フィルタが生成する
+       すべてのフォーマットの基礎になっています。
+       文字列を直接扱う関数としては、<function>gzdeflate</function> と
+       <function>gzinflate</function> が対応します。
+      </simpara>
+     </listitem>
+
+     <listitem>
+      <simpara>
+       <literal>ZLIB</literal> (<link xlink:href="&url.rfc;1950">RFC 1950</link>)
+       は、<literal>DEFLATE</literal> アルゴリズムを適用した上で、2 バイトのヘッダと、
+       圧縮前のデータの Adler32 チェックサムをビッグエンディアンのバイトオーダーで
+       格納した 4 バイトのトレーラーを追加します:
+       <literal><![CDATA[ZLIB = ZLIBHEADER(2B)  DEFLATE  ADLER32(4B)]]></literal>
+
+       2 バイトのヘッダをビッグエンディアンの 16 ビット符号なし整数として読んだ値は、
+       31 の倍数でなければなりません。
+       window パラメータに 8 から 15 の範囲の値を指定した場合に、
+       このフォーマットが生成されます。
+       文字列を直接扱う関数としては、<function>gzcompress</function> と
+       <function>gzuncompress</function> が対応します。
+      </simpara>
+     </listitem>
+
+     <listitem>
+      <simpara>
+       <literal>GZIP</literal> (<link xlink:href="&url.rfc;1952">RFC 1952</link>)
+       は、<literal>DEFLATE</literal> アルゴリズムを適用した上で、ヘッダと、
+       圧縮前のデータの <literal>CRC32</literal> チェックサムおよびその長さを、
+       どちらもリトルエンディアンのバイトオーダーで格納したトレーラーを追加します:
+       <literal><![CDATA[GZIP = GZIPHEADER(10B)  DEFLATE  CRC32(4B)  LENGTH(4B)]]></literal>
+
+       これが <literal>.gz</literal> ファイルのフォーマットです。
+       <literal>GZIPHEADER</literal> には、順に
+       <literal>GZIP</literal> シグネチャ (<literal>\x1f\x8B</literal>)、
+       圧縮メソッド (<literal>\x08</literal>)、値がゼロのフラグバイト、
+       値がゼロの 4 バイトの更新時刻、圧縮レベルに応じた extra-flags バイト、
+       そして現在のオペレーティングシステム
+       (<literal>\x00</literal> = FAT ファイルシステム、
+       <literal>\x03</literal> = Unix など) が格納されます。
+       window パラメータに 9+16=25 から 15+16=31 の範囲の値を指定した場合に、
+       このフォーマットが生成されます。
+       圧縮前のデータの長さには 4GB という上限があることに注意してください。
+       この上限を超えた場合、<literal>LENGTH</literal> の部分には実際の長さを
+       2^32 で割った余りだけが格納されます。
+       文字列を直接扱う関数としては、<function>gzencode</function> と
+       <function>gzdecode</function> が対応します。また
+       <function>gzopen</function> 関数を使うと、<literal>.gz</literal>
+       ファイルの読み書きができます。
+      </simpara>
+     </listitem>
+    </itemizedlist>
+
+    <literal>zlib.inflate</literal> フィルタで指定できるのは
+    <parameter>window</parameter> パラメータだけで、それ以外のパラメータ
+    (<parameter>memory</parameter>、<parameter>level</parameter>) は無視されます。
+    $W をヒストリバッファのサイズの 2 を底とする対数とすると、展開時には
+    2^$W バイトが確保されます。ZLIB フォーマットの場合、この値はヘッダに記録された
+    値以上でなければならず、展開時にチェックされます。それ以外のフォーマットの場合は、
+    データ中に実際に現れるマッチ距離をまかなえる大きさであれば十分です。
+    範囲は 9 ≤ $W ≤ 15 です。値がわからない場合は $W=15 にしておくのが安全です。
+
+    <itemizedlist>
+     <listitem>
+      <simpara>
+       <literal>DEFLATE</literal> (<link xlink:href="&url.rfc;1951">RFC 1951</link>):
+       window=-$W を指定します。$W には、圧縮時に使った値以上を指定します。
+       値がわからない場合は window=-15 を指定してください。
+      </simpara>
+     </listitem>
+
+     <listitem>
+      <simpara>
+       <literal>ZLIB</literal> (<link xlink:href="&url.rfc;1950">RFC 1950</link>):
+       window=$W を指定します。$W の値は ZLIB ヘッダから取得できます。
+       値がわからない場合は window=15 を指定してください。
+      </simpara>
+     </listitem>
+
+     <listitem>
+      <simpara>
+       <literal>GZIP</literal> (<link xlink:href="&url.rfc;1952">RFC 1952</link>):
+       window=$W+16 を指定します。GZIP ヘッダは window サイズを保持していないので、
+       圧縮時に使った値がわからない場合は window=31 を指定してください。
+      </simpara>
+     </listitem>
+
+     <listitem>
+      <simpara>
+       <literal>ZLIB or GZIP</literal>:
+       ヘッダを自動で検出させるには window=$W+32 を指定します。こうすると
+       どちらのフォーマットも認識して展開できます。
+       window=15+32=47 にしておくのが安全です。
+      </simpara>
+     </listitem>
+    </itemizedlist>
+
     <parameter>memory</parameter> は、作業用の一時メモリをどの程度割り当てるかを
     指定します。1 (最小限) から 9 (最大限) の間で指定できます。この値は
     圧縮の速度のみに影響し、圧縮後のデータのサイズには影響しません。
-  </simpara>
+  </para>
 
   <note>
    <simpara>

--- a/language/context/http.xml
+++ b/language/context/http.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c62ef37e0d58067b393a6cf3a14aefed90bc0bff Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 313c83d7c99b46b5d05fdf67e7346719412f522a Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 
 <refentry xml:id="context.http" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="verify_info:false" role="stream_context_option">
@@ -134,9 +134,15 @@
        <literal>Location</literal> のリダイレクトをたどります。
        <literal>0</literal> で無効にできます。
       </para>
-      <para>
-       デフォルトは <literal>1</literal> です。
-      </para>
+      <simpara>
+       このオプションを設定しない場合、リダイレクトをたどるのは
+       <literal>300</literal>、<literal>301</literal>、<literal>302</literal>、
+       <literal>303</literal>、<literal>307</literal>、<literal>308</literal>
+       のレスポンスコードのときだけです。
+       <literal>1</literal> を設定するのはこれと同等ではなく、
+       <literal>Location</literal> ヘッダを含むレスポンスであれば、
+       レスポンスコードが何であってもリダイレクトをたどるようになります。
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="context.http.max-redirects">
@@ -200,10 +206,51 @@
       </para>
      </listitem>
     </varlistentry>
+    <varlistentry xml:id="context.http.uri-parser-class">
+     <term>
+      <parameter>uri_parser_class</parameter>
+      <type>string</type> あるいは <type>null</type>
+     </term>
+     <listitem>
+      <simpara>
+       URI のパースに使用するクラス。&null; の場合は、
+       <function>parse_url</function> に基づく従来の挙動を使用します。
+       指定できる値は <classname>Uri\Rfc3986\Uri</classname>
+       (RFC 3986 に準拠したパーサー) と <classname>Uri\WhatWg\Url</classname>
+       (WHATWG URL Standard のパーサー) です。
+       ユーザーランドの独自実装はサポートされていません。
+      </simpara>
+      <simpara>
+       デフォルトは &null; です。
+      </simpara>
+     </listitem>
+    </varlistentry>
    </variablelist>
   </para>
  </refsect1>
  
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       <parameter>uri_parser_class</parameter> オプションが追加されました。
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;

--- a/language/control-structures/for.xml
+++ b/language/control-structures/for.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e674990649cd2b111b8dd1175a7a1befcc621635 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 8c273ad6577a6b4d6d3adea73502a4516ca2fe0c Maintainer: takagi Status: ready -->
 
 <sect1 xml:id="control-structures.for" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>for</title>
@@ -134,97 +134,58 @@ endfor;
   </informalexample>
  </para>
  <simpara>
-  多くのユーザーにとって、次の例のように配列をループ処理することはよくあるでしょう。
+  <varname>式2</varname> と <varname>式3</varname> は、繰り返しのたびに評価されます。
+  パフォーマンス上の問題を避けるため、ここには単純な式を使うことをお勧めします。
+  たとえば、繰り返しの回数があらかじめわかっている場合は、
+  <varname>式2</varname> で関数をコールするのではなく変数を使うほうがよいでしょう。
  </simpara>
  <para>
   <informalexample>
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
-/*
- * データが入った配列で、ループ処理中に
- * その中身を書き換えたいと考えています
- */
-$people = array(
-    array('name' => 'Kalle', 'salt' => 856412),
-    array('name' => 'Pierre', 'salt' => 215863)
-);
 
-for($i = 0; $i < count($people); ++$i) {
-    $people[$i]['salt'] = random_int(100000, 999999);
+$people = ['Kalle', 'Pierre'];
+
+// 悪い例: 繰り返しのたびに関数をコールしている
+for($i = 0; $i < getIterationCount($people); ++$i) {
+    $people[$i] .= ' is cool';
 }
-var_dump($people);
+
+// よい例: 繰り返しの回数を変数に格納している
+for($i = 0, $peopleCount = getIterationCount($people); $i < $peopleCount; ++$i) {
+    $people[$i] .= ' is cool';
+}
+
 ]]>
    </programlisting>
-   &example.outputs.similar;
-   <screen>
-<![CDATA[
-array(2) {
-  [0]=>
-  array(2) {
-    ["name"]=>
-    string(5) "Kalle"
-    ["salt"]=>
-    int(454478)
-  }
-  [1]=>
-  array(2) {
-    ["name"]=>
-    string(6) "Pierre"
-    ["salt"]=>
-    int(776978)
-  }
-}
-]]>
-   </screen>
   </informalexample>
  </para>
  <simpara>
-  このコードは実行速度が遅くなることでしょう。
-  というのも、配列のサイズを毎回取得しているからです。
-  サイズが変わることはありえないのだから、これは簡単に最適化することができます。
-  配列のサイズを変数に格納して使うようにすれば、
-  何度も <function>count</function> を呼ばずに済むのです。
+  上の例の最初のループでは、関数が常に同じ値を返すにもかかわらず、
+  繰り返しのたびにその関数をコールしています。
+  2番目のループのようにその値を変数に格納しておけば、関数のコールは一度で済みます。
+  ただし、繰り返しの回数が固定されることには注意してください。
+  ループの中で配列を変更した場合、格納した値は配列の新しいサイズを反映しなくなります。
  </simpara>
- <para>
-  <informalexample>
-   <programlisting role="php">
-<![CDATA[
-<?php
-$people = array(
-    array('name' => 'Kalle', 'salt' => 856412),
-    array('name' => 'Pierre', 'salt' => 215863)
-);
 
-for($i = 0, $size = count($people); $i < $size; ++$i) {
-    $people[$i]['salt'] = random_int(100000, 999999);
-}
-var_dump($people);
-]]>
-   </programlisting>
-   &example.outputs.similar;
-   <screen>
-<![CDATA[
-array(2) {
-  [0]=>
-  array(2) {
-    ["name"]=>
-    string(5) "Kalle"
-    ["salt"]=>
-    int(454478)
-  }
-  [1]=>
-  array(2) {
-    ["name"]=>
-    string(6) "Pierre"
-    ["salt"]=>
-    int(776978)
-  }
-}
-]]>
-   </screen>
-  </informalexample>
- </para>
+ <note>
+  <simpara>
+   配列のサイズは配列自身が保持しています。
+   つまり、ビルトイン関数 <function>count</function> をコールしても要素を数え上げる必要はなく、
+   パフォーマンス上の問題は発生しません。
+   ただし、配列全体をたどる <constant>COUNT_RECURSIVE</constant> を指定した場合は当てはまりません。
+   また、<interfacename>Countable</interfacename> を実装したオブジェクトに
+   <function>count</function> を使う場合は、そのコールのコストが高くなる可能性があるため注意が必要です。
+  </simpara>
+ </note>
+
+ <note>
+  <simpara>
+   配列を反復処理する方法として、<literal>for</literal> ループは推奨されません。
+   &foreach; ループはこの用途のために設計されており、たいていの場合はより便利です。
+  </simpara>
+ </note>
 </sect1>
 
 <!-- Keep this comment at the end of the file

--- a/language/operators/precedence.xml
+++ b/language/operators/precedence.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 80dfa568e602649eb13585bf59a7b6239eddaac3 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 3a94de0974207a5704bb9f04377a2ea2baf487ba Maintainer: mumumu Status: ready -->
 <sect1 xml:id="language.operators.precedence">
  <title>演算子の優先順位</title>
  <titleabbrev>演算子の優先順位</titleabbrev>
@@ -263,6 +263,13 @@
      </row>
      <row>
       <entry>(n/a)</entry>
+      <entry><literal>=&gt;</literal></entry>
+      <entry>
+       <link linkend="language.generators.syntax">値とキーの yield</link>
+      </entry>
+     </row>
+     <row>
+      <entry>(n/a)</entry>
       <entry><literal>yield</literal></entry>
       <entry>
        <link linkend="control-structures.yield">yield</link>
@@ -293,6 +300,26 @@
       <entry>
        <link linkend="language.operators.logical">論理演算子</link>
       </entry>
+     </row>
+     <row>
+      <entry>(n/a)</entry>
+      <entry>
+       <literal>include</literal>
+       <literal>include_once</literal>
+       <literal>require</literal>
+       <literal>require_once</literal>
+      </entry>
+      <entry>
+       <function>include</function>,
+       <function>include_once</function>,
+       <function>require</function>&listendand;
+       <function>require_once</function>
+      </entry>
+     </row>
+     <row>
+      <entry>(n/a)</entry>
+      <entry><literal>fn (...) =&gt;</literal></entry>
+      <entry><link linkend="functions.arrow">アロー関数</link>のアローの曖昧さの回避</entry>
      </row>
      <row>
       <entry>(n/a)</entry>

--- a/language/predefined/serializable.xml
+++ b/language/predefined/serializable.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 029f19dbc090e4d249a23c0ab087d47059b37adc Maintainer: satoruyoshida Status: ready -->
+<!-- EN-Revision: 72d861de4970c2dbc84c391c1a4caab4a10a91fa Maintainer: satoruyoshida Status: ready -->
 <reference xml:id="class.serializable" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>Serializable インターフェイス</title>
@@ -35,6 +35,37 @@
      を実装したクラスに対しては、推奨されない警告が発生します。
     </para>
    </warning>
+
+   <simpara>
+    新しいコードでは、代わりに PHP 7.4.0 以降で利用可能な
+    <link linkend="object.serialize">__serialize()</link> と
+    <link linkend="object.unserialize">__unserialize()</link>
+    マジックメソッドを使いましょう。
+    クラスがこれらのマジックメソッドとこのインターフェイスの両方を宣言している場合、
+    <function>serialize</function> は常に
+    <link linkend="object.serialize">__serialize()</link> を使い、
+    <methodname>Serializable::serialize</methodname> がコールされることはありません。
+    一方、アンシリアライズでどちらが使われるかは、データの形式によって決まります。
+    PHP 7.4.0 以降が書き出したデータは
+    <link linkend="object.unserialize">__unserialize()</link> が読み込み、
+    それより前のバージョンが書き出したデータは今でも
+    <methodname>Serializable::unserialize</methodname> が読み込みます。
+    そのため、<interfacename>Serializable</interfacename> の実装は、
+    このような古いデータを読み込む場合や、
+    <interfacename>Serializable</interfacename> による型宣言を満たす場合には、
+    依然として有用です。
+    4つのメソッドすべてを宣言すれば、あらゆるケースに対応でき、
+    推奨されない警告も発生しません。
+   </simpara>
+
+   <note>
+    <simpara>
+     マジックメソッドには専用のインターフェイスがありません。
+     そのため、<interfacename>Serializable</interfacename> を実装せずに
+     マジックメソッドだけを宣言したクラスは、このインターフェイスのインスタンスにはなりません。
+     マジックメソッドを検出するには <function>method_exists</function> を使います。
+    </simpara>
+   </note>
   </section>
 
   <section xml:id="serializable.synopsis">
@@ -54,45 +85,61 @@
   <section xml:id="serializable.examples">
    &reftitle.examples;
    <example xml:id="serializable.example.basic">
-    <title>基本的な使用法</title>
+    <title>PHP 7.1.0 から 7.3.0 までをサポートする</title>
+    <simpara>
+     シリアライズ後の形式はマジックメソッドが受け持ち、インターフェイスのメソッドは
+     そこに処理を委譲します。こうすることで、ひとつの表現で両方の仕組みをまかなえます。
+    </simpara>
     <programlisting role="php">
 <![CDATA[
 <?php
-class obj implements Serializable {
-    private $data;
-    public function __construct() {
-        $this->data = "My private data";
+class Task implements Serializable
+{
+    private $label;
+
+    public function __construct($label)
+    {
+        $this->label = $label;
     }
-    public function serialize() {
-        return serialize($this->data);
+
+    public function __serialize(): array
+    {
+        return ['label' => $this->label];
     }
-    public function unserialize($data) {
-        $this->data = unserialize($data);
+
+    public function __unserialize(array $data): void
+    {
+        $this->label = $data['label'];
     }
-    public function getData() {
-        return $this->data;
+
+    // PHP 7.4.0 以降はコールされません
+    public function serialize()
+    {
+        return serialize($this->__serialize());
+    }
+
+    // PHP 7.4.0 以降も、それより前に書き出されたデータに対してはコールされます
+    public function unserialize($data)
+    {
+        $this->__unserialize(unserialize($data));
     }
 }
 
-$obj = new obj;
-$ser = serialize($obj);
-
-var_dump($ser);
-
-$newobj = unserialize($ser);
-
-var_dump($newobj->getData());
+var_dump(serialize(new Task('deploy')));
 ?>
 ]]>
     </programlisting>
-    &example.outputs.similar;
+    &example.outputs;
     <screen>
 <![CDATA[
-Deprecated: obj implements the Serializable interface, which is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in script on line 2
-string(38) "C:3:"obj":23:{s:15:"My private data";}"
-string(15) "My private data"
+string(40) "O:4:"Task":1:{s:5:"label";s:6:"deploy";}"
 ]]>
     </screen>
+    <simpara>
+     PHP 7.4.0 より前のバージョンでは、同じコードがインターフェイス経由でシリアライズを行い、
+     <literal>string(47) "C:4:"Task":31:{a:1:{s:5:"label";s:6:"deploy";}}"</literal>
+     を出力します。
+    </simpara>
    </example>
   </section>
 


### PR DESCRIPTION
## 翻訳内容

### 独立ファイル

- appendices/filters.xml — zlib フィルタが window の値で DEFLATE / ZLIB / GZIP を出し分けることと、各フォーマットのヘッダ・トレーラー構造、inflate 側の window 指定値を追記
  1. php/doc-en@82b5e0afeb
- language/predefined/serializable.xml — マジックメソッドとの優先関係を追記し、コード例を 4 メソッド版に差し替え
  1. php/doc-en@72d861de49
- language/context/http.xml — follow_location の未設定時と 1 設定時が等価でないことを反映し、PHP 8.5 で追加された uri_parser_class と changelog を追記
  1. php/doc-en@aa42c6da04
  2. php/doc-en@313c83d7c9
- language/control-structures/for.xml — コード例を Bad/Good practice の並置に差し替え、count() の性能と foreach の推奨に関する note を追記
  1. php/doc-en@8c273ad657
- language/operators/precedence.xml — 優先順位表に `=>`、include 系、fn のアローの行を追加
  1. php/doc-en@3a94de0974
