### PR TITLE
属性シグネチャの原文の更新に追従 (58ファイル)

### DIFF
--- a/reference/curl/functions/curl-close.xml
+++ b/reference/curl/functions/curl-close.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 86c8ebd19ed93843f293bdcecc9ce68cb4ab57bc Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: shimooka -->
 <refentry xml:id="function.curl-close" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -15,7 +15,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.5', message: "as it has no effect since PHP 8.0")]</modifier>
    <type>void</type><methodname>curl_close</methodname>
    <methodparam><type>CurlHandle</type><parameter>handle</parameter></methodparam>
   </methodsynopsis>

--- a/reference/curl/functions/curl-share-close.xml
+++ b/reference/curl/functions/curl-share-close.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 29c3d13980c8b29b700afd85c916e064638a7944 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 
 <refentry xml:id="function.curl-share-close" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -16,7 +16,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.5', message: "as it has no effect since PHP 8.0")]</modifier>
    <type>void</type><methodname>curl_share_close</methodname>
    <methodparam><type>CurlShareHandle</type><parameter>share_handle</parameter></methodparam>
   </methodsynopsis>

--- a/reference/datetime/datetimeinterface/wakeup.xml
+++ b/reference/datetime/datetimeinterface/wakeup.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ce98b568f85353c4bf263133f09c4db9294833f9 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: takagi Status: ready -->
 
 <refentry xml:id="datetime.wakeup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -17,17 +17,17 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="DateTime">
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.5', message: 'this method is obsolete, as serialization hooks are provided by __unserialize() and __serialize()')]</modifier>
    <modifier>public</modifier> <type>void</type><methodname>DateTime::__wakeup</methodname>
    <void/>
   </methodsynopsis>
   <methodsynopsis role="DateTimeImmutable">
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.5', message: 'this method is obsolete, as serialization hooks are provided by __unserialize() and __serialize()')]</modifier>
    <modifier>public</modifier> <type>void</type><methodname>DateTimeImmutable::__wakeup</methodname>
    <void/>
   </methodsynopsis>
   <methodsynopsis role="DateTimeInterface">
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.5', message: 'this method is obsolete, as serialization hooks are provided by __unserialize() and __serialize()')]</modifier>
    <modifier>public</modifier> <type>void</type><methodname>DateTimeInterface::__wakeup</methodname>
    <void/>
   </methodsynopsis>

--- a/reference/datetime/functions/date-sunrise.xml
+++ b/reference/datetime/functions/date-sunrise.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="function.date-sunrise" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -23,7 +23,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.1', message: 'use date_sun_info() instead')]</modifier>
    <type class="union"><type>string</type><type>int</type><type>float</type><type>false</type></type><methodname>date_sunrise</methodname>
    <methodparam><type>int</type><parameter>timestamp</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>returnFormat</parameter><initializer><constant>SUNFUNCS_RET_STRING</constant></initializer></methodparam>

--- a/reference/datetime/functions/date-sunset.xml
+++ b/reference/datetime/functions/date-sunset.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="function.date-sunset" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -23,7 +23,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.1', message: 'use date_sun_info() instead')]</modifier>
    <type class="union"><type>string</type><type>int</type><type>float</type><type>false</type></type><methodname>date_sunset</methodname>
    <methodparam><type>int</type><parameter>timestamp</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>returnFormat</parameter><initializer><constant>SUNFUNCS_RET_STRING</constant></initializer></methodparam>

--- a/reference/datetime/functions/gmstrftime.xml
+++ b/reference/datetime/functions/gmstrftime.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 6c27f7044c7d42c23685afa916e7d7a44cf2bbb2 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: shimooka -->
 <refentry xml:id="function.gmstrftime" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -21,7 +21,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.1', message: 'use IntlDateFormatter::format() instead')]</modifier>
    <type class="union"><type>string</type><type>false</type></type><methodname>gmstrftime</methodname>
    <methodparam><type>string</type><parameter>format</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>timestamp</parameter><initializer>&null;</initializer></methodparam>

--- a/reference/datetime/functions/strftime.xml
+++ b/reference/datetime/functions/strftime.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: shimooka,mumumu -->
 <refentry xml:id="function.strftime" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -21,7 +21,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.1', message: 'use IntlDateFormatter::format() instead')]</modifier>
    <type class="union"><type>string</type><type>false</type></type><methodname>strftime</methodname>
    <methodparam><type>string</type><parameter>format</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>timestamp</parameter><initializer>&null;</initializer></methodparam>

