### PR TITLE
array/info/strings/misc の原文の更新に追従 (16ファイル)

### DIFF
--- a/reference/array/functions/array-column.xml
+++ b/reference/array/functions/array-column.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 8bf3587d8f70239a65d9aa44d42ced8a696a3e86 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: b91033ba3d6831cfa2ef6745150cd5d6b4af65c9 Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="function.array-column" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -24,6 +24,14 @@
    入力配列内のカラム <parameter>index_key</parameter> の値をキーとし、
    カラム <parameter>column_key</parameter> を値とした配列が返されます。
   </para>
+  <simpara>
+   <parameter>array</parameter> は行のリストとして扱われ、
+   各行はそれ自体が配列またはオブジェクトです。
+   カラムとは、各行で <parameter>column_key</parameter> が指定する要素やプロパティのことです。
+   配列でもオブジェクトでもない行や、その要素やプロパティが存在しない行は、
+   エラーや警告を出さずにスキップされます。
+   <parameter>array</parameter> のキーが保持されることはありません。
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -32,25 +40,30 @@
     <varlistentry>
      <term><parameter>array</parameter></term>
      <listitem>
-      <para>
-       値を取り出したい多次元配列 (あるいはオブジェクトの配列)。
-       オブジェクトの配列を指定した場合は、public プロパティはそのまま取得できます。
-       protected や private なプロパティを取得したい場合は、そのクラスがマジックメソッド
-       <function>__get</function> および <function>__isset</function>
+      <simpara>
+       値を取り出したいリスト。各行は配列またはオブジェクトです。
+       行がオブジェクトの場合は、public プロパティを直接読み取れます。
+       public にアクセスできないプロパティを読み取るには、そのクラスがマジックメソッド
+       <link linkend="object.get">__get()</link> および
+       <link linkend="object.isset">__isset()</link>
        を実装している必要があります。
-      </para>
+       <link linkend="object.isset">__isset()</link> がない場合はその行がスキップされ、
+       <link linkend="object.isset">__isset()</link> はあるが
+       <link linkend="object.get">__get()</link> がない場合は
+       <exceptionname>Error</exceptionname> がスローされます。
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>column_key</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        値を返したいカラム。
        取得したいカラムの番号を整数値で指定することもできるし、
        連想配列のキーやプロパティの名前を指定することもできます。
-       &null; を指定すると、配列やオブジェクト全体を返します
+       &null; を指定すると、行全体を返します
        (<parameter>index_key</parameter> との組み合わせで、配列の並べ替えをするときに便利です)。
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
@@ -71,9 +84,10 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    入力配列の単一のカラムを表す値の配列を返します。
-  </para>
+   <parameter>column_key</parameter> が &null; の場合、行そのものを返します。
+  </simpara>
  </refsect1>
  <refsect1 role="changelog">
   &reftitle.changelog;
@@ -93,6 +107,19 @@
         <parameter>index_key</parameter> で指定されたカラムにオブジェクトが含まれていても、
         文字列にキャストされなくなりました。
         代わりに、<classname>TypeError</classname> が発生するようになっています。
+       </entry>
+      </row>
+      <row>
+       <entry>7.1.0</entry>
+       <entry>
+        プロパティのアクセス権が尊重されるようになりました。
+        これより前のバージョンでは、protected や private なプロパティが直接読み取られていました。
+       </entry>
+      </row>
+      <row>
+       <entry>7.0.0</entry>
+       <entry>
+        <parameter>array</parameter> の行に、配列だけでなくオブジェクトも指定できるようになりました。
        </entry>
       </row>
      </tbody>
@@ -250,7 +277,7 @@ Array
    <example>
     <title>
      オブジェクトの private プロパティ "name" から、マジックメソッド
-     <function>__isset</function> と <function>__get</function> を使って名前を取得する例
+     <link linkend="object.isset">__isset()</link> と <link linkend="object.get">__get()</link> を使って名前を取得する例
     </title>
     <programlisting role="php">
 <![CDATA[
@@ -298,7 +325,8 @@ Array
 ]]>
     </screen>
    </example>
-   <function>__isset</function> が用意されていなければ、空の配列が返されます。
+   <link linkend="object.isset">__isset()</link> が用意されていなければ、
+   そのオブジェクトに対応する要素は返される配列に含まれません。
   </para>
  </refsect1>
 

--- a/reference/array/functions/array-walk-recursive.xml
+++ b/reference/array/functions/array-walk-recursive.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <!-- $Revision$ -->
-<!-- EN-Revision: cec5275f23d2db648df30a5702b378044431be97 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 0d8ee2131b4da66a4d274c576da9137c2a7963d5 Maintainer: takagi Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="function.array-walk-recursive" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -20,6 +20,11 @@
    <parameter>callback</parameter>を適用します。
    この関数は配列の要素内を再帰的にたどっていきます。
   </para>
