### PR TITLE
394950500 で据え置かれた EN-Revision を更新 (26ファイル)

### DIFF
--- a/appendices/ini.sections.xml
+++ b/appendices/ini.sections.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: a0ae28d3bc85f927c22649ebd9a590b921534b7d Maintainer: takagi Status: ready -->
+<!-- EN-Revision: d4d5216e7a965ca194f6b1c9dee84cecab2674e5 Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa,shimooka -->
 
  <section xml:id="ini.sections" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/apache/ini.xml
+++ b/reference/apache/ini.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: d4d5216e7a965ca194f6b1c9dee84cecab2674e5 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: shimooka -->
 <section xml:id="apache.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;

--- a/reference/curl/ini.xml
+++ b/reference/curl/ini.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: aab33d644359aba597e810e2fc0c0caa0d347c9c Maintainer: takagi Status: ready -->
+<!-- EN-Revision: d4d5216e7a965ca194f6b1c9dee84cecab2674e5 Maintainer: takagi Status: ready -->
 <section xml:id="curl.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;
  &extension.runtime;

--- a/reference/datetime/ini.xml
+++ b/reference/datetime/ini.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: b27b713b7ba469f08a7fd61d33b77fb0c758bad3 Maintainer: shimooka Status: ready -->
+<!-- EN-Revision: d4d5216e7a965ca194f6b1c9dee84cecab2674e5 Maintainer: shimooka Status: ready -->
 <!-- Credits: mumumu -->
 <section xml:id="datetime.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;

--- a/reference/filesystem/ini.xml
+++ b/reference/filesystem/ini.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 36d8d80891c1dfc49dacecccc7d43b7fe6a6bb89 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: d4d5216e7a965ca194f6b1c9dee84cecab2674e5 Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa,shimooka,mumumu -->
 <section xml:id="filesystem.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;

--- a/reference/iconv/ini.xml
+++ b/reference/iconv/ini.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 6dfe0767250cdbdf509223f6bc266557b0a3fec9 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: d4d5216e7a965ca194f6b1c9dee84cecab2674e5 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi,mumumu -->
 <section xml:id="iconv.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;

--- a/reference/image/ini.xml
+++ b/reference/image/ini.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 6dfe0767250cdbdf509223f6bc266557b0a3fec9 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: d4d5216e7a965ca194f6b1c9dee84cecab2674e5 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: shimooka,mumumu -->
 <section xml:id="image.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;

--- a/reference/imagick/ini.xml
+++ b/reference/imagick/ini.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: takagi Status: ready -->
+<!-- EN-Revision: d4d5216e7a965ca194f6b1c9dee84cecab2674e5 Maintainer: takagi Status: ready -->
 <section xml:id="imagick.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;
  &extension.runtime;

--- a/reference/imap/ini.xml
+++ b/reference/imap/ini.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: takagi Status: ready -->
+<!-- EN-Revision: d4d5216e7a965ca194f6b1c9dee84cecab2674e5 Maintainer: takagi Status: ready -->
 
 <section xml:id="imap.configuration" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.runtime;

--- a/reference/ldap/ini.xml
+++ b/reference/ldap/ini.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 6dfe0767250cdbdf509223f6bc266557b0a3fec9 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: d4d5216e7a965ca194f6b1c9dee84cecab2674e5 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi -->
 <section xml:id="ldap.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;

--- a/reference/mbstring/ini.xml
+++ b/reference/mbstring/ini.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: af844f698b38d1460464bf913a80f2397980c534 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: d4d5216e7a965ca194f6b1c9dee84cecab2674e5 Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa,mumumu -->
 <section xml:id="mbstring.configuration" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.runtime;

--- a/reference/memcached/ini.xml
+++ b/reference/memcached/ini.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9e534c19272a88cf031748348d54143f0e3ea413 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: d4d5216e7a965ca194f6b1c9dee84cecab2674e5 Maintainer: mumumu Status: ready -->
 <section xml:id="memcached.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;
  &extension.runtime;

--- a/reference/mysql_xdevapi/ini.xml
+++ b/reference/mysql_xdevapi/ini.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 40667918dcff1d5c9f7ecdc88b5caca24ba0686c Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: d4d5216e7a965ca194f6b1c9dee84cecab2674e5 Maintainer: mumumu Status: ready -->
 
 <section xml:id="mysql-xdevapi.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;

--- a/reference/pcre/ini.xml
+++ b/reference/pcre/ini.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: a0ae28d3bc85f927c22649ebd9a590b921534b7d Maintainer: takagi Status: ready -->
+<!-- EN-Revision: d4d5216e7a965ca194f6b1c9dee84cecab2674e5 Maintainer: takagi Status: ready -->
 <section xml:id="pcre.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;
  &extension.runtime;