--- a/reference/datetime/functions/strptime.xml
+++ b/reference/datetime/functions/strptime.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: takagi Status: ready -->
 <refentry xml:id="function.strptime" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
    <refnamediv>
     <refname>strptime</refname>
@@ -16,7 +16,7 @@
    <refsect1 role="description">
     &reftitle.description;
     <methodsynopsis>
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.2', message: 'use date_parse_from_format() (for locale-independent parsing), or IntlDateFormatter::parse() (for locale-dependent parsing) instead')]</modifier>
    <type class="union"><type>array</type><type>false</type></type><methodname>strptime</methodname>
    <methodparam><type>string</type><parameter>timestamp</parameter></methodparam>
    <methodparam><type>string</type><parameter>format</parameter></methodparam>

--- a/reference/enchant/functions/enchant-broker-free-dict.xml
+++ b/reference/enchant/functions/enchant-broker-free-dict.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 940ea8c1b2b727eb0f3f6412305ab699b9b47cc6 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.enchant-broker-free-dict">
+<refentry xml:id="function.enchant-broker-free-dict" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>enchant_broker_free_dict</refname>
   <refpurpose>辞書リソースを解放する</refpurpose>
@@ -15,7 +15,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.0', message: 'as EnchantDictionary objects are freed automatically')]</modifier>
    <type>bool</type><methodname>enchant_broker_free_dict</methodname>
    <methodparam><type>EnchantDictionary</type><parameter>dictionary</parameter></methodparam>
   </methodsynopsis>

--- a/reference/enchant/functions/enchant-broker-free.xml
+++ b/reference/enchant/functions/enchant-broker-free.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: a6b55f8de61955b35c83fec32651201cce4aa383 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.enchant-broker-free">
+<refentry xml:id="function.enchant-broker-free" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>enchant_broker_free</refname>
   <refpurpose>ブローカーリソースおよびその辞書を解放する</refpurpose>
@@ -15,7 +15,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.0', message: 'as EnchantBroker objects are freed automatically')]</modifier>
    <type>bool</type><methodname>enchant_broker_free</methodname>
    <methodparam><type>EnchantBroker</type><parameter>broker</parameter></methodparam>
   </methodsynopsis>

--- a/reference/enchant/functions/enchant-broker-get-dict-path.xml
+++ b/reference/enchant/functions/enchant-broker-get-dict-path.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: a6b55f8de61955b35c83fec32651201cce4aa383 Maintainer: mumumu Status: ready -->
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.enchant-broker-get-dict-path">
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: mumumu Status: ready -->
+<refentry xml:id="function.enchant-broker-get-dict-path" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>enchant_broker_get_dict_path</refname>
   <refpurpose>指定されたバックエンドの辞書のパスを取得する</refpurpose>
@@ -14,7 +14,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.0')]</modifier>
    <type class="union"><type>string</type><type>false</type></type><methodname>enchant_broker_get_dict_path</methodname>
    <methodparam><type>EnchantBroker</type><parameter>broker</parameter></methodparam>
    <methodparam><type>int</type><parameter>type</parameter></methodparam>

--- a/reference/enchant/functions/enchant-broker-set-dict-path.xml
+++ b/reference/enchant/functions/enchant-broker-set-dict-path.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: a6b55f8de61955b35c83fec32651201cce4aa383 Maintainer: mumumu Status: ready -->
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.enchant-broker-set-dict-path">
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: mumumu Status: ready -->
+<refentry xml:id="function.enchant-broker-set-dict-path" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>enchant_broker_set_dict_path</refname>
   <refpurpose>指定されたバックエンドの辞書のパスを設定する</refpurpose>
@@ -14,7 +14,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.0')]</modifier>
    <type>bool</type><methodname>enchant_broker_set_dict_path</methodname>
    <methodparam><type>EnchantBroker</type><parameter>broker</parameter></methodparam>
    <methodparam><type>int</type><parameter>type</parameter></methodparam>

--- a/reference/fileinfo/functions/finfo-close.xml
+++ b/reference/fileinfo/functions/finfo-close.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: takagi Status: ready -->
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.finfo-close">
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: takagi Status: ready -->
+<refentry xml:id="function.finfo-close" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>finfo_close</refname>
   <refpurpose>fileinfo インスタンスを閉じる</refpurpose>
@@ -12,7 +12,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.5', message: 'as finfo objects are freed automatically')]</modifier>
    <type>true</type><methodname>finfo_close</methodname>
    <methodparam><type>finfo</type><parameter>finfo</parameter></methodparam>
   </methodsynopsis>