+  <simpara>
+   <parameter>array</parameter> にはオブジェクトを渡すこともできます。
+   その場合、まず<link linkend="language.types.array.casting">配列に変換</link>されたものとして扱われます。
+   配列とオブジェクトのどちらを渡した場合でも、内部のオブジェクトは再帰的にたどりません。
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -125,6 +130,44 @@ sour holds lemon
      キー '<literal>sweet</literal>' が表示されないことにお気づきでしょう。<type>array</type>
      を要素として持つキーは関数に渡されません。
     </para>
+   </example>
+  </para>
+  <simpara>
+   コールバックのパラメータをリファレンスとして渡せば、
+   <function>array_walk_recursive</function> で値をその場で更新することもできます。
+  </simpara>
+  <para>
+   <example>
+    <title>値をその場で更新する</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$sweet = ['a' => 'apple', 'b' => 'banana'];
+$fruits = ['sweet' => $sweet, 'sour' => 'lemon'];
+
+function test_update(&$item)
+{
+    $item = strtoupper($item);
+}
+
+function test_print($item, $key)
+{
+    echo "$key holds $item\n";
+}
+
+array_walk_recursive($fruits, 'test_update');
+array_walk_recursive($fruits, 'test_print');
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+a holds APPLE
+b holds BANANA
+sour holds LEMON
+]]>
+    </screen>
    </example>
   </para>
  </refsect1>

--- a/reference/array/functions/in-array.xml
+++ b/reference/array/functions/in-array.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 2e60c5134e7a847c99f81eb3f7ecee1f5efeeace Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 40514c7a2d1262c4126d2c8906835ecaf53d6354 Maintainer: hirokawa Status: ready -->
 <refentry xml:id="function.in-array" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>in_array</refname>
@@ -56,17 +56,23 @@
        <link linkend="language.types">型</link>も確認します。
       </para>
       <note>
-       <para>
-        PHP 8.0.0 より前のバージョンでは、
-        strict フラグが指定されていない場合に、
-        配列の値が <literal>0</literal>
-        の場合でも文字列にマッチしてしまっていました。逆も同じです。
-        これにより、望ましくない結果が生じる可能性があります。
-        似たようなエッジケースは他の型でも存在します。
-        値の型が完全にわからない場合には、
-        予期せぬ振る舞いを避けるために常に
-        <parameter>strict</parameter> フラグを使うようにして下さい。
-       </para>
+       <simpara>
+        PHP 8.0.0 より前のバージョンでは、非数値形式の文字列の
+        <parameter>needle</parameter> が <parameter>haystack</parameter> の中の値
+        <literal>0</literal> に緩やかな比較でマッチしていました。逆も同じです。
+        PHP 8.0.0 以降は、数値を文字列に変換して両者を文字列として比較するため、
+        引き続きマッチするのは同じ値の数値形式の文字列だけです。
+       </simpara>
+       <simpara>
+        とはいえ、strict を指定しない場合は
+        <link linkend="types.comparisions-loose">緩やかな比較</link>
+        を使うため、型が異なる値同士が等しいと判断されることがあります。
+        たとえば &true; は真と評価される文字列すべてにマッチし、
+        &false; は <literal>""</literal> と <literal>"0"</literal>
+        の両方にマッチします。
+        関係する値すべての型が確実にわかっているのでなければ、
+        常に <parameter>strict</parameter> を渡して同一性の比較を強制してください。
+       </simpara>
       </note>
      </listitem>
     </varlistentry>

--- a/reference/info/functions/assert.xml
+++ b/reference/info/functions/assert.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 2916fa4160bdf53bb316a5c7c018fc91df7cd951 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 5367d2fcdf4b710a81806aba52a71c522f082713 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi,mumumu -->
 <refentry xml:id="function.assert" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -15,31 +15,31 @@
    <methodparam><type>mixed</type><parameter>assertion</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>Throwable</type><type>string</type><type>null</type></type><parameter>description</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    <function>assert</function> は expectation の定義を満たします。すなわち、
    開発環境やテスト環境では有効であるが、
    運用環境では除去されて、まったくコストのかからないアサーションということです。
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    アサーションは、デバッグを支援する目的に使用するべきです。
    アサーションを常に &true; となる条件を調べる不具合診断に使用し、
    true でない場合に何らかのプログラミングエラーを示したり、
    extension 関数または特定のシステム制限や機能といった、
    特定の機能の存在をチェックするために使用することが可能です。
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    アサーションは削除するように設定できるため、
    入力パラメータのチェックのような通常の実行動作に使用するべきでは
    <emphasis>ありません</emphasis>。
    一般的には、アサーションのチェックを無効にしてもそのコードが正常に動作しなければなりません。
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    <function>assert</function> は
    <parameter>assertion</parameter> で指定された
    expectation をチェックします。
    それを満たさない場合、この関数の結果は &false; になり、
    <function>assert</function> の設定に応じて適切な動作をします。
-  </para>
+  </simpara>
 
   <para>
    <function>assert</function> の振る舞いは、以下のINI設定によって制御できます:
@@ -124,7 +124,7 @@
        <entry>&true;</entry>
        <entry>
         &true; を指定すると、expectation を満たさない場合に