--- a/reference/pdo_mysql/ini.xml
+++ b/reference/pdo_mysql/ini.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: takagi Status: ready -->
+<!-- EN-Revision: d4d5216e7a965ca194f6b1c9dee84cecab2674e5 Maintainer: takagi Status: ready -->
 <section xml:id="pdo-mysql.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;
  &extension.runtime;

--- a/reference/pdo_odbc/ini.xml
+++ b/reference/pdo_odbc/ini.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <!-- $Revision$ -->
-<!-- EN-Revision: aab33d644359aba597e810e2fc0c0caa0d347c9c Maintainer: takagi Status: ready -->
+<!-- EN-Revision: d4d5216e7a965ca194f6b1c9dee84cecab2674e5 Maintainer: takagi Status: ready -->
 <section xml:id="pdo-odbc.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;
  &extension.runtime;

--- a/reference/pgsql/ini.xml
+++ b/reference/pgsql/ini.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: a0ae28d3bc85f927c22649ebd9a590b921534b7d Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: d4d5216e7a965ca194f6b1c9dee84cecab2674e5 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi -->
 <section xml:id="pgsql.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;

--- a/reference/soap/ini.xml
+++ b/reference/soap/ini.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 6dfe0767250cdbdf509223f6bc266557b0a3fec9 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: d4d5216e7a965ca194f6b1c9dee84cecab2674e5 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: shimooka -->
 
 <section xml:id="soap.configuration" xmlns="http://docbook.org/ns/docbook">

--- a/reference/sqlite3/ini.xml
+++ b/reference/sqlite3/ini.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 65716f4761484e314ee86fa23493f00f7823ace1 Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: d4d5216e7a965ca194f6b1c9dee84cecab2674e5 Maintainer: mumumu Status: ready -->
 
 <section xml:id="sqlite3.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;

--- a/reference/taint/ini.xml
+++ b/reference/taint/ini.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: takagi Status: ready -->
+<!-- EN-Revision: d4d5216e7a965ca194f6b1c9dee84cecab2674e5 Maintainer: takagi Status: ready -->
  
 <section xml:id="taint.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;

--- a/reference/tidy/ini.xml
+++ b/reference/tidy/ini.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: f9c4a68ef4f89e51e6d9b905ad3ddb6492386dd3 Maintainer: shimooka Status: ready -->
+<!-- EN-Revision: d4d5216e7a965ca194f6b1c9dee84cecab2674e5 Maintainer: shimooka Status: ready -->
 <!-- CREDITS: hirokawa, shimooka -->
 <section xml:id="tidy.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;

--- a/reference/v8js/ini.xml
+++ b/reference/v8js/ini.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: takagi Status: ready -->
+<!-- EN-Revision: d4d5216e7a965ca194f6b1c9dee84cecab2674e5 Maintainer: takagi Status: ready -->
 
 <section xml:id="v8js.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;

--- a/reference/var/ini.xml
+++ b/reference/var/ini.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ce3a2d381693ccbc10cc4a808c3eb853f3c85c9e Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: d4d5216e7a965ca194f6b1c9dee84cecab2674e5 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: shimooka -->
 <section xml:id="var.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;

--- a/reference/wincache/ini.xml
+++ b/reference/wincache/ini.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: takagi Status: ready -->
+<!-- EN-Revision: d4d5216e7a965ca194f6b1c9dee84cecab2674e5 Maintainer: takagi Status: ready -->
 <section xml:id="wincache.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;
  &extension.runtime;

--- a/reference/yaml/ini.xml
+++ b/reference/yaml/ini.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: takagi Status: ready -->
+<!-- EN-Revision: d4d5216e7a965ca194f6b1c9dee84cecab2674e5 Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 
 <section xml:id="yaml.configuration" xmlns="http://docbook.org/ns/docbook">

--- a/reference/zlib/ini.xml
+++ b/reference/zlib/ini.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 6dfe0767250cdbdf509223f6bc266557b0a3fec9 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: d4d5216e7a965ca194f6b1c9dee84cecab2674e5 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: shimooka -->
 <section xml:id="zlib.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;


### PR DESCRIPTION
394950500 は php/doc-en@d4d5216 の内容（PHP_INI_* を INI_* 定数へ置き換え）を
ja に適用したが、EN-Revision は更新していなかった。26 ファイルは現在も
EN-Revision が d4d5216 より前のコミットを指しているため、d4d5216 に更新する。

訳文・マークアップの変更はない。

- appendices/ini.sections.xml
- reference/{apache,curl,datetime,filesystem,iconv,image,imagick,imap,ldap,
  mbstring,memcached,mysql_xdevapi,pcre,pdo_mysql,pdo_odbc,pgsql,soap,sqlite3,
  taint,tidy,v8js,var,wincache,yaml,zlib}/ini.xml