--- a/reference/image/functions/imagedestroy.xml
+++ b/reference/image/functions/imagedestroy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: shimooka -->
 <refentry xml:id="function.imagedestroy" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,7 +13,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.5', message: "as it has no effect since PHP 8.0")]</modifier>
    <type>true</type><methodname>imagedestroy</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
   </methodsynopsis>

--- a/reference/libxml/functions/libxml-disable-entity-loader.xml
+++ b/reference/libxml/functions/libxml-disable-entity-loader.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c62ef37e0d58067b393a6cf3a14aefed90bc0bff Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 
 <refentry xml:id="function.libxml-disable-entity-loader" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -16,7 +16,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.0', message: 'as external entity loading is disabled by default')]</modifier>
    <type>bool</type><methodname>libxml_disable_entity_loader</methodname>
    <methodparam choice="opt"><type>bool</type><parameter>disable</parameter><initializer>&true;</initializer></methodparam>
   </methodsynopsis>

--- a/reference/mhash/functions/mhash-count.xml
+++ b/reference/mhash/functions/mhash-count.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: hirokawa Status: ready -->
 <refentry xml:id="function.mhash-count" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mhash_count</refname>
@@ -14,7 +14,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.1')]</modifier>
    <type>int</type><methodname>mhash_count</methodname>
    <void/>
   </methodsynopsis>

--- a/reference/mhash/functions/mhash-get-block-size.xml
+++ b/reference/mhash/functions/mhash-get-block-size.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: hirokawa Status: ready -->
 <refentry xml:id="function.mhash-get-block-size" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mhash_get_block_size</refname>
@@ -14,7 +14,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.1')]</modifier>
    <type class="union"><type>int</type><type>false</type></type><methodname>mhash_get_block_size</methodname>
    <methodparam><type>int</type><parameter>algo</parameter></methodparam>
   </methodsynopsis>

--- a/reference/mhash/functions/mhash-get-hash-name.xml
+++ b/reference/mhash/functions/mhash-get-hash-name.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: hirokawa Status: ready -->
 <refentry xml:id="function.mhash-get-hash-name" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mhash_get_hash_name</refname>
@@ -14,7 +14,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.1')]</modifier>
    <type class="union"><type>string</type><type>false</type></type><methodname>mhash_get_hash_name</methodname>
    <methodparam><type>int</type><parameter>algo</parameter></methodparam>
   </methodsynopsis>

--- a/reference/mhash/functions/mhash-keygen-s2k.xml
+++ b/reference/mhash/functions/mhash-keygen-s2k.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: hirokawa Status: ready -->
 <refentry xml:id="function.mhash-keygen-s2k" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>mhash_keygen_s2k</refname>
@@ -14,7 +14,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.1')]</modifier>
    <type class="union"><type>string</type><type>false</type></type><methodname>mhash_keygen_s2k</methodname>
    <methodparam><type>int</type><parameter>algo</parameter></methodparam>
    <methodparam><type>string</type><parameter>password</parameter></methodparam>

--- a/reference/mhash/functions/mhash.xml
+++ b/reference/mhash/functions/mhash.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: hirokawa Status: ready -->
 <refentry xml:id="function.mhash" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mhash</refname>
@@ -14,7 +14,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.1')]</modifier>
    <type>string</type><methodname>mhash</methodname>
    <methodparam><type>int</type><parameter>hash</parameter></methodparam>
    <methodparam><type>string</type><parameter>data</parameter></methodparam>

--- a/reference/mysqli/mysqli/get-client-info.xml
+++ b/reference/mysqli/mysqli/get-client-info.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="mysqli.get-client-info" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -15,7 +15,7 @@
   <para>&style.oop;</para>
   <fieldsynopsis><type>string</type><varname linkend="mysqli.get-client-info">mysqli-&gt;client_info</varname></fieldsynopsis>
   <methodsynopsis role="mysqli">
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.1', message: 'use mysqli_get_client_info() instead')]</modifier>
    <modifier>public</modifier> <type>string</type><methodname>mysqli::get_client_info</methodname>
    <void/>
   </methodsynopsis>

--- a/reference/mysqli/mysqli/init.xml
+++ b/reference/mysqli/mysqli/init.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: mumumu Status: ready -->
 
 <refentry xml:id="mysqli.init" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,7 +13,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="mysqli">
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.1', message: 'replace calls to parent::init() with parent::__construct()')]</modifier>
    <modifier>public</modifier> <type class="union"><type>bool</type><type>null</type></type><methodname>mysqli::init</methodname>
    <void/>
   </methodsynopsis>