-        <classname>AssertionError</classname> がスローされます。
+        <exceptionname>AssertionError</exceptionname> がスローされます。
        </entry>
        <entry>
         PHP 8.3.0 以降は非推奨
@@ -168,13 +168,13 @@
     <varlistentry>
      <term><parameter>assertion</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        値を返すあらゆる式を指定できます。
        この式を実行した結果を用いて、アサーションに成功したか否かを判断します。
-      </para>
+      </simpara>
 
       <warning>
-       <para>
+       <simpara>
         PHP 8.0.0 より前のバージョンでは、
         <parameter>assertion</parameter> に文字列を指定すると、
         PHP コードとして解釈され、
@@ -183,7 +183,7 @@
         この振る舞いは PHP 7.2.0 以降では
         <emphasis>非推奨</emphasis> になり、
         PHP 8.0.0 で <emphasis>削除されました</emphasis>。
-       </para>
+       </simpara>
       </warning>
      </listitem>
     </varlistentry>
@@ -192,44 +192,44 @@
      <listitem>
       <para>
        <parameter>description</parameter> が
-       <classname>Throwable</classname> のインスタンスの場合、
+       <exceptionname>Throwable</exceptionname> のインスタンスの場合、
        <parameter>assertion</parameter> が実行され、
        かつ失敗した場合にスローされます。
        <note>
-        <para>
+        <simpara>
          PHP 8.0.0 以降では、
          定義済みのアサーションのコールバックがコールされる
          <emphasis>前</emphasis> に上の処理は行われます。
-        </para>
+        </simpara>
        </note>
        <note>
-        <para>
+        <simpara>
          PHP 8.0.0 以降では、
          <link linkend="ini.assert.exception">assert.exception</link>
          の設定に関わらず、&object; がスローされます。
-        </para>
+        </simpara>
        </note>
        <note>
-        <para>
+        <simpara>
          例外がスローされる場合、
          PHP 8.0.0 以降では、
          <link linkend="ini.assert.bail">assert.bail</link>
          は意味がありません。
-        </para>
+        </simpara>
        </note>
       </para>
-      <para>
+      <simpara>
        <parameter>description</parameter> が文字列の場合、
        例外や警告が発生した場合にここで指定したメッセージを使います。
        <parameter>assertion</parameter>
        が失敗したときのオプションのメッセージを指定します。
-      </para>
-      <para>
+      </simpara>
+      <simpara>
        <parameter>description</parameter> は省略できます。
        <!-- This does not happen if &null; is passed ... -->
        デフォルトの値は、<function>assert</function>
        を呼び出したソースコードと同じです。この値はコンパイル時に生成されます。
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -238,22 +238,19 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    <function>assert</function> は、以下のうちのひとつが当てはまる場合、常に &true; を返します:
-  </para>
+  </simpara>
   <simplelist>
    <member><literal>zend.assertions=0</literal></member>
    <member><literal>zend.assertions=-1</literal></member>
    <member><literal>assert.active=0</literal></member>
-   <member><literal>assert.exception=1</literal></member>
-   <member><literal>assert.bail=1</literal></member>
-   <member>カスタムの例外オブジェクトが <parameter>description</parameter> に渡された場合</member>
   </simplelist>
-  <para>
+  <simpara>
    上記の条件がすべて当てはまらない場合でも、
    <parameter>assertion</parameter> が真と評価できる値であれば &true; を返します。
    そうでない場合、&false; を返します。
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -290,7 +287,7 @@
        <entry>8.0.0</entry>
        <entry>
         <parameter>description</parameter> が
-        <classname>Throwable</classname> のインスタンスの場合、
+        <exceptionname>Throwable</exceptionname> のインスタンスの場合、
         assertion が失敗した場合、
         <link linkend="ini.assert.exception">assert.exception</link>
         の値に関わらず、&object; がスローされるようになりました。
@@ -300,7 +297,7 @@
        <entry>8.0.0</entry>
        <entry>
         <parameter>description</parameter>が
-        <classname>Throwable</classname> のインスタンスの場合、
+        <exceptionname>Throwable</exceptionname> のインスタンスの場合、
         たとえ設定されていてもコールバックは呼び出されません。
        </entry>
       </row>
@@ -349,9 +346,9 @@ assert(1 > 2);
 echo 'Hi!';
 ]]>
     </programlisting>
-    <para>
+    <simpara>
      アサーションが有効になっている (<link linkend="ini.zend.assertions"><literal>zend.assertions=1</literal></link>) 場合は、上の例の結果は次のようになります:
-    </para>
+    </simpara>
     <screen>
 <![CDATA[
 Fatal error: Uncaught AssertionError: assert(1 > 2) in example.php:2
@@ -361,9 +358,9 @@ Stack trace:
   thrown in example.php on line 2
 ]]>
     </screen>
-    <para>
+    <simpara>
      アサーションが無効になっている (<literal>zend.assertions=0</literal> または <literal>zend.assertions=-1</literal>) 場合は、上の例の結果は次のようになります:
-    </para>
+    </simpara>
     <screen>
 <![CDATA[
 Hi!
@@ -379,9 +376,9 @@ assert(1 > 2, "Expected one to be greater than two");
 echo 'Hi!';
 ]]>
     </programlisting>
-    <para>
+    <simpara>
      アサーションが有効になっている場合は、上の例の結果は次のようになります:
-    </para>
+    </simpara>
     <screen>
 <![CDATA[
 Fatal error: Uncaught AssertionError: Expected one to be greater than two in example.php:2
@@ -391,9 +388,9 @@ Stack trace:
   thrown in example.php on line 2
 ]]>
     </screen>
-    <para>
+    <simpara>
      アサーションが無効になっている場合は、上の例の結果は次のようになります:
-    </para>
+    </simpara>
     <screen>
 <![CDATA[
 Hi!
@@ -411,9 +408,9 @@ assert(1 > 2, new ArithmeticAssertionError("Expected one to be greater than two"
 echo 'Hi!';
 ]]>
     </programlisting>
-    <para>
+    <simpara>
      アサーションが有効になっている場合は、上の例の結果は次のようになります:
-    </para>
+    </simpara>
     <screen>
 <![CDATA[
 Fatal error: Uncaught ArithmeticAssertionError: Expected one to be greater than two in example.php:4
@@ -422,9 +419,9 @@ Stack trace:
   thrown in example.php on line 4
 ]]>
     </screen>
-    <para>
+    <simpara>
      アサーションが無効になっている場合は、上の例の結果は次のようになります:
-    </para>
+    </simpara>
     <screen>
 <![CDATA[
 Hi!

--- a/reference/info/functions/dl.xml
+++ b/reference/info/functions/dl.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: a89c6d71c7b65e3de84f26230fbf72c9b8948adf Maintainer: takagi Status: ready -->
+<!-- EN-Revision: 5367d2fcdf4b710a81806aba52a71c522f082713 Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa,mumumu -->
 <refentry xml:id="function.dl" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -95,15 +95,15 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success; 
    拡張モジュールのロード機能が無効だったり、あるいは
    無効化されている(<link linkend="ini.enable-dl">enable_dl</link> でオフにされている)場合は、
-   <constant>E_ERROR</constant> を発行して実行は停止されます。
+   <constant>E_WARNING</constant> を発行して &false; を返します。
    指定されたライブラリをロードできず <function>dl</function> が
    失敗した場合、&false; に加えて <constant>E_WARNING</constant> メッセージが
    発行されます。
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/info/functions/get-defined-constants.xml
+++ b/reference/info/functions/get-defined-constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: df4b2be84a0ca22f837f2a921bc40b178be45c66 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi,mumumu -->
 <refentry xml:id="function.get-defined-constants" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -14,11 +14,13 @@
    <type>array</type><methodname>get_defined_constants</methodname>
    <methodparam choice="opt"><type>bool</type><parameter>categorize</parameter><initializer>&false;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    現在定義されている全ての定数の名前と値を返します。返される値には、
-   拡張モジュールにより作成された定数や
+   拡張モジュールにより定義された定数や
    <function>define</function> 関数で作成された定数も含まれます。
-  </para>
+   ただし、コンパイル時に解決される
+   <link linkend="language.constants.magic">マジック定数</link>は含まれません。
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -59,7 +61,7 @@ Array
             [E_USER_ERROR] => 256
             [E_USER_WARNING] => 512
             [E_USER_NOTICE] => 1024
-            [E_ALL] => 2047
+            [E_ALL] => 30719
             [TRUE] => 1
         )
 
@@ -126,7 +128,7 @@ Array
     [E_USER_ERROR] => 256
     [E_USER_WARNING] => 512
     [E_USER_NOTICE] => 1024
-    [E_ALL] => 2047
+    [E_ALL] => 30719
     [TRUE] => 1
 )
 ]]>

--- a/reference/info/functions/getrusage.xml
+++ b/reference/info/functions/getrusage.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: a277389c9d2d5a940fcd6dbe62da7e109282379d Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 5367d2fcdf4b710a81806aba52a71c522f082713 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi,mumumu -->
 <refentry xml:id="function.getrusage" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -101,12 +101,11 @@ echo $dat["ru_stime.tv_sec"];  // 使用するシステム時間 (秒)
      </member>
     </simplelist>
    </para>
-   <para>
+   <simpara>
     <function>getrusage</function> を呼び出す際に <parameter>mode</parameter>
     に <literal>1</literal> (<constant>RUSAGE_CHILDREN</constant>) を指定すると、
-    各スレッドのリソース使用状況を収集します (つまり、内部的には
-    <constant>RUSAGE_THREAD</constant> を指定してこの関数が呼ばれるということです)。
-   </para>
+    子プロセスのリソース使用状況を収集します。
+   </simpara>
   </note>
   <note>
    <para>