--- a/reference/mysqli/mysqli/kill.xml
+++ b/reference/mysqli/mysqli/kill.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="mysqli.kill" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -17,13 +17,13 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="mysqli">
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.4', message: 'use KILL CONNECTION/QUERY SQL statement instead')]</modifier>
    <modifier>public</modifier> <type>bool</type><methodname>mysqli::kill</methodname>
    <methodparam><type>int</type><parameter>process_id</parameter></methodparam>
   </methodsynopsis>
   <para>&style.procedural;</para>
   <methodsynopsis>
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.4', message: 'use KILL CONNECTION/QUERY SQL statement instead')]</modifier>
    <type>bool</type><methodname>mysqli_kill</methodname>
    <methodparam><type>mysqli</type><parameter>mysql</parameter></methodparam>
    <methodparam><type>int</type><parameter>process_id</parameter></methodparam>

--- a/reference/mysqli/mysqli/ping.xml
+++ b/reference/mysqli/mysqli/ping.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="mysqli.ping" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -17,13 +17,13 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="mysqli">
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.4', message: 'because the reconnect feature has been removed in PHP 8.2 and this method is now redundant')]</modifier>
    <modifier>public</modifier> <type>bool</type><methodname>mysqli::ping</methodname>
    <void/>
   </methodsynopsis>
   <para>&style.procedural;</para>
   <methodsynopsis>
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.4', message: 'because the reconnect feature has been removed in PHP 8.2 and this function is now redundant')]</modifier>
    <type>bool</type><methodname>mysqli_ping</methodname>
    <methodparam><type>mysqli</type><parameter>mysql</parameter></methodparam>
   </methodsynopsis>

--- a/reference/mysqli/mysqli/refresh.xml
+++ b/reference/mysqli/mysqli/refresh.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="mysqli.refresh" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -17,13 +17,13 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="mysqli">
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.4', message: 'use FLUSH SQL statement instead')]</modifier>
    <modifier>public</modifier> <type>bool</type><methodname>mysqli::refresh</methodname>
    <methodparam><type>int</type><parameter>flags</parameter></methodparam>
   </methodsynopsis>
   <para>&style.procedural;</para>
   <methodsynopsis>
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.4', message: 'use FLUSH SQL statement instead')]</modifier>
    <type>bool</type><methodname>mysqli_refresh</methodname>
    <methodparam><type>mysqli</type><parameter>mysql</parameter></methodparam>
    <methodparam><type>int</type><parameter>flags</parameter></methodparam>

--- a/reference/openssl/functions/openssl-free-key.xml
+++ b/reference/openssl/functions/openssl-free-key.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi -->
 <refentry xml:id="function.openssl-free-key" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -15,7 +15,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.0', message: 'as OpenSSLAsymmetricKey objects are freed automatically')]</modifier>
    <type>void</type><methodname>openssl_free_key</methodname>
    <methodparam><type>OpenSSLAsymmetricKey</type><parameter>key</parameter></methodparam>
   </methodsynopsis>

--- a/reference/openssl/functions/openssl-password-hash.xml
+++ b/reference/openssl/functions/openssl-password-hash.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 29cecd7f180bfdae00ebd6128b6dd4255eb30365 Maintainer: KentarouTakeda Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: KentarouTakeda Status: ready -->
 <refentry xml:id="function.openssl-password-hash" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>openssl_password_hash</refname>
@@ -12,7 +12,7 @@
   <methodsynopsis>
    <type>string</type><methodname>openssl_password_hash</methodname>
    <methodparam><type>string</type><parameter>algo</parameter></methodparam>
-   <methodparam><type>string</type><parameter>password</parameter></methodparam>
+   <methodparam><modifier role="attribute">#[\SensitiveParameter]</modifier><type>string</type><parameter>password</parameter></methodparam>
    <methodparam choice="opt"><type>array</type><parameter>options</parameter><initializer>[]</initializer></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/openssl/functions/openssl-password-verify.xml
+++ b/reference/openssl/functions/openssl-password-verify.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 29cecd7f180bfdae00ebd6128b6dd4255eb30365 Maintainer: KentarouTakeda Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: KentarouTakeda Status: ready -->
 <refentry xml:id="function.openssl-password-verify" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>openssl_password_verify</refname>
@@ -12,7 +12,7 @@
   <methodsynopsis>
    <type>bool</type><methodname>openssl_password_verify</methodname>
    <methodparam><type>string</type><parameter>algo</parameter></methodparam>
-   <methodparam><type>string</type><parameter>password</parameter></methodparam>
+   <methodparam><modifier role="attribute">#[\SensitiveParameter]</modifier><type>string</type><parameter>password</parameter></methodparam>
    <methodparam><type>string</type><parameter>hash</parameter></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/openssl/functions/openssl-pkey-free.xml
+++ b/reference/openssl/functions/openssl-pkey-free.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: takagi Status: ready -->
 <refentry xml:id="function.openssl-pkey-free" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>openssl_pkey_free</refname>
@@ -14,7 +14,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.0', message: 'as OpenSSLAsymmetricKey objects are freed automatically')]</modifier>
    <type>void</type><methodname>openssl_pkey_free</methodname>
    <methodparam><type>OpenSSLAsymmetricKey</type><parameter>key</parameter></methodparam>
   </methodsynopsis>

--- a/reference/openssl/functions/openssl-x509-free.xml
+++ b/reference/openssl/functions/openssl-x509-free.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: hirokawa Status: ready -->
 <refentry xml:id="function.openssl-x509-free" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>openssl_x509_free</refname>
@@ -14,7 +14,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.0', message: 'as OpenSSLCertificate objects are freed automatically')]</modifier>
    <type>void</type><methodname>openssl_x509_free</methodname>
    <methodparam><type>OpenSSLCertificate</type><parameter>certificate</parameter></methodparam>
   </methodsynopsis>

--- a/reference/pgsql/functions/pg-change-password.xml
+++ b/reference/pgsql/functions/pg-change-password.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 491bd06bf430a9b0d9117a7b7c2c2b02a46ef84b Maintainer: KentarouTakeda Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: KentarouTakeda Status: ready -->
 <refentry xml:id="function.pg-change-password" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>pg_change_password</refname>
@@ -13,7 +13,7 @@
    <type>bool</type><methodname>pg_change_password</methodname>
    <methodparam><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
    <methodparam><type>string</type><parameter>user</parameter></methodparam>
-   <methodparam><type>string</type><parameter>password</parameter></methodparam>
+   <methodparam><modifier role="attribute">#[\SensitiveParameter]</modifier><type>string</type><parameter>password</parameter></methodparam>
   </methodsynopsis>
   <simpara>
    <function>pg_change_password</function> は、

--- a/reference/random/functions/lcg-value.xml
+++ b/reference/random/functions/lcg-value.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: hirokawa Status: ready -->
 <!-- Credits: mumumu,jdkfx -->
 <refentry xml:id="function.lcg-value" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -15,7 +15,7 @@
  <refsect1 role="description">
   &reftitle.description;
    <methodsynopsis>
-    <modifier role="attribute">#[\Deprecated]</modifier>
+    <modifier role="attribute">#[\Deprecated(since: '8.4', message: "use \\Random\\Randomizer::getFloat() instead")]</modifier>
     <type>float</type><methodname>lcg_value</methodname>
     <void/>
    </methodsynopsis>

--- a/reference/reflection/reflectionfunction/isdisabled.xml
+++ b/reference/reflection/reflectionfunction/isdisabled.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: takagi Status: ready -->
 
 <refentry xml:id="reflectionfunction.isdisabled" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,7 +15,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="ReflectionFunction">
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.0', message: "as ReflectionFunction can no longer be constructed for disabled functions")]</modifier>
    <modifier>public</modifier> <type>bool</type><methodname>ReflectionFunction::isDisabled</methodname>
    <void/>
   </methodsynopsis>

--- a/reference/reflection/reflectionmethod/setaccessible.xml
+++ b/reference/reflection/reflectionmethod/setaccessible.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e5c8e7add9291c70be2ecd046de6ecfd034545a9 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 
 <refentry xml:id="reflectionmethod.setaccessible" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -16,7 +16,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="ReflectionMethod">
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.5', message: "as it has no effect since PHP 8.1")]</modifier>
    <modifier>public</modifier> <type>void</type><methodname>ReflectionMethod::setAccessible</methodname>
    <methodparam><type>bool</type><parameter>accessible</parameter></methodparam>
   </methodsynopsis>

--- a/reference/reflection/reflectionparameter/getclass.xml
+++ b/reference/reflection/reflectionparameter/getclass.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 
 <refentry xml:id="reflectionparameter.getclass" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -16,7 +16,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="ReflectionParameter">
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.0', message: "use ReflectionParameter::getType() instead")]</modifier>
    <modifier>public</modifier> <type class="union"><type>ReflectionClass</type><type>null</type></type><methodname>ReflectionParameter::getClass</methodname>
    <void/>
   </methodsynopsis>