--- a/reference/info/functions/memory-get-usage.xml
+++ b/reference/info/functions/memory-get-usage.xml
@@ -1,41 +1,52 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9af43469f46843451955b8926fe470a9f3d45034 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: f78a9528a2fe8e78380fb28cacbe6e152fa4bb6d Maintainer: hirokawa Status: ready -->
 <!-- Credits: mumumu -->
 <refentry xml:id="function.memory-get-usage" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>memory_get_usage</refname>
-  <refpurpose>PHP に割り当てられたメモリの量を返す </refpurpose>
+  <refpurpose>
+   PHP スクリプトに割り当てられたメモリの量、または PHP のメモリマネージャーがシステムから確保したメモリの量を返す
+  </refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
    <type>int</type><methodname>memory_get_usage</methodname>
    <methodparam choice="opt"><type>bool</type><parameter>real_usage</parameter><initializer>&false;</initializer></methodparam>
   </methodsynopsis>
-  <para>
-   現在の PHP スクリプトに割り当てられたメモリの量をバイト単位で返します。
-  </para>
+  <simpara>
+   PHP のメモリマネージャーが現在 PHP スクリプトに割り当てているメモリの量を、バイト単位で返します。
+   報告される値はアロケータの割り当て単位に切り上げられるため、実際に要求されたバイト数よりも大きくなります。
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>real_usage</parameter></term>
-     <listitem>
-      <para>
-       これを &true; に設定すると、システムが割り当てた実際のメモリの大きさ (未使用のページも含むもの) を取得します。
-       省略したり &false; を設定したりすると、使用したメモリのみを報告します。
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  <variablelist>
+   <varlistentry>
+    <term><parameter>real_usage</parameter></term>
+    <listitem>
+     <simpara>
+      これを &true; に設定すると、PHP のメモリマネージャーがシステムから確保したメモリの総量 (現在使われていないページも含む) を取得します。
+      <link linkend="ini.memory-limit">memory_limit</link> による制限は、この値に対して適用されます。
+      これは、オペレーティングシステムが PHP プロセスに与えたメモリの量ではありません。
+      オペレーティングシステムが与えるメモリは、通常これよりもはるかに大きくなります。
+     </simpara>
+     <simpara>
+      省略したり &false; を設定したりすると、現在 PHP スクリプトに割り当てられているメモリのみを報告します。
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
   <note>
-   <para>PHP は、<literal>emalloc()</literal> が割り当てたメモリ以外のメモリは追跡しません。</para>
+   <simpara>
+    PHP が追跡するのは、自身のメモリマネージャーを通じて、つまり内部関数 <literal>emalloc()</literal>
+    やその関連関数を通じて割り当てられたメモリだけです。
+    永続的に割り当てられたメモリや、拡張モジュールが <literal>malloc()</literal> で直接割り当てたメモリは、
+    <parameter>real_usage</parameter> が &true; の場合でも報告されません。
+   </simpara>
   </note>
  </refsect1>
 
@@ -54,18 +65,19 @@
     <programlisting role="php">
 <![CDATA[
 <?php
+
 // これは単なる例にすぎません。
 // 以下の数値はシステムによって変化します。
 
-echo memory_get_usage() . "\n"; // 36640
+echo memory_get_usage(), "\n"; // 36640
 
 $a = str_repeat("Hello", 4242);
 
-echo memory_get_usage() . "\n"; // 57960
+echo memory_get_usage(), "\n"; // 57960
 
 unset($a);
 
-echo memory_get_usage() . "\n"; // 36744
+echo memory_get_usage(), "\n"; // 36744
 
 ?>
 ]]>

--- a/reference/misc/functions/constant.xml
+++ b/reference/misc/functions/constant.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 6c3091b54b66181db5f81ef5afe1d2e8b6efdeac Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 5dc2deaf9f59287a5a5e327b7de538a9ff3fddf2 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi -->
 <refentry xml:id="function.constant" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -40,6 +40,27 @@
       <para>
        定数名。
       </para>
+      <note>
+       <simpara>
+        <function>constant</function> は名前を通常の文字列として受け取り、
+        現在の<link linkend="language.namespaces.dynamic">名前空間</link>を基準に
+        解決することはありません。
+        名前はグローバル名前空間から探されます。
+        そのため非修飾名を渡すと、同じ名前を識別子としてそのまま書いた場合に
+        参照される定数ではなく、グローバル名前空間にある同名の定数の値が
+        黙って返されることがあります。
+        名前空間の中で宣言された定数の値を取得するには、
+        <literal>constant('My\Namespace\MYCONST')</literal> や
+        <literal>constant(__NAMESPACE__ . '\MYCONST')</literal> のように、
+        名前空間を名前の一部に含める必要があります。
+        名前は単なる文字列なので、<literal>use</literal> 文で導入したエイリアスや
+        <literal>namespace\</literal> プレフィックスは適用されません。
+        ダブルクォートで囲んだ文字列の中では、
+        <literal>"My\\Namespace\\MYCONST"</literal> のように
+        名前空間区切り文字をエスケープする必要があります。
+        名前のうち名前空間の部分は大文字小文字を区別しませんが、定数名は区別します。
+       </simpara>
+      </note>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/misc/functions/define.xml
+++ b/reference/misc/functions/define.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: a124543dd3f6b1e5567b07420d23899e582514dc Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 5dc2deaf9f59287a5a5e327b7de538a9ff3fddf2 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi,mumumu -->
 <refentry xml:id="function.define" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -38,6 +38,29 @@
         <function>constant</function> 関数を使うこと(だけ)しかできません。
         しかしながら、こういったことをするのは推奨されません。
        </para>
+       <simpara>
+        <function>define</function> は名前を通常の文字列として受け取り、
+        現在の<link linkend="language.namespaces.dynamic">名前空間</link>を基準に
+        解決することはありません。
+        そのため、<literal>namespace My\Namespace;</literal> の内部で
+        <literal>define('MYCONST', 1)</literal> と書くと、
+        エラーも発生せず、黙って <literal>MYCONST</literal>
+        がグローバル名前空間に定義されます。
+        定数を名前空間の中に置くには、名前空間を名前の一部に含める必要があり、
+        先頭に名前空間区切り文字を付けずに
+        <literal>define('My\Namespace\MYCONST', 1)</literal> や
+        <literal>define(__NAMESPACE__ . '\MYCONST', 1)</literal>
+        のように書きます。
+        <function>defined</function> や <function>constant</function> と違い、
+        <function>define</function> は先頭の区切り文字を取り除きません。
+        <literal>define('\My\Namespace\MYCONST', 1)</literal> は &true;
+        を返しますが、作られた定数を取得する手段はありません。
+        名前は単なる文字列なので、<literal>use</literal>
+        文で導入したエイリアスは適用されません。
+        ダブルクォートで囲んだ文字列の中では、
+        <literal>"My\\Namespace\\MYCONST"</literal> のように
+        名前空間区切り文字をエスケープする必要があります。
+       </simpara>
       </note>
      </listitem>
     </varlistentry>

--- a/reference/misc/functions/defined.xml
+++ b/reference/misc/functions/defined.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 36e1d917ef7be36e8b4ff5193b456390061f2e21 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 5dc2deaf9f59287a5a5e327b7de538a9ff3fddf2 Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: takagi -->
 <refentry xml:id="function.defined" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -44,6 +44,28 @@
       <para>
        定数名。
       </para>
+      <note>
+       <simpara>
+        <function>defined</function> は名前を通常の文字列として受け取り、
+        現在の<link linkend="language.namespaces.dynamic">名前空間</link>を基準に
+        解決することはありません。
+        名前はグローバル名前空間から探されます。
+        そのため非修飾名を渡すと、同じ名前を識別子としてそのまま書いた場合に
+        参照される定数ではなく、グローバル名前空間にある同名の定数が
+        黙って調べられることがあります。
+        名前空間の中で宣言された定数が定義されているかどうかを調べるには、
+        <literal>defined('My\Namespace\MYCONST')</literal> や
+        <literal>defined(__NAMESPACE__ . '\MYCONST')</literal>
+        のように、名前空間を名前の一部に含める必要があります。
+        名前は単なる文字列なので、<literal>use</literal>
+        文で導入したエイリアスや <literal>namespace\</literal>
+        プレフィックスは適用されません。
+        ダブルクォートで囲んだ文字列の中では、
+        <literal>"My\\Namespace\\MYCONST"</literal>
+        のように名前空間区切り文字をエスケープする必要があります。
+        名前のうち名前空間の部分は大文字小文字を区別しませんが、定数名は区別します。
+       </simpara>
+      </note>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/misc/functions/hrtime.xml
+++ b/reference/misc/functions/hrtime.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 0c9c2dd669fe9395eaa73d487fbd160f9057429a Maintainer: mumumu Status: ready -->
+<!-- EN-Revision: 2594e1b8a9dc9c4afad73e1a6b260cabc378db17 Maintainer: mumumu Status: ready -->
 <refentry xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://docbook.org/ns/docbook" xml:id="function.hrtime">
  <refnamediv>
   <refname>hrtime</refname>
@@ -46,6 +46,30 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       macOS では、実装が <code>mach_absolute_time()</code> の代わりに
+       <code>clock_gettime_nsec_np(CLOCK_UPTIME_RAW)</code>
+       を使うようになりました。
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -79,6 +103,7 @@ Array
   <simplelist>
    <member><link linkend="book.hrtime">High resolution timing</link> 拡張モジュール</member>
    <member><function>microtime</function></member>
+   <member><function>time_nanosleep</function></member>
   </simplelist>
  </refsect1>
 

--- a/reference/strings/functions/crypt.xml
+++ b/reference/strings/functions/crypt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 46efd980535e8de6f6639a0015d2ad1e4bfe9d00 Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 4850727cb124abe071e9adaf851f86a872eb2adf Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: shimooka,mumumu -->
 <refentry xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://docbook.org/ns/docbook" xml:id="function.crypt">
  <refnamediv>