--- a/reference/reflection/reflectionparameter/isarray.xml
+++ b/reference/reflection/reflectionparameter/isarray.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: takagi Status: ready -->
 
 <refentry xml:id="reflectionparameter.isarray" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -16,7 +16,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="ReflectionParameter">
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.0', message: "use ReflectionParameter::getType() instead")]</modifier>
    <modifier>public</modifier> <type>bool</type><methodname>ReflectionParameter::isArray</methodname>
    <void/>
   </methodsynopsis>

--- a/reference/reflection/reflectionparameter/iscallable.xml
+++ b/reference/reflection/reflectionparameter/iscallable.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: takagi Status: ready -->
 
 <refentry xml:id="reflectionparameter.iscallable" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -16,7 +16,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="ReflectionParameter">
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.0', message: "use ReflectionParameter::getType() instead")]</modifier>
    <modifier>public</modifier> <type>bool</type><methodname>ReflectionParameter::isCallable</methodname>
    <void/>
   </methodsynopsis>

--- a/reference/reflection/reflectionproperty/setaccessible.xml
+++ b/reference/reflection/reflectionproperty/setaccessible.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e5c8e7add9291c70be2ecd046de6ecfd034545a9 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 
 <refentry xml:id="reflectionproperty.setaccessible" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -16,7 +16,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="ReflectionProperty">
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.5', message: "as it has no effect since PHP 8.1")]</modifier>
    <modifier>public</modifier> <type>void</type><methodname>ReflectionProperty::setAccessible</methodname>
    <methodparam><type>bool</type><parameter>accessible</parameter></methodparam>
   </methodsynopsis>

--- a/reference/shmop/functions/shmop-close.xml
+++ b/reference/shmop/functions/shmop-close.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 41d34439ea8cae2bb1204264c1bce15d88284503 Maintainer: mumumu Status: ready -->
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.shmop-close">
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: mumumu Status: ready -->
+<refentry xml:id="function.shmop-close" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>shmop_close</refname>
   <refpurpose>共有メモリブロックを閉じる</refpurpose>
@@ -14,7 +14,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.0', message: 'as Shmop objects are freed automatically')]</modifier>
    <type>void</type><methodname>shmop_close</methodname>
    <methodparam><type>Shmop</type><parameter>shmop</parameter></methodparam>
   </methodsynopsis>

--- a/reference/spl/splfixedarray/wakeup.xml
+++ b/reference/spl/splfixedarray/wakeup.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: takagi Status: ready -->
 <refentry xml:id="splfixedarray.wakeup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SplFixedArray::__wakeup</refname>
@@ -14,7 +14,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="SplFixedArray">
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.4', message: 'this method is obsolete, as serialization hooks are provided by __unserialize() and __serialize()')]</modifier>
    <modifier>public</modifier> <type>void</type><methodname>SplFixedArray::__wakeup</methodname>
    <void/>
   </methodsynopsis>

--- a/reference/spl/splobjectstorage/attach.xml
+++ b/reference/spl/splobjectstorage/attach.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e5c8e7add9291c70be2ecd046de6ecfd034545a9 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="splobjectstorage.attach" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,7 +15,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="SplObjectStorage">
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.5', message: "use method SplObjectStorage::offsetSet() instead")]</modifier>
    <modifier>public</modifier> <type>void</type><methodname>SplObjectStorage::attach</methodname>
    <methodparam><type>object</type><parameter>object</parameter></methodparam>
    <methodparam choice="opt"><type>mixed</type><parameter>info</parameter><initializer>&null;</initializer></methodparam>

--- a/reference/spl/splobjectstorage/contains.xml
+++ b/reference/spl/splobjectstorage/contains.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e5c8e7add9291c70be2ecd046de6ecfd034545a9 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: takagi Status: ready -->
 <refentry xml:id="splobjectstorage.contains" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SplObjectStorage::contains</refname>
@@ -14,7 +14,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="SplObjectStorage">
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.5', message: "use method SplObjectStorage::offsetExists() instead")]</modifier>
    <modifier>public</modifier> <type>bool</type><methodname>SplObjectStorage::contains</methodname>
    <methodparam><type>object</type><parameter>object</parameter></methodparam>
   </methodsynopsis>

--- a/reference/spl/splobjectstorage/detach.xml
+++ b/reference/spl/splobjectstorage/detach.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e5c8e7add9291c70be2ecd046de6ecfd034545a9 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: takagi Status: ready -->
 <refentry xml:id="splobjectstorage.detach" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SplObjectStorage::detach</refname>
@@ -14,7 +14,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="SplObjectStorage">
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.5', message: "use method SplObjectStorage::offsetUnset() instead")]</modifier>
    <modifier>public</modifier> <type>void</type><methodname>SplObjectStorage::detach</methodname>
    <methodparam><type>object</type><parameter>object</parameter></methodparam>
   </methodsynopsis>

--- a/reference/strings/functions/utf8-decode.xml
+++ b/reference/strings/functions/utf8-decode.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: hirokawa Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="function.utf8-decode" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -17,7 +17,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.2', message: 'visit the php.net documentation for various alternatives')]</modifier>
    <type>string</type><methodname>utf8_decode</methodname>
    <methodparam><type>string</type><parameter>string</parameter></methodparam>
   </methodsynopsis>

--- a/reference/strings/functions/utf8-encode.xml
+++ b/reference/strings/functions/utf8-encode.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: hirokawa Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="function.utf8-encode" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -15,7 +15,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.2', message: 'visit the php.net documentation for various alternatives')]</modifier>
    <type>string</type><methodname>utf8_encode</methodname>
    <methodparam><type>string</type><parameter>string</parameter></methodparam>
   </methodsynopsis>

--- a/reference/uodbc/functions/odbc-result-all.xml
+++ b/reference/uodbc/functions/odbc-result-all.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ed1aff13602c94f86344bdd7c4fbc31f5a71bf84 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: hirokawa Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="function.odbc-result-all" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -15,6 +15,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
+   <modifier role="attribute">#[\Deprecated(since: '8.1')]</modifier>
    <type class="union"><type>int</type><type>false</type></type><methodname>odbc_result_all</methodname>
    <methodparam><type>Odbc\Result</type><parameter>statement</parameter></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>format</parameter><initializer>""</initializer></methodparam>

--- a/reference/xml/functions/xml-parser-free.xml
+++ b/reference/xml/functions/xml-parser-free.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 00a8ae0c879a70f4bc96a707212482f0fcbd9ac6 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: hirokawa Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="function.xml-parser-free" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -15,7 +15,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.5', message: "as it has no effect since PHP 8.0")]</modifier>
    <type>bool</type><methodname>xml_parser_free</methodname>
    <methodparam><type>XMLParser</type><parameter>parser</parameter></methodparam>
   </methodsynopsis>

--- a/reference/xml/functions/xml-set-object.xml
+++ b/reference/xml/functions/xml-set-object.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: hirokawa Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="function.xml-set-object" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -15,7 +15,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.4', message: 'provide a proper method callable to xml_set_*_handler() functions')]</modifier>
    <type>true</type><methodname>xml_set_object</methodname>
    <methodparam><type>XMLParser</type><parameter>parser</parameter></methodparam>
    <methodparam><type>object</type><parameter>object</parameter></methodparam>

--- a/reference/zip/functions/zip-close.xml
+++ b/reference/zip/functions/zip-close.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 <!-- splitted from ./ja/functions/zip.xml, last change in rev 1.1 -->
-<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi,mumumu -->
 <refentry xml:id="function.zip-close" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -16,7 +16,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.0', message: 'use ZipArchive::close() instead')]</modifier>
    <type>void</type><methodname>zip_close</methodname>
    <methodparam><type>resource</type><parameter>zip</parameter></methodparam>
   </methodsynopsis>

--- a/reference/zip/functions/zip-entry-close.xml
+++ b/reference/zip/functions/zip-entry-close.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi,mumumu -->
 <refentry xml:id="function.zip-entry-close" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -15,7 +15,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.0')]</modifier>
    <type>bool</type><methodname>zip_entry_close</methodname>
    <methodparam><type>resource</type><parameter>zip_entry</parameter></methodparam>
   </methodsynopsis>

--- a/reference/zip/functions/zip-entry-compressedsize.xml
+++ b/reference/zip/functions/zip-entry-compressedsize.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: hirokawa Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="function.zip-entry-compressedsize" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -15,7 +15,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.0', message: 'use ZipArchive::statIndex() instead')]</modifier>
    <type class="union"><type>int</type><type>false</type></type><methodname>zip_entry_compressedsize</methodname>
    <methodparam><type>resource</type><parameter>zip_entry</parameter></methodparam>
   </methodsynopsis>