@@ -55,6 +55,21 @@
    つまり、最初の 8 文字が同じである長い文字列は、
    同じ salt を使う限り同じ結果となります。
   </para>
+  <warning>
+   <simpara>
+    以下に挙げるアルゴリズムは、どれも新たにパスワードハッシュを作る用途には適していません。
+    <constant>CRYPT_STD_DES</constant>、<constant>CRYPT_EXT_DES</constant>、
+    <constant>CRYPT_MD5</constant> は計算があまりに高速で、
+    オフラインでのクラックに耐えられません。
+    この理由により、md5crypt の End of Life が宣言されました (CVE-2012-3287)。
+    <constant>CRYPT_SHA256</constant> と <constant>CRYPT_SHA512</constant>
+    の実行時間は <parameter>string</parameter> の長さの 2 乗で増加するため、
+    長さを制限しない入力を使って CPU を枯渇させることができます
+    (CVE-2016-20013)。
+    代わりに <function>password_hash</function> を使ってください。
+    これは適切なアルゴリズムとコストを自動的に選択します。
+   </simpara>
+  </warning>
   <simpara>
    以下のハッシュ形式がサポートされています:
   </simpara>

--- a/reference/strings/functions/htmlspecialchars.xml
+++ b/reference/strings/functions/htmlspecialchars.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: eabde0419cf90f596f60db00e31fcb6ebe41ac55 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: a9d052e2db27dd26e5f77b13ca03f0e9d352db5a Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa,shimooka,mumumu -->
 <refentry xml:id="function.htmlspecialchars" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -255,6 +255,27 @@
 <?php
 $new = htmlspecialchars("<a href='test'>Test</a>", ENT_QUOTES);
 echo $new; // &lt;a href=&#039;test&#039;&gt;Test&lt;/a&gt;
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+  <para>
+   <example>
+    <title>無効な UTF-8 シーケンスに対する <constant>ENT_IGNORE</constant> と <constant>ENT_SUBSTITUTE</constant></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+// "\x80" は有効な UTF-8 のバイト列ではありません。
+$input = "atta\x80ck";
+
+// ENT_IGNORE は無効なバイトを黙って切り捨てます。出力: "attack"
+echo bin2hex(htmlspecialchars($input, ENT_QUOTES | ENT_IGNORE, 'UTF-8')), "\n";
+// 61747461636b
+
+// ENT_SUBSTITUTE は無効なバイトを U+FFFD に置き換えます。出力: "atta" + 置換文字 + "ck"
+echo bin2hex(htmlspecialchars($input, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8')), "\n";
+// 61747461efbfbd636b
 ?>
 ]]>
     </programlisting>

--- a/reference/strings/functions/strpos.xml
+++ b/reference/strings/functions/strpos.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4b72b23513caa3a8bc520d459a0417defc7b3880 Maintainer: takagi Status: ready -->
+<!-- EN-Revision: dd5db7c6b22c45108b19ca815a0bdf07909bf14a Maintainer: takagi Status: ready -->
 <!-- CREDITS: hirokawa,mumumu -->
 <refentry xml:id="function.strpos" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -37,9 +37,14 @@
     <varlistentry>
      <term><parameter>needle</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        検索する文字列。
-      </para>
+      </simpara>
+      <simpara>
+       <parameter>needle</parameter> に空文字列を渡すと、すべての位置でマッチします。
+       <function>strpos</function> は、<parameter>offset</parameter>
+       が指定されている場合はその値を、そうでない場合は <literal>0</literal> を返します。
+      </simpara>
       &strings.parameter.needle.non-string;
      </listitem>
     </varlistentry>

--- a/reference/strings/functions/strtr.xml
+++ b/reference/strings/functions/strtr.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 45042fef652f1b4e904e809fcbfcf31f6c60670b Maintainer: hirokawa Status: ready -->
+<!-- EN-Revision: 1ed119182ad4629064b13301d0e427de47736bfe Maintainer: hirokawa Status: ready -->
 <!-- CREDITS: shimooka -->
 <refentry xml:id="function.strtr" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -113,15 +113,20 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-$addr = "The river å";
 
-// この形式の場合、strtr() はバイト単位での変換を行います。
-// したがって、ここではシングルバイトエンコーディングを想定しています。
-$addr = strtr($addr, "äåö", "aao");
-echo $addr, PHP_EOL;
-?>
+$original = "He1Lo, w0rld!";
+
+// 引数を三つ渡した場合、strtr() はバイト単位での変換を行います。
+$result = strtr($original, "1L0", "llo");
+echo $result;
 ]]>
     </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+Hello, world!
+]]>
+    </screen>
    </example>
   </para>
   <para>
@@ -135,9 +140,9 @@ echo $addr, PHP_EOL;
     <programlisting role="php">
 <![CDATA[
 <?php
-$trans = array("h" => "-", "hello" => "hi", "hi" => "hello");
-echo strtr("hi all, I said hello", $trans);
-?>
+
+$replace_pairs = ["h" => "-", "hello" => "hi", "hi" => "hello"];
+echo strtr("hi all, I said hello", $replace_pairs);
 ]]>
     </programlisting>
     &example.outputs;