--- a/reference/zip/functions/zip-entry-compressionmethod.xml
+++ b/reference/zip/functions/zip-entry-compressionmethod.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: hirokawa Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="function.zip-entry-compressionmethod" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -15,7 +15,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.0', message: 'use ZipArchive::statIndex() instead')]</modifier>
    <type class="union"><type>string</type><type>false</type></type><methodname>zip_entry_compressionmethod</methodname>
    <methodparam><type>resource</type><parameter>zip_entry</parameter></methodparam>
   </methodsynopsis>

--- a/reference/zip/functions/zip-entry-filesize.xml
+++ b/reference/zip/functions/zip-entry-filesize.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: hirokawa Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="function.zip-entry-filesize" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -15,7 +15,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.0', message: 'use ZipArchive::statIndex() instead')]</modifier>
    <type class="union"><type>int</type><type>false</type></type><methodname>zip_entry_filesize</methodname>
    <methodparam><type>resource</type><parameter>zip_entry</parameter></methodparam>
   </methodsynopsis>

--- a/reference/zip/functions/zip-entry-name.xml
+++ b/reference/zip/functions/zip-entry-name.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: hirokawa Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="function.zip-entry-name" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -15,7 +15,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.0', message: 'use ZipArchive::statIndex() instead')]</modifier>
    <type class="union"><type>string</type><type>false</type></type><methodname>zip_entry_name</methodname>
    <methodparam><type>resource</type><parameter>zip_entry</parameter></methodparam>
   </methodsynopsis>

--- a/reference/zip/functions/zip-entry-open.xml
+++ b/reference/zip/functions/zip-entry-open.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: hirokawa Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="function.zip-entry-open" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -15,7 +15,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.0')]</modifier>
    <type>bool</type><methodname>zip_entry_open</methodname>
    <methodparam><type>resource</type><parameter>zip_dp</parameter></methodparam>
    <methodparam><type>resource</type><parameter>zip_entry</parameter></methodparam>

--- a/reference/zip/functions/zip-entry-read.xml
+++ b/reference/zip/functions/zip-entry-read.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: hirokawa Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="function.zip-entry-read" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -15,7 +15,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.0', message: 'use ZipArchive::getFromIndex() instead')]</modifier>
    <type class="union"><type>string</type><type>false</type></type><methodname>zip_entry_read</methodname>
    <methodparam><type>resource</type><parameter>zip_entry</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>len</parameter><initializer>1024</initializer></methodparam>

--- a/reference/zip/functions/zip-open.xml
+++ b/reference/zip/functions/zip-open.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: hirokawa Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="function.zip-open" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -15,7 +15,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.0', message: 'use ZipArchive::open() instead')]</modifier>
    <type class="union"><type>resource</type><type>int</type><type>false</type></type><methodname>zip_open</methodname>
    <methodparam><type>string</type><parameter>filename</parameter></methodparam>
   </methodsynopsis>

--- a/reference/zip/functions/zip-read.xml
+++ b/reference/zip/functions/zip-read.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 8dc5bef8981ffd33c8c51f7f33414fcf5c03767a Maintainer: hirokawa Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="function.zip-read" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -15,7 +15,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier role="attribute">#[\Deprecated]</modifier>
+   <modifier role="attribute">#[\Deprecated(since: '8.0', message: 'use ZipArchive::statIndex() instead')]</modifier>
    <type class="union"><type>resource</type><type>false</type></type><methodname>zip_read</methodname>
    <methodparam><type>resource</type><parameter>zip</parameter></methodparam>
   </methodsynopsis>


### PR DESCRIPTION
php/doc-en@8dc5bef8（php/doc-en#5631）に追従しました。変更箇所は属性シグネチャと
`<refentry>` の属性順のみで、日本語の訳文は変更していません。

### `#[\Deprecated]` に since / message を付与（55件）

reference/ 配下: zip (10), reflection (6), datetime (6), mysqli (5), mhash (5),
spl (4), enchant (4), openssl (3), xml (2), strings (2), curl (2), uodbc (1),
shmop (1), random (1), libxml (1), image (1), fileinfo (1)

### `#[\SensitiveParameter]` を付与（3件）

reference/openssl/functions/openssl-password-hash.xml,
reference/openssl/functions/openssl-password-verify.xml,
reference/pgsql/functions/pg-change-password.xml

### `<refentry>` の属性順を `xml:id` → `xmlns` に変更（6件・上記 55 件に含む）

reference/enchant/functions/* (4), reference/fileinfo/functions/finfo-close.xml,
reference/shmop/functions/shmop-close.xml

### その他

reference/uodbc/functions/odbc-result-all.xml は ja 側に `#[\Deprecated]` 行が
無かったため、置換ではなく追加で反映しています。