@@ -156,11 +161,22 @@ hello all, I said hi
     <programlisting role="php">
 <![CDATA[
 <?php
-echo strtr("baab", "ab", "01"),"\n";
 
-$trans = array("ab" => "01");
-echo strtr("baab", $trans);
-?>
+// シングルバイト文字
+$singlebyte_string = "baab";
+echo strtr($singlebyte_string, "ab", "01"), "\n"; // バイト単位での変換
+
+$replace_pairs = ["ab" => "01"];
+echo strtr($singlebyte_string, $replace_pairs), "\n"; // 部分文字列の置換
+
+// マルチバイト文字
+$multibyte_string = "Ä"; // UTF-8 では 2 バイト "\xC3\x84" にエンコードされます
+
+$result = strtr($multibyte_string, 'Ä', 'A');
+echo bin2hex($result), "\n"; // "4184"。"c3" が "41" ("A") になり、"84" はそのまま残るので UTF-8 として壊れます
+
+$replace_pairs = ['Ä' => 'A'];
+echo strtr($multibyte_string, $replace_pairs); // マルチバイト文字列に対する正しい部分文字列の置換
 ]]>
     </programlisting>
     &example.outputs;
@@ -168,6 +184,8 @@ echo strtr("baab", $trans);
 <![CDATA[
 1001
 ba01
+4184
+A
 ]]>
     </screen>
   </example>


### PR DESCRIPTION
## 翻訳内容

### reference/array（3件）

- reference/array/functions/array-walk-recursive.xml — オブジェクトを渡した場合にたどる範囲を追記し、リファレンス渡しで値をその場で更新する例を追加
  1. php/doc-en@63f09f4d81
  2. php/doc-en@0d8ee2131b
- reference/array/functions/array-column.xml — カラムの定義と、行がオブジェクトでもよいことを説明に追記。column_key が null のときは行全体を返すこと、__isset() を持たない行はスキップされること、__isset() だけがあって __get() がない場合は Error がスローされることの誤りを修正し、7.0.0 と 7.1.0 の changelog を追加
  1. php/doc-en@b91033ba3d
- reference/array/functions/in-array.xml — strict の note を PHP 8.0.0 以降の文字列比較に合わせて修正し、true / false を緩やかに比較した場合の落とし穴を追記
  1. php/doc-en@40514c7a2d

### reference/info（5件）

- reference/info/functions/assert.xml — 戻り値の記述にあった誤った箇条書き 3 件を削除
  1. php/doc-en@5367d2fcdf
- reference/info/functions/dl.xml — ロード機能が無効な場合の挙動を、E_ERROR を発行して実行停止から E_WARNING を発行して false を返すへ、誤りを修正
  1. php/doc-en@5367d2fcdf
- reference/info/functions/getrusage.xml — mode に 1 を指定した場合に収集する対象の誤りを修正（スレッドではなく子プロセス）
  1. php/doc-en@5367d2fcdf
- reference/info/functions/get-defined-constants.xml — コンパイル時に解決されるマジック定数が含まれないことを追記し、出力例の E_ALL の値の誤りを修正
  1. php/doc-en@5367d2fcdf
  2. php/doc-en@df4b2be84a
- reference/info/functions/memory-get-usage.xml — 2 つの返り値が何を測っているのかを、メモリマネージャーがシステムから確保した量とスクリプトへの割り当て量の区別として書き直し、追跡対象外のメモリについての note を差し替え
  1. php/doc-en@f78a9528a2

### reference/strings（4件）

- reference/strings/functions/strtr.xml — 紛らわしいコード例を差し替え、マルチバイト文字での挙動を比較する例を追加
  1. php/doc-en@1ed119182a
- reference/strings/functions/htmlspecialchars.xml — 不正な UTF-8 バイト列に対する ENT_IGNORE と ENT_SUBSTITUTE の例を追加
  1. php/doc-en@a9d052e2db
- reference/strings/functions/crypt.xml — アルゴリズム一覧の前に、CVE 2 件を挙げた警告を追加
  1. php/doc-en@4850727cb1
- reference/strings/functions/strpos.xml — needle が空文字列の場合の挙動を追記
  1. php/doc-en@dd5db7c6b2

### reference/misc（4件）

- reference/misc/functions/constant.xml — 定数名が現在の名前空間を基準に解決されないことの note を追加
  1. php/doc-en@5dc2deaf9f
- reference/misc/functions/define.xml — 同じ note に加えて、先頭の名前空間区切り文字が取り除かれないため取得できない定数が作れてしまうことを追記
  1. php/doc-en@5dc2deaf9f
- reference/misc/functions/defined.xml — constant.xml と同じ note を追加
  1. php/doc-en@5dc2deaf9f
- reference/misc/functions/hrtime.xml — macOS での実装変更を changelog に追加
  1. php/doc-en@2594e1b8a9
